### PR TITLE
feat: add structured logging utility

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,110 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  module: string;
+  message: string;
+  data?: unknown;
+}
+
+export interface LoggerOptions {
+  debugMode: boolean;
+  accessKey: string;
+}
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export class Logger {
+  private module: string;
+  private options: LoggerOptions;
+
+  constructor(module: string, options: LoggerOptions) {
+    this.module = module;
+    this.options = options;
+  }
+
+  debug(message: string, data?: unknown): void {
+    this.log('debug', message, data);
+  }
+
+  info(message: string, data?: unknown): void {
+    this.log('info', message, data);
+  }
+
+  warn(message: string, data?: unknown): void {
+    this.log('warn', message, data);
+  }
+
+  error(message: string, data?: unknown): void {
+    this.log('error', message, data);
+  }
+
+  updateOptions(options: Partial<LoggerOptions>): void {
+    this.options = { ...this.options, ...options };
+  }
+
+  private log(level: LogLevel, message: string, data?: unknown): void {
+    const minLevel: LogLevel = this.options.debugMode ? 'debug' : 'info';
+    if (LOG_LEVEL_PRIORITY[level] < LOG_LEVEL_PRIORITY[minLevel]) {
+      return;
+    }
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      module: this.module,
+      message: this.redact(message),
+      ...(data !== undefined && { data: this.redactUnknown(data) }),
+    };
+
+    switch (level) {
+      case 'debug':
+      case 'info':
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(entry));
+        break;
+      case 'warn':
+        // eslint-disable-next-line no-console
+        console.warn(JSON.stringify(entry));
+        break;
+      case 'error':
+        // eslint-disable-next-line no-console
+        console.error(JSON.stringify(entry));
+        break;
+    }
+  }
+
+  private redact(value: string): string {
+    if (!this.options.accessKey || this.options.accessKey.length === 0) {
+      return value;
+    }
+    return value.split(this.options.accessKey).join('[REDACTED]');
+  }
+
+  private redactUnknown(value: unknown): unknown {
+    if (typeof value === 'string') {
+      return this.redact(value);
+    }
+    if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        return value.map((item) => this.redactUnknown(item));
+      }
+      const result: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        result[key] = this.redactUnknown(val);
+      }
+      return result;
+    }
+    return value;
+  }
+}
+
+export function createLogger(module: string, options: LoggerOptions): Logger {
+  return new Logger(module, options);
+}

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Logger, createLogger, LogEntry } from '../../src/utils/logger';
+
+describe('Logger', () => {
+  let logger: Logger;
+  const accessKey = 'secret-key-12345';
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('with debug mode enabled', () => {
+    beforeEach(() => {
+      logger = createLogger('test-module', { debugMode: true, accessKey });
+    });
+
+    it('should log debug messages when debug mode is on', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.debug('test debug message');
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.level).toBe('debug');
+      expect(entry.module).toBe('test-module');
+      expect(entry.message).toBe('test debug message');
+    });
+
+    it('should log info messages', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('test info');
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.level).toBe('info');
+    });
+
+    it('should log warn messages', () => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      logger.warn('test warning');
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.level).toBe('warn');
+    });
+
+    it('should log error messages', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      logger.error('test error');
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.level).toBe('error');
+    });
+
+    it('should include a timestamp in ISO format', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('timestamp test');
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(() => new Date(entry.timestamp)).not.toThrow();
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('should include optional data when provided', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('with data', { foo: 'bar' });
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.data).toEqual({ foo: 'bar' });
+    });
+
+    it('should not include data key when data is not provided', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('no data');
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry).not.toHaveProperty('data');
+    });
+  });
+
+  describe('with debug mode disabled', () => {
+    beforeEach(() => {
+      logger = createLogger('test-module', { debugMode: false, accessKey });
+    });
+
+    it('should suppress debug messages', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.debug('this should not appear');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should still log info messages', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('this should appear');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still log warn messages', () => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      logger.warn('this should appear');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still log error messages', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      logger.error('this should appear');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('access key redaction', () => {
+    beforeEach(() => {
+      logger = createLogger('test-module', { debugMode: true, accessKey });
+    });
+
+    it('should redact access key in message strings', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info(`Authorization header: Bearer ${accessKey}`);
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.message).not.toContain(accessKey);
+      expect(entry.message).toContain('[REDACTED]');
+    });
+
+    it('should redact access key in data strings', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('request', { header: `Bearer ${accessKey}` });
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      const data = entry.data as Record<string, string>;
+      expect(data.header).not.toContain(accessKey);
+      expect(data.header).toContain('[REDACTED]');
+    });
+
+    it('should redact access key in nested data objects', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('nested', { req: { auth: accessKey } });
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      const data = entry.data as Record<string, Record<string, string>>;
+      expect(data.req.auth).toBe('[REDACTED]');
+    });
+
+    it('should redact access key in arrays', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('array', [accessKey, 'safe']);
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      const data = entry.data as string[];
+      expect(data[0]).toBe('[REDACTED]');
+      expect(data[1]).toBe('safe');
+    });
+
+    it('should not redact when access key is empty', () => {
+      const emptyLogger = createLogger('test', { debugMode: true, accessKey: '' });
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      emptyLogger.info('no redaction needed');
+      const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.message).toBe('no redaction needed');
+    });
+
+    it('should handle non-string, non-object data without redaction', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      logger.info('number data', 42);
+      const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
+      expect(entry.data).toBe(42);
+    });
+  });
+
+  describe('updateOptions', () => {
+    it('should update debug mode dynamically', () => {
+      logger = createLogger('test', { debugMode: false, accessKey: '' });
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      logger.debug('suppressed');
+      expect(spy).not.toHaveBeenCalled();
+
+      logger.updateOptions({ debugMode: true });
+      logger.debug('visible');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Logger` class with debug/info/warn/error levels and structured JSON output
- Debug mode toggle suppresses debug-level messages when disabled
- Access key redaction in messages, data objects, and nested arrays
- 18 unit tests covering all log levels, redaction, and dynamic options

Closes #7