### PR TITLE
feat: add Obsidian API abstraction layer

### DIFF
--- a/src/obsidian/adapter.ts
+++ b/src/obsidian/adapter.ts
@@ -1,0 +1,166 @@
+import { App, TFile, TFolder, TAbstractFile, Vault } from 'obsidian';
+
+export interface FileStat {
+  size: number;
+  ctime: number;
+  mtime: number;
+}
+
+export interface ListResult {
+  files: string[];
+  folders: string[];
+}
+
+export interface ObsidianAdapter {
+  // File operations
+  readFile(path: string): Promise<string>;
+  readBinary(path: string): Promise<ArrayBuffer>;
+  createFile(path: string, content: string): Promise<void>;
+  modifyFile(path: string, content: string): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  renameFile(oldPath: string, newPath: string): Promise<void>;
+  copyFile(sourcePath: string, destPath: string): Promise<void>;
+  writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+
+  // Folder operations
+  createFolder(path: string): Promise<void>;
+  deleteFolder(path: string, recursive: boolean): Promise<void>;
+
+  // Query operations
+  exists(path: string): Promise<boolean>;
+  stat(path: string): Promise<FileStat | null>;
+  list(path: string): ListResult;
+  listRecursive(path: string): ListResult;
+
+  // Vault info
+  getVaultPath(): string;
+}
+
+export class RealObsidianAdapter implements ObsidianAdapter {
+  constructor(private app: App) {}
+
+  async readFile(path: string): Promise<string> {
+    const file = this.getFile(path);
+    return this.app.vault.read(file);
+  }
+
+  async readBinary(path: string): Promise<ArrayBuffer> {
+    const file = this.getFile(path);
+    return this.app.vault.readBinary(file);
+  }
+
+  async createFile(path: string, content: string): Promise<void> {
+    await this.app.vault.create(path, content);
+  }
+
+  async modifyFile(path: string, content: string): Promise<void> {
+    const file = this.getFile(path);
+    await this.app.vault.modify(file, content);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    const file = this.getFile(path);
+    await this.app.vault.delete(file);
+  }
+
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    const file = this.getAbstractFile(oldPath);
+    await this.app.vault.rename(file, newPath);
+  }
+
+  async copyFile(sourcePath: string, destPath: string): Promise<void> {
+    const file = this.getFile(sourcePath);
+    await this.app.vault.copy(file, destPath);
+  }
+
+  async writeBinary(path: string, data: ArrayBuffer): Promise<void> {
+    const existing = this.app.vault.getAbstractFileByPath(path);
+    if (existing instanceof TFile) {
+      await this.app.vault.modifyBinary(existing, data);
+    } else {
+      await this.app.vault.createBinary(path, data);
+    }
+  }
+
+  async createFolder(path: string): Promise<void> {
+    await this.app.vault.createFolder(path);
+  }
+
+  async deleteFolder(path: string, recursive: boolean): Promise<void> {
+    const folder = this.getFolder(path);
+    if (!recursive && folder.children.length > 0) {
+      throw new Error(`Folder "${path}" is not empty. Use recursive=true to delete.`);
+    }
+    await this.app.vault.delete(folder, true);
+  }
+
+  exists(path: string): Promise<boolean> {
+    return Promise.resolve(this.app.vault.getAbstractFileByPath(path) !== null);
+  }
+
+  async stat(path: string): Promise<FileStat | null> {
+    const stat = await this.app.vault.adapter.stat(path);
+    if (!stat) return null;
+    return {
+      size: stat.size,
+      ctime: stat.ctime,
+      mtime: stat.mtime,
+    };
+  }
+
+  list(path: string): ListResult {
+    const folder = this.getFolder(path);
+    const files: string[] = [];
+    const folders: string[] = [];
+    for (const child of folder.children) {
+      if (child instanceof TFile) {
+        files.push(child.path);
+      } else if (child instanceof TFolder) {
+        folders.push(child.path);
+      }
+    }
+    return { files, folders };
+  }
+
+  listRecursive(path: string): ListResult {
+    const folder = this.getFolder(path);
+    const files: string[] = [];
+    const folders: string[] = [];
+    Vault.recurseChildren(folder, (child: TAbstractFile) => {
+      if (child instanceof TFile) {
+        files.push(child.path);
+      } else if (child instanceof TFolder && child.path !== folder.path) {
+        folders.push(child.path);
+      }
+    });
+    return { files, folders };
+  }
+
+  getVaultPath(): string {
+    return (this.app.vault.adapter as { basePath?: string }).basePath ?? '';
+  }
+
+  private getFile(path: string): TFile {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) {
+      throw new Error(`File not found: ${path}`);
+    }
+    return file;
+  }
+
+  private getFolder(path: string): TFolder {
+    const folder = this.app.vault.getAbstractFileByPath(path);
+    if (!(folder instanceof TFolder)) {
+      throw new Error(`Folder not found: ${path}`);
+    }
+    return folder;
+  }
+
+  private getAbstractFile(path: string): TAbstractFile {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!file) {
+      throw new Error(`Path not found: ${path}`);
+    }
+    return file;
+  }
+}

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -1,0 +1,248 @@
+import { FileStat, ListResult, ObsidianAdapter } from './adapter';
+
+interface MockFile {
+  content: string;
+  binary?: ArrayBuffer;
+  stat: FileStat;
+}
+
+/* eslint-disable @typescript-eslint/require-await */
+export class MockObsidianAdapter implements ObsidianAdapter {
+  private files: Map<string, MockFile> = new Map();
+  private folders: Set<string> = new Set(['/']);
+  private vaultPath = '/mock-vault';
+
+  async readFile(path: string): Promise<string> {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`File not found: ${path}`);
+    return file.content;
+  }
+
+  async readBinary(path: string): Promise<ArrayBuffer> {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`File not found: ${path}`);
+    if (!file.binary) {
+      const encoder = new TextEncoder();
+      return encoder.encode(file.content).buffer;
+    }
+    return file.binary;
+  }
+
+  async createFile(path: string, content: string): Promise<void> {
+    if (this.files.has(path)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+    this.ensureParentFolder(path);
+    const now = Date.now();
+    this.files.set(path, {
+      content,
+      stat: { size: content.length, ctime: now, mtime: now },
+    });
+  }
+
+  async modifyFile(path: string, content: string): Promise<void> {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`File not found: ${path}`);
+    file.content = content;
+    file.stat.mtime = Date.now();
+    file.stat.size = content.length;
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    if (!this.files.has(path)) {
+      throw new Error(`File not found: ${path}`);
+    }
+    this.files.delete(path);
+  }
+
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    const file = this.files.get(oldPath);
+    const isFolder = this.folders.has(oldPath);
+
+    if (!file && !isFolder) {
+      throw new Error(`Path not found: ${oldPath}`);
+    }
+
+    if (file) {
+      this.ensureParentFolder(newPath);
+      this.files.set(newPath, { ...file, stat: { ...file.stat, mtime: Date.now() } });
+      this.files.delete(oldPath);
+    }
+
+    if (isFolder) {
+      this.folders.add(newPath);
+      this.folders.delete(oldPath);
+      // Move all children
+      for (const [filePath, fileData] of this.files.entries()) {
+        if (filePath.startsWith(oldPath + '/')) {
+          const newFilePath = newPath + filePath.slice(oldPath.length);
+          this.files.set(newFilePath, fileData);
+          this.files.delete(filePath);
+        }
+      }
+      for (const folderPath of this.folders) {
+        if (folderPath.startsWith(oldPath + '/')) {
+          const newFolderPath = newPath + folderPath.slice(oldPath.length);
+          this.folders.add(newFolderPath);
+          this.folders.delete(folderPath);
+        }
+      }
+    }
+  }
+
+  async copyFile(sourcePath: string, destPath: string): Promise<void> {
+    const file = this.files.get(sourcePath);
+    if (!file) throw new Error(`File not found: ${sourcePath}`);
+    this.ensureParentFolder(destPath);
+    const now = Date.now();
+    this.files.set(destPath, {
+      content: file.content,
+      binary: file.binary,
+      stat: { size: file.stat.size, ctime: now, mtime: now },
+    });
+  }
+
+  async writeBinary(path: string, data: ArrayBuffer): Promise<void> {
+    const existing = this.files.get(path);
+    const now = Date.now();
+    if (existing) {
+      existing.binary = data;
+      existing.stat.mtime = now;
+      existing.stat.size = data.byteLength;
+    } else {
+      this.ensureParentFolder(path);
+      this.files.set(path, {
+        content: '',
+        binary: data,
+        stat: { size: data.byteLength, ctime: now, mtime: now },
+      });
+    }
+  }
+
+  async createFolder(path: string): Promise<void> {
+    if (this.folders.has(path)) {
+      throw new Error(`Folder already exists: ${path}`);
+    }
+    this.ensureParentFolder(path);
+    this.folders.add(path);
+  }
+
+  async deleteFolder(path: string, recursive: boolean): Promise<void> {
+    if (!this.folders.has(path)) {
+      throw new Error(`Folder not found: ${path}`);
+    }
+    const children = this.getDirectChildren(path);
+    if (!recursive && (children.files.length > 0 || children.folders.length > 0)) {
+      throw new Error(`Folder "${path}" is not empty. Use recursive=true to delete.`);
+    }
+    if (recursive) {
+      for (const [filePath] of this.files.entries()) {
+        if (filePath.startsWith(path + '/')) {
+          this.files.delete(filePath);
+        }
+      }
+      for (const folderPath of this.folders) {
+        if (folderPath.startsWith(path + '/')) {
+          this.folders.delete(folderPath);
+        }
+      }
+    }
+    this.folders.delete(path);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path) || this.folders.has(path);
+  }
+
+  async stat(path: string): Promise<FileStat | null> {
+    const file = this.files.get(path);
+    if (file) return { ...file.stat };
+    return null;
+  }
+
+  list(path: string): ListResult {
+    if (!this.folders.has(path) && path !== '/') {
+      throw new Error(`Folder not found: ${path}`);
+    }
+    return this.getDirectChildren(path);
+  }
+
+  listRecursive(path: string): ListResult {
+    if (!this.folders.has(path) && path !== '/') {
+      throw new Error(`Folder not found: ${path}`);
+    }
+    const prefix = path === '/' ? '' : path + '/';
+    const files: string[] = [];
+    const folders: string[] = [];
+    for (const filePath of this.files.keys()) {
+      if (path === '/' || filePath.startsWith(prefix)) {
+        files.push(filePath);
+      }
+    }
+    for (const folderPath of this.folders) {
+      if (folderPath !== path && (path === '/' || folderPath.startsWith(prefix))) {
+        folders.push(folderPath);
+      }
+    }
+    return { files: files.sort(), folders: folders.sort() };
+  }
+
+  getVaultPath(): string {
+    return this.vaultPath;
+  }
+
+  // Test helpers
+  setVaultPath(path: string): void {
+    this.vaultPath = path;
+  }
+
+  addFile(path: string, content: string, stat?: Partial<FileStat>): void {
+    this.ensureParentFolder(path);
+    const now = Date.now();
+    this.files.set(path, {
+      content,
+      stat: {
+        size: stat?.size ?? content.length,
+        ctime: stat?.ctime ?? now,
+        mtime: stat?.mtime ?? now,
+      },
+    });
+  }
+
+  addFolder(path: string): void {
+    this.folders.add(path);
+  }
+
+  private getDirectChildren(path: string): ListResult {
+    const prefix = path === '/' ? '' : path + '/';
+    const files: string[] = [];
+    const folders: string[] = [];
+    for (const filePath of this.files.keys()) {
+      if (filePath.startsWith(prefix) && !filePath.slice(prefix.length).includes('/')) {
+        files.push(filePath);
+      }
+    }
+    for (const folderPath of this.folders) {
+      if (
+        folderPath !== path &&
+        folderPath.startsWith(prefix) &&
+        !folderPath.slice(prefix.length).includes('/')
+      ) {
+        folders.push(folderPath);
+      }
+    }
+    return { files: files.sort(), folders: folders.sort() };
+  }
+
+  private ensureParentFolder(path: string): void {
+    const parts = path.split('/');
+    parts.pop(); // Remove the file/folder name
+    let current = '';
+    for (const part of parts) {
+      current = current ? `${current}/${part}` : part;
+      if (current && !this.folders.has(current)) {
+        this.folders.add(current);
+      }
+    }
+  }
+}

--- a/tests/obsidian/mock-adapter.test.ts
+++ b/tests/obsidian/mock-adapter.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+
+describe('MockObsidianAdapter', () => {
+  let adapter: MockObsidianAdapter;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+  });
+
+  describe('file operations', () => {
+    it('should create and read a file', async () => {
+      await adapter.createFile('test.md', '# Hello');
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('# Hello');
+    });
+
+    it('should throw when reading a nonexistent file', async () => {
+      await expect(adapter.readFile('missing.md')).rejects.toThrow('File not found');
+    });
+
+    it('should throw when creating a file that already exists', async () => {
+      await adapter.createFile('test.md', 'content');
+      await expect(adapter.createFile('test.md', 'other')).rejects.toThrow('already exists');
+    });
+
+    it('should modify an existing file', async () => {
+      await adapter.createFile('test.md', 'old');
+      await adapter.modifyFile('test.md', 'new');
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('new');
+    });
+
+    it('should throw when modifying a nonexistent file', async () => {
+      await expect(adapter.modifyFile('missing.md', 'data')).rejects.toThrow('File not found');
+    });
+
+    it('should delete a file', async () => {
+      await adapter.createFile('test.md', 'content');
+      await adapter.deleteFile('test.md');
+      await expect(adapter.readFile('test.md')).rejects.toThrow('File not found');
+    });
+
+    it('should throw when deleting a nonexistent file', async () => {
+      await expect(adapter.deleteFile('missing.md')).rejects.toThrow('File not found');
+    });
+
+    it('should rename a file', async () => {
+      await adapter.createFile('old.md', 'content');
+      await adapter.renameFile('old.md', 'new.md');
+      const content = await adapter.readFile('new.md');
+      expect(content).toBe('content');
+      await expect(adapter.readFile('old.md')).rejects.toThrow('File not found');
+    });
+
+    it('should copy a file', async () => {
+      await adapter.createFile('source.md', 'content');
+      await adapter.copyFile('source.md', 'dest.md');
+      expect(await adapter.readFile('source.md')).toBe('content');
+      expect(await adapter.readFile('dest.md')).toBe('content');
+    });
+
+    it('should throw when copying a nonexistent file', async () => {
+      await expect(adapter.copyFile('missing.md', 'dest.md')).rejects.toThrow('File not found');
+    });
+  });
+
+  describe('binary operations', () => {
+    it('should write and read binary data', async () => {
+      const data = new Uint8Array([1, 2, 3, 4]).buffer;
+      await adapter.writeBinary('test.bin', data);
+      const result = await adapter.readBinary('test.bin');
+      expect(new Uint8Array(result)).toEqual(new Uint8Array([1, 2, 3, 4]));
+    });
+
+    it('should overwrite existing binary data', async () => {
+      const data1 = new Uint8Array([1, 2]).buffer;
+      const data2 = new Uint8Array([3, 4, 5]).buffer;
+      await adapter.writeBinary('test.bin', data1);
+      await adapter.writeBinary('test.bin', data2);
+      const result = await adapter.readBinary('test.bin');
+      expect(new Uint8Array(result)).toEqual(new Uint8Array([3, 4, 5]));
+    });
+  });
+
+  describe('folder operations', () => {
+    it('should create a folder', async () => {
+      await adapter.createFolder('notes');
+      expect(await adapter.exists('notes')).toBe(true);
+    });
+
+    it('should throw when creating a folder that already exists', async () => {
+      await adapter.createFolder('notes');
+      await expect(adapter.createFolder('notes')).rejects.toThrow('already exists');
+    });
+
+    it('should delete an empty folder', async () => {
+      await adapter.createFolder('notes');
+      await adapter.deleteFolder('notes', false);
+      expect(await adapter.exists('notes')).toBe(false);
+    });
+
+    it('should throw when deleting a non-empty folder without recursive', async () => {
+      await adapter.createFolder('notes');
+      await adapter.createFile('notes/test.md', 'content');
+      await expect(adapter.deleteFolder('notes', false)).rejects.toThrow('not empty');
+    });
+
+    it('should delete a non-empty folder with recursive', async () => {
+      await adapter.createFolder('notes');
+      await adapter.createFile('notes/test.md', 'content');
+      await adapter.deleteFolder('notes', true);
+      expect(await adapter.exists('notes')).toBe(false);
+      expect(await adapter.exists('notes/test.md')).toBe(false);
+    });
+
+    it('should throw when deleting a nonexistent folder', async () => {
+      await expect(adapter.deleteFolder('missing', false)).rejects.toThrow('Folder not found');
+    });
+  });
+
+  describe('query operations', () => {
+    it('should check existence of files', async () => {
+      expect(await adapter.exists('test.md')).toBe(false);
+      await adapter.createFile('test.md', 'content');
+      expect(await adapter.exists('test.md')).toBe(true);
+    });
+
+    it('should check existence of folders', async () => {
+      expect(await adapter.exists('notes')).toBe(false);
+      await adapter.createFolder('notes');
+      expect(await adapter.exists('notes')).toBe(true);
+    });
+
+    it('should return stat for a file', async () => {
+      await adapter.createFile('test.md', 'hello');
+      const stat = await adapter.stat('test.md');
+      expect(stat).not.toBeNull();
+      expect(stat!.size).toBe(5);
+      expect(stat!.ctime).toBeGreaterThan(0);
+      expect(stat!.mtime).toBeGreaterThan(0);
+    });
+
+    it('should return null stat for nonexistent path', async () => {
+      const stat = await adapter.stat('missing.md');
+      expect(stat).toBeNull();
+    });
+
+    it('should list direct children', async () => {
+      await adapter.createFolder('notes');
+      await adapter.createFile('notes/a.md', 'a');
+      await adapter.createFile('notes/b.md', 'b');
+      await adapter.createFolder('notes/sub');
+      await adapter.createFile('notes/sub/c.md', 'c');
+
+      const result = adapter.list('notes');
+      expect(result.files).toEqual(['notes/a.md', 'notes/b.md']);
+      expect(result.folders).toEqual(['notes/sub']);
+    });
+
+    it('should list recursively', async () => {
+      await adapter.createFolder('notes');
+      await adapter.createFile('notes/a.md', 'a');
+      await adapter.createFolder('notes/sub');
+      await adapter.createFile('notes/sub/b.md', 'b');
+
+      const result = adapter.listRecursive('notes');
+      expect(result.files).toEqual(['notes/a.md', 'notes/sub/b.md']);
+      expect(result.folders).toEqual(['notes/sub']);
+    });
+
+    it('should throw when listing a nonexistent folder', () => {
+      expect(() => adapter.list('missing')).toThrow('Folder not found');
+    });
+  });
+
+  describe('vault info', () => {
+    it('should return the vault path', () => {
+      expect(adapter.getVaultPath()).toBe('/mock-vault');
+    });
+
+    it('should allow setting the vault path', () => {
+      adapter.setVaultPath('/custom/path');
+      expect(adapter.getVaultPath()).toBe('/custom/path');
+    });
+  });
+
+  describe('test helpers', () => {
+    it('should add files via helper', async () => {
+      adapter.addFile('test.md', '# Test');
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('# Test');
+    });
+
+    it('should add files with custom stat via helper', async () => {
+      adapter.addFile('test.md', 'content', { ctime: 1000, mtime: 2000 });
+      const stat = await adapter.stat('test.md');
+      expect(stat!.ctime).toBe(1000);
+      expect(stat!.mtime).toBe(2000);
+    });
+
+    it('should add folders via helper', async () => {
+      adapter.addFolder('notes');
+      expect(await adapter.exists('notes')).toBe(true);
+    });
+  });
+
+  describe('rename folder', () => {
+    it('should rename a folder and move its children', async () => {
+      await adapter.createFolder('old');
+      await adapter.createFile('old/test.md', 'content');
+      await adapter.renameFile('old', 'new');
+
+      expect(await adapter.exists('new')).toBe(true);
+      expect(await adapter.exists('old')).toBe(false);
+      expect(await adapter.readFile('new/test.md')).toBe('content');
+      await expect(adapter.readFile('old/test.md')).rejects.toThrow('File not found');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ObsidianAdapter` interface covering vault CRUD, stat, list, binary operations
- Add `RealObsidianAdapter` delegating to Obsidian `App` object
- Add `MockObsidianAdapter` with in-memory file system for testing
- 31 unit tests for mock adapter covering all operations

Closes #19