### PR TITLE
feat: add path validation and security utilities

### DIFF
--- a/src/utils/path-guard.ts
+++ b/src/utils/path-guard.ts
@@ -1,0 +1,55 @@
+import { posix } from 'path';
+
+export class PathTraversalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathTraversalError';
+  }
+}
+
+export function validateVaultPath(inputPath: string, vaultRoot: string): string {
+  if (!inputPath || inputPath.trim().length === 0) {
+    throw new PathTraversalError('Path must not be empty');
+  }
+
+  // Reject null bytes
+  if (inputPath.includes('\0')) {
+    throw new PathTraversalError('Path must not contain null bytes');
+  }
+
+  // Reject backslashes (Windows-style path separators used as escape attempts)
+  if (inputPath.includes('\\')) {
+    throw new PathTraversalError('Path must not contain backslashes');
+  }
+
+  // Reject percent-encoded sequences that could hide traversal
+  if (/%2[eE]/g.test(inputPath) || /%2[fF]/g.test(inputPath) || /%5[cC]/g.test(inputPath)) {
+    throw new PathTraversalError('Path must not contain encoded traversal sequences');
+  }
+
+  // Normalize the path
+  const normalized = posix.normalize(inputPath);
+
+  // Reject if normalization reveals traversal
+  if (normalized.startsWith('..') || normalized.includes('/..') || normalized === '..') {
+    throw new PathTraversalError('Path must not traverse outside the vault');
+  }
+
+  // Remove leading slashes — vault paths are relative
+  const relativePath = normalized.replace(/^\/+/, '');
+
+  if (relativePath.length === 0) {
+    throw new PathTraversalError('Path must not be empty after normalization');
+  }
+
+  // Build the absolute path and verify it's within the vault
+  const normalizedVaultRoot = posix.normalize(vaultRoot);
+  const absolutePath = posix.join(normalizedVaultRoot, relativePath);
+  const resolvedAbsolute = posix.normalize(absolutePath);
+
+  if (!resolvedAbsolute.startsWith(normalizedVaultRoot + '/') && resolvedAbsolute !== normalizedVaultRoot) {
+    throw new PathTraversalError('Path must not traverse outside the vault');
+  }
+
+  return relativePath;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const filePathSchema = z
+  .string()
+  .min(1, 'File path must not be empty')
+  .refine((val) => !val.includes('\0'), 'File path must not contain null bytes')
+  .refine((val) => !val.includes('\\'), 'File path must not contain backslashes');
+
+export const folderPathSchema = z
+  .string()
+  .min(1, 'Folder path must not be empty')
+  .refine((val) => !val.includes('\0'), 'Folder path must not contain null bytes')
+  .refine((val) => !val.includes('\\'), 'Folder path must not contain backslashes');
+
+export const lineNumberSchema = z.number().int().min(0, 'Line number must be non-negative');
+
+export const columnNumberSchema = z.number().int().min(0, 'Column number must be non-negative');
+
+export const positionSchema = z.object({
+  line: lineNumberSchema,
+  ch: columnNumberSchema,
+});
+
+export const rangeSchema = z.object({
+  from: positionSchema,
+  to: positionSchema,
+});
+
+export const paginationSchema = z.object({
+  offset: z.number().int().min(0).default(0),
+  limit: z.number().int().min(1).max(10000).default(100),
+});
+
+export const contentSchema = z.string();
+
+export const base64Schema = z
+  .string()
+  .refine(
+    (val) => /^[A-Za-z0-9+/]*={0,2}$/.test(val),
+    'Invalid base64 string',
+  );

--- a/tests/utils/path-guard.test.ts
+++ b/tests/utils/path-guard.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { validateVaultPath, PathTraversalError } from '../../src/utils/path-guard';
+
+const VAULT_ROOT = '/home/user/vault';
+
+describe('validateVaultPath', () => {
+  describe('valid paths', () => {
+    it('should accept a simple file path', () => {
+      expect(validateVaultPath('notes/test.md', VAULT_ROOT)).toBe('notes/test.md');
+    });
+
+    it('should accept a root-level file', () => {
+      expect(validateVaultPath('test.md', VAULT_ROOT)).toBe('test.md');
+    });
+
+    it('should accept deeply nested paths', () => {
+      expect(validateVaultPath('a/b/c/d/e.md', VAULT_ROOT)).toBe('a/b/c/d/e.md');
+    });
+
+    it('should normalize redundant slashes', () => {
+      expect(validateVaultPath('notes//test.md', VAULT_ROOT)).toBe('notes/test.md');
+    });
+
+    it('should normalize current directory references', () => {
+      expect(validateVaultPath('./notes/test.md', VAULT_ROOT)).toBe('notes/test.md');
+    });
+
+    it('should strip leading slashes', () => {
+      expect(validateVaultPath('/notes/test.md', VAULT_ROOT)).toBe('notes/test.md');
+    });
+
+    it('should accept paths with spaces', () => {
+      expect(validateVaultPath('my notes/my file.md', VAULT_ROOT)).toBe('my notes/my file.md');
+    });
+
+    it('should accept paths with unicode characters', () => {
+      expect(validateVaultPath('notes/日本語.md', VAULT_ROOT)).toBe('notes/日本語.md');
+    });
+  });
+
+  describe('path traversal attacks', () => {
+    it('should reject simple ../ traversal', () => {
+      expect(() => validateVaultPath('../etc/passwd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject ../../ traversal', () => {
+      expect(() => validateVaultPath('../../etc/passwd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject mid-path traversal', () => {
+      expect(() => validateVaultPath('notes/../../etc/passwd', VAULT_ROOT)).toThrow(
+        PathTraversalError,
+      );
+    });
+
+    it('should reject backslash traversal', () => {
+      expect(() => validateVaultPath('..\\etc\\passwd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject null byte injection', () => {
+      expect(() => validateVaultPath('test.md\0.jpg', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject encoded dot traversal (%2e)', () => {
+      expect(() => validateVaultPath('%2e%2e/etc/passwd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject encoded slash (%2f)', () => {
+      expect(() => validateVaultPath('..%2fetc/passwd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject encoded backslash (%5c)', () => {
+      expect(() => validateVaultPath('..%5cetc%5cpasswd', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject uppercase encoded sequences', () => {
+      expect(() => validateVaultPath('%2E%2E/%2F', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should reject empty string', () => {
+      expect(() => validateVaultPath('', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject whitespace-only string', () => {
+      expect(() => validateVaultPath('   ', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject bare ..', () => {
+      expect(() => validateVaultPath('..', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should reject path that resolves to vault root exactly via traversal', () => {
+      expect(() => validateVaultPath('notes/../..', VAULT_ROOT)).toThrow(PathTraversalError);
+    });
+
+    it('should handle paths with consecutive dots in names (not traversal)', () => {
+      expect(validateVaultPath('notes/file...md', VAULT_ROOT)).toBe('notes/file...md');
+    });
+
+    it('should handle paths with .. in filenames (not traversal)', () => {
+      expect(validateVaultPath('notes/file..name.md', VAULT_ROOT)).toBe('notes/file..name.md');
+    });
+  });
+});

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filePathSchema,
+  folderPathSchema,
+  lineNumberSchema,
+  columnNumberSchema,
+  positionSchema,
+  rangeSchema,
+  paginationSchema,
+  base64Schema,
+} from '../../src/utils/validation';
+
+describe('filePathSchema', () => {
+  it('should accept a valid file path', () => {
+    expect(filePathSchema.parse('notes/test.md')).toBe('notes/test.md');
+  });
+
+  it('should reject an empty string', () => {
+    expect(() => filePathSchema.parse('')).toThrow();
+  });
+
+  it('should reject a path with null bytes', () => {
+    expect(() => filePathSchema.parse('test\0.md')).toThrow();
+  });
+
+  it('should reject a path with backslashes', () => {
+    expect(() => filePathSchema.parse('notes\\test.md')).toThrow();
+  });
+});
+
+describe('folderPathSchema', () => {
+  it('should accept a valid folder path', () => {
+    expect(folderPathSchema.parse('notes/subfolder')).toBe('notes/subfolder');
+  });
+
+  it('should reject an empty string', () => {
+    expect(() => folderPathSchema.parse('')).toThrow();
+  });
+});
+
+describe('lineNumberSchema', () => {
+  it('should accept zero', () => {
+    expect(lineNumberSchema.parse(0)).toBe(0);
+  });
+
+  it('should accept positive integers', () => {
+    expect(lineNumberSchema.parse(42)).toBe(42);
+  });
+
+  it('should reject negative numbers', () => {
+    expect(() => lineNumberSchema.parse(-1)).toThrow();
+  });
+
+  it('should reject floats', () => {
+    expect(() => lineNumberSchema.parse(1.5)).toThrow();
+  });
+});
+
+describe('columnNumberSchema', () => {
+  it('should accept zero', () => {
+    expect(columnNumberSchema.parse(0)).toBe(0);
+  });
+
+  it('should reject negative numbers', () => {
+    expect(() => columnNumberSchema.parse(-1)).toThrow();
+  });
+});
+
+describe('positionSchema', () => {
+  it('should accept a valid position', () => {
+    const result = positionSchema.parse({ line: 5, ch: 10 });
+    expect(result).toEqual({ line: 5, ch: 10 });
+  });
+
+  it('should reject missing line', () => {
+    expect(() => positionSchema.parse({ ch: 10 })).toThrow();
+  });
+
+  it('should reject missing ch', () => {
+    expect(() => positionSchema.parse({ line: 5 })).toThrow();
+  });
+});
+
+describe('rangeSchema', () => {
+  it('should accept a valid range', () => {
+    const result = rangeSchema.parse({
+      from: { line: 1, ch: 0 },
+      to: { line: 5, ch: 10 },
+    });
+    expect(result.from.line).toBe(1);
+    expect(result.to.line).toBe(5);
+  });
+});
+
+describe('paginationSchema', () => {
+  it('should apply defaults', () => {
+    const result = paginationSchema.parse({});
+    expect(result.offset).toBe(0);
+    expect(result.limit).toBe(100);
+  });
+
+  it('should accept custom values', () => {
+    const result = paginationSchema.parse({ offset: 50, limit: 200 });
+    expect(result.offset).toBe(50);
+    expect(result.limit).toBe(200);
+  });
+
+  it('should reject negative offset', () => {
+    expect(() => paginationSchema.parse({ offset: -1 })).toThrow();
+  });
+
+  it('should reject limit over 10000', () => {
+    expect(() => paginationSchema.parse({ limit: 10001 })).toThrow();
+  });
+});
+
+describe('base64Schema', () => {
+  it('should accept valid base64', () => {
+    expect(base64Schema.parse('SGVsbG8=')).toBe('SGVsbG8=');
+  });
+
+  it('should accept empty string', () => {
+    expect(base64Schema.parse('')).toBe('');
+  });
+
+  it('should reject invalid characters', () => {
+    expect(() => base64Schema.parse('invalid!@#')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `validateVaultPath()` for path traversal protection — rejects `../`, null bytes, encoded sequences, backslashes
- Add Zod schema helpers for file paths, positions, ranges, pagination, and base64
- 46 unit tests covering traversal attacks, edge cases, and validation schemas

Closes #21