### PR TITLE
feat: add module registry and tool registration system

### DIFF
--- a/src/registry/module-registry.ts
+++ b/src/registry/module-registry.ts
@@ -1,0 +1,142 @@
+import { Logger } from '../utils/logger';
+import { ModuleRegistration, ToolDefinition, ToolModule } from './types';
+
+export type ModuleStateMap = Record<string, { enabled: boolean; readOnly: boolean }>;
+
+export type RegistryChangeHandler = () => void;
+
+export class ModuleRegistry {
+  private modules: Map<string, ModuleRegistration> = new Map();
+  private changeHandlers: Set<RegistryChangeHandler> = new Set();
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  registerModule(module: ToolModule): void {
+    const { id } = module.metadata;
+    if (this.modules.has(id)) {
+      this.logger.warn(`Module "${id}" is already registered, skipping`);
+      return;
+    }
+    this.modules.set(id, {
+      module,
+      enabled: true,
+      readOnly: false,
+    });
+    this.logger.info(`Registered module: ${module.metadata.name}`, { id });
+    this.notifyChange();
+  }
+
+  unregisterModule(id: string): void {
+    if (!this.modules.has(id)) {
+      this.logger.warn(`Module "${id}" is not registered, skipping`);
+      return;
+    }
+    this.modules.delete(id);
+    this.logger.info(`Unregistered module: ${id}`);
+    this.notifyChange();
+  }
+
+  enableModule(id: string): void {
+    const registration = this.modules.get(id);
+    if (!registration) {
+      throw new Error(`Module "${id}" is not registered`);
+    }
+    registration.enabled = true;
+    this.logger.info(`Enabled module: ${id}`);
+    this.notifyChange();
+  }
+
+  disableModule(id: string): void {
+    const registration = this.modules.get(id);
+    if (!registration) {
+      throw new Error(`Module "${id}" is not registered`);
+    }
+    registration.enabled = false;
+    this.logger.info(`Disabled module: ${id}`);
+    this.notifyChange();
+  }
+
+  setReadOnly(id: string, readOnly: boolean): void {
+    const registration = this.modules.get(id);
+    if (!registration) {
+      throw new Error(`Module "${id}" is not registered`);
+    }
+    if (!registration.module.metadata.supportsReadOnly) {
+      throw new Error(`Module "${id}" does not support read-only mode`);
+    }
+    registration.readOnly = readOnly;
+    this.logger.info(`Set module "${id}" read-only: ${String(readOnly)}`);
+    this.notifyChange();
+  }
+
+  getModules(): ModuleRegistration[] {
+    return Array.from(this.modules.values());
+  }
+
+  getModule(id: string): ModuleRegistration | undefined {
+    return this.modules.get(id);
+  }
+
+  getActiveTools(): ToolDefinition[] {
+    const tools: ToolDefinition[] = [];
+    for (const registration of this.modules.values()) {
+      if (!registration.enabled) continue;
+      const moduleTools = registration.module.tools();
+      for (const tool of moduleTools) {
+        if (registration.readOnly && !tool.isReadOnly) continue;
+        tools.push(tool);
+      }
+    }
+    return tools;
+  }
+
+  isModuleEnabled(id: string): boolean {
+    const registration = this.modules.get(id);
+    return registration?.enabled ?? false;
+  }
+
+  applyState(state: ModuleStateMap): void {
+    for (const [id, moduleState] of Object.entries(state)) {
+      const registration = this.modules.get(id);
+      if (registration) {
+        registration.enabled = moduleState.enabled;
+        if (registration.module.metadata.supportsReadOnly) {
+          registration.readOnly = moduleState.readOnly;
+        }
+      }
+    }
+    this.notifyChange();
+  }
+
+  getState(): ModuleStateMap {
+    const state: ModuleStateMap = {};
+    for (const [id, registration] of this.modules.entries()) {
+      state[id] = {
+        enabled: registration.enabled,
+        readOnly: registration.readOnly,
+      };
+    }
+    return state;
+  }
+
+  onChange(handler: RegistryChangeHandler): () => void {
+    this.changeHandlers.add(handler);
+    return () => {
+      this.changeHandlers.delete(handler);
+    };
+  }
+
+  clear(): void {
+    this.modules.clear();
+    this.notifyChange();
+  }
+
+  private notifyChange(): void {
+    for (const handler of this.changeHandlers) {
+      handler();
+    }
+  }
+}

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  schema: z.ZodType;
+  handler: (params: unknown) => Promise<ToolResult>;
+  isReadOnly: boolean;
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+export interface ModuleMetadata {
+  id: string;
+  name: string;
+  description: string;
+  supportsReadOnly: boolean;
+}
+
+export interface ToolModule {
+  metadata: ModuleMetadata;
+  tools(): ToolDefinition[];
+}
+
+export interface ModuleRegistration {
+  module: ToolModule;
+  enabled: boolean;
+  readOnly: boolean;
+}

--- a/tests/registry/module-registry.test.ts
+++ b/tests/registry/module-registry.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ModuleRegistry } from '../../src/registry/module-registry';
+import { ToolModule, ToolDefinition, ToolResult } from '../../src/registry/types';
+import { Logger } from '../../src/utils/logger';
+import { z } from 'zod';
+
+function createMockLogger(): Logger {
+  const logger = new Logger('test', { debugMode: false, accessKey: '' });
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  return logger;
+}
+
+function createMockTool(name: string, isReadOnly: boolean): ToolDefinition {
+  return {
+    name,
+    description: `Mock tool: ${name}`,
+    schema: z.object({}),
+    handler: (): Promise<ToolResult> =>
+      Promise.resolve({
+        content: [{ type: 'text', text: 'ok' }],
+      }),
+    isReadOnly,
+  };
+}
+
+function createMockModule(
+  id: string,
+  tools: ToolDefinition[],
+  supportsReadOnly = false,
+): ToolModule {
+  return {
+    metadata: {
+      id,
+      name: `Mock ${id}`,
+      description: `Mock module: ${id}`,
+      supportsReadOnly,
+    },
+    tools: () => tools,
+  };
+}
+
+describe('ModuleRegistry', () => {
+  let registry: ModuleRegistry;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    const logger = createMockLogger();
+    registry = new ModuleRegistry(logger);
+  });
+
+  describe('registerModule', () => {
+    it('should register a module', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      expect(registry.getModules()).toHaveLength(1);
+      expect(registry.getModules()[0].module).toBe(module);
+    });
+
+    it('should register modules as enabled by default', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      expect(registry.getModules()[0].enabled).toBe(true);
+    });
+
+    it('should skip duplicate module registration', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      registry.registerModule(module);
+      expect(registry.getModules()).toHaveLength(1);
+    });
+  });
+
+  describe('unregisterModule', () => {
+    it('should remove a registered module', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      registry.unregisterModule('vault');
+      expect(registry.getModules()).toHaveLength(0);
+    });
+
+    it('should handle unregistering a non-existent module gracefully', () => {
+      expect(() => registry.unregisterModule('missing')).not.toThrow();
+    });
+  });
+
+  describe('enableModule / disableModule', () => {
+    it('should disable a module', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      registry.disableModule('vault');
+      expect(registry.isModuleEnabled('vault')).toBe(false);
+    });
+
+    it('should re-enable a disabled module', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      registry.disableModule('vault');
+      registry.enableModule('vault');
+      expect(registry.isModuleEnabled('vault')).toBe(true);
+    });
+
+    it('should throw when enabling a non-existent module', () => {
+      expect(() => registry.enableModule('missing')).toThrow('not registered');
+    });
+
+    it('should throw when disabling a non-existent module', () => {
+      expect(() => registry.disableModule('missing')).toThrow('not registered');
+    });
+  });
+
+  describe('setReadOnly', () => {
+    it('should set a module to read-only', () => {
+      const module = createMockModule('vault', [], true);
+      registry.registerModule(module);
+      registry.setReadOnly('vault', true);
+      const reg = registry.getModule('vault');
+      expect(reg?.readOnly).toBe(true);
+    });
+
+    it('should throw when module does not support read-only', () => {
+      const module = createMockModule('search', [], false);
+      registry.registerModule(module);
+      expect(() => registry.setReadOnly('search', true)).toThrow('does not support read-only');
+    });
+
+    it('should throw for non-existent module', () => {
+      expect(() => registry.setReadOnly('missing', true)).toThrow('not registered');
+    });
+  });
+
+  describe('getActiveTools', () => {
+    it('should return tools from enabled modules', () => {
+      const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
+      const module = createMockModule('vault', tools);
+      registry.registerModule(module);
+      expect(registry.getActiveTools()).toHaveLength(2);
+    });
+
+    it('should exclude tools from disabled modules', () => {
+      const module = createMockModule('vault', [createMockTool('vault_read', true)]);
+      registry.registerModule(module);
+      registry.disableModule('vault');
+      expect(registry.getActiveTools()).toHaveLength(0);
+    });
+
+    it('should exclude write tools in read-only mode', () => {
+      const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
+      const module = createMockModule('vault', tools, true);
+      registry.registerModule(module);
+      registry.setReadOnly('vault', true);
+      const active = registry.getActiveTools();
+      expect(active).toHaveLength(1);
+      expect(active[0].name).toBe('vault_read');
+    });
+
+    it('should include all tools when read-only is off', () => {
+      const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
+      const module = createMockModule('vault', tools, true);
+      registry.registerModule(module);
+      expect(registry.getActiveTools()).toHaveLength(2);
+    });
+
+    it('should aggregate tools from multiple modules', () => {
+      registry.registerModule(
+        createMockModule('vault', [createMockTool('vault_read', true)]),
+      );
+      registry.registerModule(
+        createMockModule('search', [createMockTool('search_fulltext', true)]),
+      );
+      expect(registry.getActiveTools()).toHaveLength(2);
+    });
+  });
+
+  describe('applyState / getState', () => {
+    it('should apply state from settings', () => {
+      const module = createMockModule('vault', [], true);
+      registry.registerModule(module);
+      registry.applyState({
+        vault: { enabled: false, readOnly: true },
+      });
+      expect(registry.isModuleEnabled('vault')).toBe(false);
+      expect(registry.getModule('vault')?.readOnly).toBe(true);
+    });
+
+    it('should ignore state for unregistered modules', () => {
+      registry.applyState({ missing: { enabled: false, readOnly: false } });
+      expect(registry.getModules()).toHaveLength(0);
+    });
+
+    it('should return current state', () => {
+      const module = createMockModule('vault', [], true);
+      registry.registerModule(module);
+      registry.disableModule('vault');
+      const state = registry.getState();
+      expect(state.vault).toEqual({ enabled: false, readOnly: false });
+    });
+  });
+
+  describe('onChange', () => {
+    it('should notify on module registration', () => {
+      const handler = vi.fn();
+      registry.onChange(handler);
+      registry.registerModule(createMockModule('vault', []));
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should notify on enable/disable', () => {
+      const handler = vi.fn();
+      registry.registerModule(createMockModule('vault', []));
+      registry.onChange(handler);
+      registry.disableModule('vault');
+      registry.enableModule('vault');
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('should support unsubscribe', () => {
+      const handler = vi.fn();
+      const unsubscribe = registry.onChange(handler);
+      unsubscribe();
+      registry.registerModule(createMockModule('vault', []));
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all modules', () => {
+      registry.registerModule(createMockModule('vault', []));
+      registry.registerModule(createMockModule('search', []));
+      registry.clear();
+      expect(registry.getModules()).toHaveLength(0);
+    });
+  });
+
+  describe('getModule', () => {
+    it('should return a specific module registration', () => {
+      const module = createMockModule('vault', []);
+      registry.registerModule(module);
+      expect(registry.getModule('vault')?.module).toBe(module);
+    });
+
+    it('should return undefined for non-existent module', () => {
+      expect(registry.getModule('missing')).toBeUndefined();
+    });
+  });
+
+  describe('isModuleEnabled', () => {
+    it('should return false for non-existent module', () => {
+      expect(registry.isModuleEnabled('missing')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ToolModule` interface and `ModuleMetadata` for self-describing modules
- Add `ModuleRegistry` with register/unregister, enable/disable, read-only filtering
- State persistence via `applyState()`/`getState()` and change notification handlers
- 27 unit tests covering all registry operations

Closes #23