### PR TITLE
feat: add MCP server core with Streamable HTTP transport

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,65 @@
 import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, McpPluginSettings } from './types';
+import { createLogger, Logger } from './utils/logger';
+import { ModuleRegistry } from './registry/module-registry';
+import { createMcpServer } from './server/mcp-server';
+import { HttpMcpServer } from './server/http-server';
 
 export default class McpPlugin extends Plugin {
   settings: McpPluginSettings = DEFAULT_SETTINGS;
+  logger!: Logger;
+  registry!: ModuleRegistry;
+  httpServer: HttpMcpServer | null = null;
 
   async onload(): Promise<void> {
     await this.loadSettings();
+
+    this.logger = createLogger('mcp-plugin', {
+      debugMode: this.settings.debugMode,
+      accessKey: this.settings.accessKey,
+    });
+
+    this.registry = new ModuleRegistry(this.logger);
+
+    // Apply saved module states
+    this.registry.applyState(this.settings.moduleStates);
+
+    // Start server if access key is configured
+    if (this.settings.accessKey) {
+      await this.startServer();
+    } else {
+      this.logger.info('MCP server not started: no access key configured');
+    }
   }
 
   onunload(): void {
-    // Cleanup will be added as features are implemented
+    void this.stopServer();
+  }
+
+  async startServer(): Promise<void> {
+    try {
+      const mcpServer = createMcpServer(this.registry, this.logger);
+      this.httpServer = new HttpMcpServer(mcpServer, this.logger, {
+        port: this.settings.port,
+        accessKey: this.settings.accessKey,
+      });
+      await this.httpServer.start();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to start MCP server: ${message}`);
+    }
+  }
+
+  async stopServer(): Promise<void> {
+    if (this.httpServer) {
+      await this.httpServer.stop();
+      this.httpServer = null;
+    }
+  }
+
+  async restartServer(): Promise<void> {
+    await this.stopServer();
+    await this.startServer();
   }
 
   async loadSettings(): Promise<void> {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,16 +1,12 @@
 import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 export interface ToolDefinition {
   name: string;
   description: string;
-  schema: z.ZodType;
-  handler: (params: unknown) => Promise<ToolResult>;
+  schema: Record<string, z.ZodType>;
+  handler: (params: Record<string, unknown>) => Promise<CallToolResult>;
   isReadOnly: boolean;
-}
-
-export interface ToolResult {
-  content: Array<{ type: 'text'; text: string }>;
-  isError?: boolean;
 }
 
 export interface ModuleMetadata {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,40 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+export interface AuthResult {
+  authenticated: boolean;
+  error?: string;
+}
+
+export function authenticateRequest(
+  req: IncomingMessage,
+  accessKey: string,
+): AuthResult {
+  if (!accessKey || accessKey.length === 0) {
+    return { authenticated: false, error: 'Server access key is not configured' };
+  }
+
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return { authenticated: false, error: 'Missing Authorization header' };
+  }
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return { authenticated: false, error: 'Invalid Authorization header format. Expected: Bearer <key>' };
+  }
+
+  const token = parts[1];
+  if (token !== accessKey) {
+    return { authenticated: false, error: 'Invalid access key' };
+  }
+
+  return { authenticated: true };
+}
+
+export function sendAuthError(res: ServerResponse, error: string): void {
+  res.writeHead(401, {
+    'Content-Type': 'application/json',
+    'WWW-Authenticate': 'Bearer',
+  });
+  res.end(JSON.stringify({ error }));
+}

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,33 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+export interface CorsOptions {
+  allowOrigin: string;
+  allowMethods: string[];
+  allowHeaders: string[];
+  maxAge: number;
+}
+
+export const DEFAULT_CORS_OPTIONS: CorsOptions = {
+  allowOrigin: 'http://localhost',
+  allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id'],
+  maxAge: 86400,
+};
+
+export function applyCorsHeaders(res: ServerResponse, options: CorsOptions = DEFAULT_CORS_OPTIONS): void {
+  res.setHeader('Access-Control-Allow-Origin', options.allowOrigin);
+  res.setHeader('Access-Control-Allow-Methods', options.allowMethods.join(', '));
+  res.setHeader('Access-Control-Allow-Headers', options.allowHeaders.join(', '));
+  res.setHeader('Access-Control-Max-Age', String(options.maxAge));
+  res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+}
+
+export function handlePreflight(req: IncomingMessage, res: ServerResponse, options: CorsOptions = DEFAULT_CORS_OPTIONS): boolean {
+  if (req.method === 'OPTIONS') {
+    applyCorsHeaders(res, options);
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+  return false;
+}

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -1,0 +1,131 @@
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { randomUUID } from 'crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { Logger } from '../utils/logger';
+import { authenticateRequest, sendAuthError } from './auth';
+import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } from './cors';
+
+export interface HttpServerOptions {
+  port: number;
+  accessKey: string;
+  corsOptions?: CorsOptions;
+}
+
+export class HttpMcpServer {
+  private httpServer: Server | null = null;
+  private transport: StreamableHTTPServerTransport | null = null;
+  private logger: Logger;
+  private mcpServer: McpServer;
+  private options: HttpServerOptions;
+  private _connectedClients = 0;
+
+  constructor(mcpServer: McpServer, logger: Logger, options: HttpServerOptions) {
+    this.mcpServer = mcpServer;
+    this.logger = logger;
+    this.options = options;
+  }
+
+  get connectedClients(): number {
+    return this._connectedClients;
+  }
+
+  get isRunning(): boolean {
+    return this.httpServer !== null && this.httpServer.listening;
+  }
+
+  get port(): number {
+    return this.options.port;
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('Server is already running');
+      return;
+    }
+
+    this.transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    await this.mcpServer.connect(this.transport);
+
+    const corsOptions = this.options.corsOptions ?? DEFAULT_CORS_OPTIONS;
+
+    this.httpServer = createServer((req: IncomingMessage, res: ServerResponse): void => {
+      // CORS preflight
+      if (handlePreflight(req, res, corsOptions)) {
+        return;
+      }
+
+      // Apply CORS headers to all responses
+      applyCorsHeaders(res, corsOptions);
+
+      // Authenticate
+      const authResult = authenticateRequest(req, this.options.accessKey);
+      if (!authResult.authenticated) {
+        this.logger.warn('Authentication failed', { error: authResult.error });
+        sendAuthError(res, authResult.error ?? 'Authentication failed');
+        return;
+      }
+
+      // Log request in debug mode
+      this.logger.debug(`${req.method ?? 'UNKNOWN'} ${req.url ?? '/'}`);
+
+      // Delegate to MCP transport
+      void this.transport!.handleRequest(req, res);
+    });
+
+    this.httpServer.on('connection', () => {
+      this._connectedClients++;
+    });
+
+    this.httpServer.on('close', () => {
+      this._connectedClients = 0;
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.httpServer!.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code === 'EADDRINUSE') {
+          reject(new Error(`Port ${String(this.options.port)} is already in use. Choose a different port in settings.`));
+        } else {
+          reject(error);
+        }
+      });
+
+      this.httpServer!.listen(this.options.port, '127.0.0.1', () => {
+        this.logger.info(`MCP server listening on http://127.0.0.1:${String(this.options.port)}`);
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.httpServer) {
+      return;
+    }
+
+    this.logger.info('Stopping MCP server...');
+
+    await this.mcpServer.close();
+
+    await new Promise<void>((resolve, reject) => {
+      this.httpServer!.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    this.httpServer = null;
+    this.transport = null;
+    this._connectedClients = 0;
+    this.logger.info('MCP server stopped');
+  }
+
+  updateOptions(options: Partial<HttpServerOptions>): void {
+    this.options = { ...this.options, ...options };
+  }
+}

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -1,0 +1,53 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Logger } from '../utils/logger';
+import { ModuleRegistry } from '../registry/module-registry';
+
+export function createMcpServer(
+  registry: ModuleRegistry,
+  logger: Logger,
+): McpServer {
+  const server = new McpServer(
+    {
+      name: 'obsidian-mcp',
+      version: '0.0.0',
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  registerTools(server, registry, logger);
+
+  return server;
+}
+
+function registerTools(
+  server: McpServer,
+  registry: ModuleRegistry,
+  logger: Logger,
+): void {
+  const tools = registry.getActiveTools();
+  for (const tool of tools) {
+    logger.debug(`Registering tool: ${tool.name}`);
+    server.tool(
+      tool.name,
+      tool.description,
+      tool.schema,
+      async (params) => {
+        try {
+          return await tool.handler(params as Record<string, unknown>);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.error(`Tool "${tool.name}" error: ${message}`);
+          return {
+            content: [{ type: 'text' as const, text: `Error: ${message}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+  logger.info(`Registered ${String(tools.length)} tools from ${String(registry.getModules().filter(m => m.enabled).length)} modules`);
+}

--- a/tests/registry/module-registry.test.ts
+++ b/tests/registry/module-registry.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ModuleRegistry } from '../../src/registry/module-registry';
-import { ToolModule, ToolDefinition, ToolResult } from '../../src/registry/types';
+import { ToolModule, ToolDefinition } from '../../src/registry/types';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '../../src/utils/logger';
-import { z } from 'zod';
 
 function createMockLogger(): Logger {
   const logger = new Logger('test', { debugMode: false, accessKey: '' });
@@ -16,10 +16,10 @@ function createMockTool(name: string, isReadOnly: boolean): ToolDefinition {
   return {
     name,
     description: `Mock tool: ${name}`,
-    schema: z.object({}),
-    handler: (): Promise<ToolResult> =>
+    schema: {},
+    handler: (): Promise<CallToolResult> =>
       Promise.resolve({
-        content: [{ type: 'text', text: 'ok' }],
+        content: [{ type: 'text' as const, text: 'ok' }],
       }),
     isReadOnly,
   };

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { authenticateRequest } from '../../src/server/auth';
+import { IncomingMessage } from 'http';
+
+function createMockRequest(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+describe('authenticateRequest', () => {
+  const accessKey = 'test-key-12345';
+
+  it('should authenticate with a valid bearer token', () => {
+    const req = createMockRequest({ authorization: `Bearer ${accessKey}` });
+    const result = authenticateRequest(req, accessKey);
+    expect(result.authenticated).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should reject when no Authorization header is present', () => {
+    const req = createMockRequest({});
+    const result = authenticateRequest(req, accessKey);
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('Missing Authorization');
+  });
+
+  it('should reject when Authorization header format is invalid', () => {
+    const req = createMockRequest({ authorization: 'Basic abc123' });
+    const result = authenticateRequest(req, accessKey);
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('Invalid Authorization');
+  });
+
+  it('should reject when the token does not match', () => {
+    const req = createMockRequest({ authorization: 'Bearer wrong-key' });
+    const result = authenticateRequest(req, accessKey);
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('Invalid access key');
+  });
+
+  it('should reject when access key is empty', () => {
+    const req = createMockRequest({ authorization: 'Bearer something' });
+    const result = authenticateRequest(req, '');
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('not configured');
+  });
+
+  it('should reject token with extra spaces', () => {
+    const req = createMockRequest({ authorization: `Bearer  ${accessKey}` });
+    const result = authenticateRequest(req, accessKey);
+    expect(result.authenticated).toBe(false);
+  });
+});

--- a/tests/server/cors.test.ts
+++ b/tests/server/cors.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyCorsHeaders, handlePreflight, DEFAULT_CORS_OPTIONS } from '../../src/server/cors';
+import { IncomingMessage, ServerResponse } from 'http';
+
+interface MockResponseResult {
+  res: ServerResponse;
+  setHeaderCalls: Array<[string, string]>;
+  writeHeadCalls: number[];
+  endCallCount: { value: number };
+}
+
+function createMockResponse(): MockResponseResult {
+  const setHeaderCalls: Array<[string, string]> = [];
+  const writeHeadCalls: number[] = [];
+  const endCallCount = { value: 0 };
+
+  const res = {
+    setHeader: vi.fn((name: string, value: string) => {
+      setHeaderCalls.push([name, value]);
+    }),
+    writeHead: vi.fn((code: number) => {
+      writeHeadCalls.push(code);
+    }),
+    end: vi.fn(() => {
+      endCallCount.value++;
+    }),
+  } as unknown as ServerResponse;
+
+  return { res, setHeaderCalls, writeHeadCalls, endCallCount };
+}
+
+function createMockRequest(method: string): IncomingMessage {
+  return { method } as unknown as IncomingMessage;
+}
+
+describe('applyCorsHeaders', () => {
+  it('should set all CORS headers with defaults', () => {
+    const { res, setHeaderCalls } = createMockResponse();
+    applyCorsHeaders(res);
+    const headerMap = new Map(setHeaderCalls);
+    expect(headerMap.get('Access-Control-Allow-Origin')).toBe('http://localhost');
+    expect(headerMap.get('Access-Control-Allow-Methods')).toBe('GET, POST, DELETE, OPTIONS');
+    expect(headerMap.get('Access-Control-Allow-Headers')).toBe(
+      'Content-Type, Authorization, Mcp-Session-Id',
+    );
+    expect(headerMap.get('Access-Control-Max-Age')).toBe('86400');
+    expect(headerMap.get('Access-Control-Expose-Headers')).toBe('Mcp-Session-Id');
+  });
+
+  it('should use custom options when provided', () => {
+    const { res, setHeaderCalls } = createMockResponse();
+    applyCorsHeaders(res, {
+      allowOrigin: '*',
+      allowMethods: ['POST'],
+      allowHeaders: ['Content-Type'],
+      maxAge: 3600,
+    });
+    const headerMap = new Map(setHeaderCalls);
+    expect(headerMap.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(headerMap.get('Access-Control-Allow-Methods')).toBe('POST');
+  });
+});
+
+describe('handlePreflight', () => {
+  it('should handle OPTIONS requests and return true', () => {
+    const req = createMockRequest('OPTIONS');
+    const { res, writeHeadCalls, endCallCount } = createMockResponse();
+    const result = handlePreflight(req, res, DEFAULT_CORS_OPTIONS);
+    expect(result).toBe(true);
+    expect(writeHeadCalls).toContain(204);
+    expect(endCallCount.value).toBe(1);
+  });
+
+  it('should not handle non-OPTIONS requests', () => {
+    const req = createMockRequest('POST');
+    const { res, writeHeadCalls } = createMockResponse();
+    const result = handlePreflight(req, res, DEFAULT_CORS_OPTIONS);
+    expect(result).toBe(false);
+    expect(writeHeadCalls).toHaveLength(0);
+  });
+
+  it('should not handle GET requests', () => {
+    const req = createMockRequest('GET');
+    const { res } = createMockResponse();
+    const result = handlePreflight(req, res, DEFAULT_CORS_OPTIONS);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add HTTP server with bearer token authentication and CORS middleware
- Integrate MCP SDK via `StreamableHTTPServerTransport` with session support
- Wire server lifecycle into plugin `onload()`/`onunload()` with graceful shutdown
- Port conflict detection with clear error messaging
- 11 unit tests for auth and CORS middleware

Closes #25