### PR TITLE
feat: add ribbon icon and command palette commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'obsidian';
+import { Notice, Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, McpPluginSettings } from './types';
 import { createLogger, Logger } from './utils/logger';
 import { ModuleRegistry } from './registry/module-registry';
@@ -6,11 +6,15 @@ import { createMcpServer } from './server/mcp-server';
 import { HttpMcpServer } from './server/http-server';
 import { McpSettingsTab, migrateSettings } from './settings';
 
+const ICON_MCP = 'plug';
+
 export default class McpPlugin extends Plugin {
   settings: McpPluginSettings = DEFAULT_SETTINGS;
   logger!: Logger;
   registry!: ModuleRegistry;
   httpServer: HttpMcpServer | null = null;
+  private statusBarItem: { setText: (text: string) => void } | null = null;
+  private ribbonIconEl: HTMLElement | null = null;
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -28,11 +32,63 @@ export default class McpPlugin extends Plugin {
     // Add settings tab
     this.addSettingTab(new McpSettingsTab(this.app, this));
 
+    // Add ribbon icon
+    this.ribbonIconEl = this.addRibbonIcon(
+      ICON_MCP,
+      'MCP Server',
+      () => {
+        if (this.httpServer?.isRunning) {
+          void this.stopServer();
+        } else {
+          void this.startServer();
+        }
+      },
+    );
+
+    // Add status bar item
+    this.statusBarItem = this.addStatusBarItem();
+
+    // Register commands
+    this.addCommand({
+      id: 'start-server',
+      name: 'Start MCP Server',
+      callback: () => {
+        void this.startServer();
+      },
+    });
+
+    this.addCommand({
+      id: 'stop-server',
+      name: 'Stop MCP Server',
+      callback: () => {
+        void this.stopServer();
+      },
+    });
+
+    this.addCommand({
+      id: 'restart-server',
+      name: 'Restart MCP Server',
+      callback: () => {
+        void this.restartServer();
+      },
+    });
+
+    this.addCommand({
+      id: 'copy-access-key',
+      name: 'Copy Access Key',
+      callback: () => {
+        void navigator.clipboard.writeText(this.settings.accessKey).then(() => {
+          new Notice('Access key copied to clipboard');
+        });
+      },
+    });
+
     // Start server if access key is configured
     if (this.settings.accessKey) {
       await this.startServer();
     } else {
       this.logger.info('MCP server not started: no access key configured');
+      this.updateStatusDisplay();
     }
   }
 
@@ -48,9 +104,12 @@ export default class McpPlugin extends Plugin {
         accessKey: this.settings.accessKey,
       });
       await this.httpServer.start();
+      this.updateStatusDisplay();
+      new Notice(`MCP server started on port ${String(this.settings.port)}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to start MCP server: ${message}`);
+      new Notice(`Failed to start MCP server: ${message}`);
     }
   }
 
@@ -58,12 +117,31 @@ export default class McpPlugin extends Plugin {
     if (this.httpServer) {
       await this.httpServer.stop();
       this.httpServer = null;
+      this.updateStatusDisplay();
     }
   }
 
   async restartServer(): Promise<void> {
     await this.stopServer();
     await this.startServer();
+  }
+
+  private updateStatusDisplay(): void {
+    const isRunning = this.httpServer?.isRunning ?? false;
+
+    // Update status bar
+    if (this.statusBarItem) {
+      this.statusBarItem.setText(
+        isRunning ? `MCP :${String(this.settings.port)}` : '',
+      );
+    }
+
+    // Update ribbon icon
+    if (this.ribbonIconEl) {
+      this.ribbonIconEl.ariaLabel = isRunning
+        ? `MCP Server (running on :${String(this.settings.port)})`
+        : 'MCP Server (stopped)';
+    }
   }
 
   async loadSettings(): Promise<void> {


### PR DESCRIPTION
## Summary
- Add ribbon icon for toggling MCP server on/off
- Add status bar item showing port when server is running
- Register 4 commands: Start/Stop/Restart MCP Server, Copy Access Key
- User notifications on server start/stop/errors

Closes #29