### PR TITLE
feat: add vault file operations tools (CRUD)

### DIFF
--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -1,0 +1,132 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+import { validateVaultPath } from '../../utils/path-guard';
+
+export class WriteMutex {
+  private locks: Map<string, Promise<void>> = new Map();
+
+  async acquire(path: string, fn: () => Promise<CallToolResult>): Promise<CallToolResult> {
+    const existing = this.locks.get(path) ?? Promise.resolve();
+    let resolve: () => void;
+    const lock = new Promise<void>((r) => {
+      resolve = r;
+    });
+    this.locks.set(path, lock);
+
+    await existing;
+    try {
+      return await fn();
+    } finally {
+      resolve!();
+      if (this.locks.get(path) === lock) {
+        this.locks.delete(path);
+      }
+    }
+  }
+}
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): CallToolResult {
+  return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+}
+
+export function createHandlers(
+  adapter: ObsidianAdapter,
+  mutex: WriteMutex,
+): {
+  createFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  readFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  updateFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  deleteFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  appendFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  getMetadata: (params: Record<string, unknown>) => Promise<CallToolResult>;
+} {
+  const vaultPath = adapter.getVaultPath();
+
+  return {
+    async createFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const content = params.content as string;
+        return await mutex.acquire(path, async () => {
+          await adapter.createFile(path, content);
+          return textResult(`Created file: ${path}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async readFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const content = await adapter.readFile(path);
+        return textResult(content);
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async updateFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const content = params.content as string;
+        return await mutex.acquire(path, async () => {
+          await adapter.modifyFile(path, content);
+          return textResult(`Updated file: ${path}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async deleteFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        return await mutex.acquire(path, async () => {
+          await adapter.deleteFile(path);
+          return textResult(`Deleted file: ${path}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async appendFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const content = params.content as string;
+        return await mutex.acquire(path, async () => {
+          const existing = await adapter.readFile(path);
+          await adapter.modifyFile(path, existing + content);
+          return textResult(`Appended to file: ${path}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async getMetadata(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const stat = await adapter.stat(path);
+        if (!stat) {
+          return errorResult(`File not found: ${path}`);
+        }
+        return textResult(
+          JSON.stringify({
+            path,
+            size: stat.size,
+            created: new Date(stat.ctime).toISOString(),
+            modified: new Date(stat.mtime).toISOString(),
+          }),
+        );
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+  };
+}

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -1,0 +1,72 @@
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+import { createHandlers, WriteMutex } from './handlers';
+import {
+  createFileSchema,
+  readFileSchema,
+  updateFileSchema,
+  deleteFileSchema,
+  appendFileSchema,
+  getMetadataSchema,
+} from './schemas';
+
+export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
+  const mutex = new WriteMutex();
+  const handlers = createHandlers(adapter, mutex);
+
+  return {
+    metadata: {
+      id: 'vault',
+      name: 'Vault and File Operations',
+      description: 'Create, read, update, delete, and manage files in the vault',
+      supportsReadOnly: true,
+    },
+
+    tools(): ToolDefinition[] {
+      return [
+        {
+          name: 'vault_create',
+          description: 'Create a new file with specified path and content',
+          schema: createFileSchema,
+          handler: handlers.createFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_read',
+          description: 'Read the full content of a file by path',
+          schema: readFileSchema,
+          handler: handlers.readFile,
+          isReadOnly: true,
+        },
+        {
+          name: 'vault_update',
+          description: 'Update (overwrite) the content of an existing file',
+          schema: updateFileSchema,
+          handler: handlers.updateFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_delete',
+          description: 'Delete a file by path',
+          schema: deleteFileSchema,
+          handler: handlers.deleteFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_append',
+          description: 'Append content to the end of an existing file',
+          schema: appendFileSchema,
+          handler: handlers.appendFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_get_metadata',
+          description: 'Get file metadata (size, creation date, modification date)',
+          schema: getMetadataSchema,
+          handler: handlers.getMetadata,
+          isReadOnly: true,
+        },
+      ];
+    },
+  };
+}

--- a/src/tools/vault/schemas.ts
+++ b/src/tools/vault/schemas.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const createFileSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+  content: z.string().describe('File content'),
+};
+
+export const readFileSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+};
+
+export const updateFileSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+  content: z.string().describe('New file content'),
+};
+
+export const deleteFileSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+};
+
+export const appendFileSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+  content: z.string().describe('Content to append'),
+};
+
+export const getMetadataSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+};

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createHandlers, WriteMutex } from '../../../src/tools/vault/handlers';
+
+function getText(result: CallToolResult): string {
+  const item = result.content[0];
+  if (item.type === 'text') return item.text;
+  return '';
+}
+
+describe('vault handlers', () => {
+  let adapter: MockObsidianAdapter;
+  let mutex: WriteMutex;
+  let handlers: ReturnType<typeof createHandlers>;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+    mutex = new WriteMutex();
+    handlers = createHandlers(adapter, mutex);
+  });
+
+  describe('createFile', () => {
+    it('should create a file', async () => {
+      const result = await handlers.createFile({ path: 'test.md', content: '# Hello' });
+      expect(result.isError).toBeUndefined();
+      expect(getText(result)).toContain('Created file');
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('# Hello');
+    });
+
+    it('should reject path traversal', async () => {
+      const result = await handlers.createFile({ path: '../etc/passwd', content: 'hack' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('Error');
+    });
+
+    it('should return error when file already exists', async () => {
+      adapter.addFile('test.md', 'existing');
+      const result = await handlers.createFile({ path: 'test.md', content: 'new' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('readFile', () => {
+    it('should read a file', async () => {
+      adapter.addFile('test.md', '# Hello World');
+      const result = await handlers.readFile({ path: 'test.md' });
+      expect(getText(result)).toBe('# Hello World');
+    });
+
+    it('should return error for nonexistent file', async () => {
+      const result = await handlers.readFile({ path: 'missing.md' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject path traversal', async () => {
+      const result = await handlers.readFile({ path: '../../etc/passwd' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('updateFile', () => {
+    it('should update a file', async () => {
+      adapter.addFile('test.md', 'old');
+      const result = await handlers.updateFile({ path: 'test.md', content: 'new' });
+      expect(result.isError).toBeUndefined();
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('new');
+    });
+
+    it('should return error for nonexistent file', async () => {
+      const result = await handlers.updateFile({ path: 'missing.md', content: 'data' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should delete a file', async () => {
+      adapter.addFile('test.md', 'content');
+      const result = await handlers.deleteFile({ path: 'test.md' });
+      expect(result.isError).toBeUndefined();
+      expect(await adapter.exists('test.md')).toBe(false);
+    });
+
+    it('should return error for nonexistent file', async () => {
+      const result = await handlers.deleteFile({ path: 'missing.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('appendFile', () => {
+    it('should append to a file', async () => {
+      adapter.addFile('test.md', 'Hello');
+      const result = await handlers.appendFile({ path: 'test.md', content: ' World' });
+      expect(result.isError).toBeUndefined();
+      const content = await adapter.readFile('test.md');
+      expect(content).toBe('Hello World');
+    });
+
+    it('should return error for nonexistent file', async () => {
+      const result = await handlers.appendFile({ path: 'missing.md', content: 'data' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('should return file metadata', async () => {
+      adapter.addFile('test.md', 'content', { ctime: 1000, mtime: 2000 });
+      const result = await handlers.getMetadata({ path: 'test.md' });
+      const data = JSON.parse(getText(result)) as Record<string, unknown>;
+      expect(data.path).toBe('test.md');
+      expect(data.size).toBe(7);
+    });
+
+    it('should return error for nonexistent file', async () => {
+      const result = await handlers.getMetadata({ path: 'missing.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+describe('WriteMutex', () => {
+  it('should serialize writes to the same path', async () => {
+    const mutex = new WriteMutex();
+    const order: number[] = [];
+
+    const p1 = mutex.acquire('test.md', async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      order.push(1);
+      return { content: [{ type: 'text' as const, text: '1' }] };
+    });
+
+    const p2 = mutex.acquire('test.md', () => {
+      order.push(2);
+      return Promise.resolve({ content: [{ type: 'text' as const, text: '2' }] });
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('should allow parallel writes to different paths', async () => {
+    const mutex = new WriteMutex();
+    const order: string[] = [];
+
+    const p1 = mutex.acquire('a.md', async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('a');
+      return { content: [{ type: 'text' as const, text: 'a' }] };
+    });
+
+    const p2 = mutex.acquire('b.md', () => {
+      order.push('b');
+      return Promise.resolve({ content: [{ type: 'text' as const, text: 'b' }] });
+    });
+
+    await Promise.all([p1, p2]);
+    // 'b' should complete before 'a' since they're independent
+    expect(order[0]).toBe('b');
+  });
+});

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createVaultModule } from '../../../src/tools/vault/index';
+
+describe('vault module', () => {
+  it('should have correct metadata', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    expect(module.metadata.id).toBe('vault');
+    expect(module.metadata.name).toBe('Vault and File Operations');
+    expect(module.metadata.supportsReadOnly).toBe(true);
+  });
+
+  it('should register 6 tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    const tools = module.tools();
+    expect(tools).toHaveLength(6);
+  });
+
+  it('should have 2 read-only tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    const readOnlyTools = module.tools().filter((t) => t.isReadOnly);
+    expect(readOnlyTools).toHaveLength(2);
+    expect(readOnlyTools.map((t) => t.name).sort()).toEqual(['vault_get_metadata', 'vault_read']);
+  });
+
+  it('should have 4 write tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    const writeTools = module.tools().filter((t) => !t.isReadOnly);
+    expect(writeTools).toHaveLength(4);
+  });
+
+  it('should have correct tool names', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    const names = module.tools().map((t) => t.name).sort();
+    expect(names).toEqual([
+      'vault_append',
+      'vault_create',
+      'vault_delete',
+      'vault_get_metadata',
+      'vault_read',
+      'vault_update',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add vault module with 6 MCP tools: `vault_create`, `vault_read`, `vault_update`, `vault_delete`, `vault_append`, `vault_get_metadata`
- Path traversal protection on all operations
- Per-path write mutex for concurrent write serialization (NFR16)
- Read-only mode: only `vault_read` and `vault_get_metadata` exposed
- 21 unit tests (handlers + module structure + mutex)

Closes #31