### PR TITLE
feat: add vault file move, copy, and rename tools

### DIFF
--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -42,6 +42,9 @@ export function createHandlers(
   updateFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
   deleteFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
   appendFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  renameFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  moveFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  copyFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
   getMetadata: (params: Record<string, unknown>) => Promise<CallToolResult>;
 } {
   const vaultPath = adapter.getVaultPath();
@@ -124,6 +127,47 @@ export function createHandlers(
             modified: new Date(stat.mtime).toISOString(),
           }),
         );
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async renameFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const newName = params.newName as string;
+        const parts = path.split('/');
+        parts[parts.length - 1] = newName;
+        const newPath = parts.join('/');
+        validateVaultPath(newPath, vaultPath);
+        return await mutex.acquire(path, async () => {
+          await adapter.renameFile(path, newPath);
+          return textResult(`Renamed file: ${path} → ${newPath}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async moveFile(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const newPath = validateVaultPath(params.newPath as string, vaultPath);
+        return await mutex.acquire(path, async () => {
+          await adapter.renameFile(path, newPath);
+          return textResult(`Moved file: ${path} → ${newPath}`);
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    async copyFile(params): Promise<CallToolResult> {
+      try {
+        const sourcePath = validateVaultPath(params.sourcePath as string, vaultPath);
+        const destPath = validateVaultPath(params.destPath as string, vaultPath);
+        await adapter.copyFile(sourcePath, destPath);
+        return textResult(`Copied file: ${sourcePath} → ${destPath}`);
       } catch (error) {
         return errorResult(error instanceof Error ? error.message : String(error));
       }

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -8,6 +8,9 @@ import {
   deleteFileSchema,
   appendFileSchema,
   getMetadataSchema,
+  renameFileSchema,
+  moveFileSchema,
+  copyFileSchema,
 } from './schemas';
 
 export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
@@ -65,6 +68,27 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: getMetadataSchema,
           handler: handlers.getMetadata,
           isReadOnly: true,
+        },
+        {
+          name: 'vault_rename',
+          description: 'Rename a file within the same folder',
+          schema: renameFileSchema,
+          handler: handlers.renameFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_move',
+          description: 'Move a file to a different folder',
+          schema: moveFileSchema,
+          handler: handlers.moveFile,
+          isReadOnly: false,
+        },
+        {
+          name: 'vault_copy',
+          description: 'Copy a file to a new path',
+          schema: copyFileSchema,
+          handler: handlers.copyFile,
+          isReadOnly: false,
         },
       ];
     },

--- a/src/tools/vault/schemas.ts
+++ b/src/tools/vault/schemas.ts
@@ -26,3 +26,18 @@ export const appendFileSchema = {
 export const getMetadataSchema = {
   path: z.string().min(1).describe('File path relative to vault root'),
 };
+
+export const renameFileSchema = {
+  path: z.string().min(1).describe('Current file path'),
+  newName: z.string().min(1).describe('New file name (within the same folder)'),
+};
+
+export const moveFileSchema = {
+  path: z.string().min(1).describe('Current file path'),
+  newPath: z.string().min(1).describe('New file path (different folder)'),
+};
+
+export const copyFileSchema = {
+  sourcePath: z.string().min(1).describe('Source file path'),
+  destPath: z.string().min(1).describe('Destination file path'),
+};

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -118,6 +118,53 @@ describe('vault handlers', () => {
       expect(result.isError).toBe(true);
     });
   });
+
+  describe('renameFile', () => {
+    it('should rename a file', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({ path: 'notes/old.md', newName: 'new.md' });
+      expect(result.isError).toBeUndefined();
+      expect(getText(result)).toContain('Renamed');
+      const content = await adapter.readFile('notes/new.md');
+      expect(content).toBe('content');
+    });
+
+    it('should reject path traversal in rename', async () => {
+      adapter.addFile('test.md', 'content');
+      const result = await handlers.renameFile({ path: '../test.md', newName: 'new.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('moveFile', () => {
+    it('should move a file', async () => {
+      adapter.addFile('old/test.md', 'content');
+      adapter.addFolder('new');
+      const result = await handlers.moveFile({ path: 'old/test.md', newPath: 'new/test.md' });
+      expect(result.isError).toBeUndefined();
+      expect(getText(result)).toContain('Moved');
+    });
+
+    it('should reject path traversal in move', async () => {
+      const result = await handlers.moveFile({ path: '../test.md', newPath: 'safe.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('copyFile', () => {
+    it('should copy a file', async () => {
+      adapter.addFile('source.md', 'content');
+      const result = await handlers.copyFile({ sourcePath: 'source.md', destPath: 'dest.md' });
+      expect(result.isError).toBeUndefined();
+      expect(await adapter.readFile('source.md')).toBe('content');
+      expect(await adapter.readFile('dest.md')).toBe('content');
+    });
+
+    it('should reject path traversal in copy', async () => {
+      const result = await handlers.copyFile({ sourcePath: '../etc/passwd', destPath: 'dest.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
 });
 
 describe('WriteMutex', () => {

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -11,11 +11,11 @@ describe('vault module', () => {
     expect(module.metadata.supportsReadOnly).toBe(true);
   });
 
-  it('should register 6 tools', () => {
+  it('should register 9 tools', () => {
     const adapter = new MockObsidianAdapter();
     const module = createVaultModule(adapter);
     const tools = module.tools();
-    expect(tools).toHaveLength(6);
+    expect(tools).toHaveLength(9);
   });
 
   it('should have 2 read-only tools', () => {
@@ -26,11 +26,11 @@ describe('vault module', () => {
     expect(readOnlyTools.map((t) => t.name).sort()).toEqual(['vault_get_metadata', 'vault_read']);
   });
 
-  it('should have 4 write tools', () => {
+  it('should have 7 write tools', () => {
     const adapter = new MockObsidianAdapter();
     const module = createVaultModule(adapter);
     const writeTools = module.tools().filter((t) => !t.isReadOnly);
-    expect(writeTools).toHaveLength(4);
+    expect(writeTools).toHaveLength(7);
   });
 
   it('should have correct tool names', () => {
@@ -39,10 +39,13 @@ describe('vault module', () => {
     const names = module.tools().map((t) => t.name).sort();
     expect(names).toEqual([
       'vault_append',
+      'vault_copy',
       'vault_create',
       'vault_delete',
       'vault_get_metadata',
+      'vault_move',
       'vault_read',
+      'vault_rename',
       'vault_update',
     ]);
   });


### PR DESCRIPTION
## Summary
- Add `vault_rename`, `vault_move`, `vault_copy` tools
- Path traversal protection on all new operations
- 6 new unit tests

Closes #33