### PR TITLE
feat: add search and metadata tools

### DIFF
--- a/src/obsidian/adapter.ts
+++ b/src/obsidian/adapter.ts
@@ -34,6 +34,20 @@ export interface ObsidianAdapter {
 
   // Vault info
   getVaultPath(): string;
+
+  // Metadata operations
+  getFileContent(path: string): Promise<string>;
+  getFrontmatter(path: string): Record<string, unknown> | null;
+  getTags(path: string): string[];
+  getAllTags(): Record<string, string[]>;
+  getHeadings(path: string): Array<{ heading: string; level: number }>;
+  getLinks(path: string): Array<{ link: string; displayText?: string }>;
+  getEmbeds(path: string): Array<{ link: string; displayText?: string }>;
+  getBacklinks(path: string): string[];
+  getResolvedLinks(): Record<string, Record<string, number>>;
+  getUnresolvedLinks(): Record<string, Record<string, number>>;
+  getAllFiles(): string[];
+  searchContent(query: string): Promise<Array<{ path: string; matches: string[] }>>;
 }
 
 export class RealObsidianAdapter implements ObsidianAdapter {
@@ -138,6 +152,104 @@ export class RealObsidianAdapter implements ObsidianAdapter {
 
   getVaultPath(): string {
     return (this.app.vault.adapter as { basePath?: string }).basePath ?? '';
+  }
+
+  async getFileContent(path: string): Promise<string> {
+    return this.readFile(path);
+  }
+
+  getFrontmatter(path: string): Record<string, unknown> | null {
+    const file = this.getFile(path);
+    const cache = this.app.metadataCache.getFileCache(file);
+    return (cache?.frontmatter as Record<string, unknown>) ?? null;
+  }
+
+  getTags(path: string): string[] {
+    const file = this.getFile(path);
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (!cache?.tags) return [];
+    return cache.tags.map((t: { tag: string }) => t.tag);
+  }
+
+  getAllTags(): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    const files = this.app.vault.getMarkdownFiles();
+    for (const file of files) {
+      const tags = this.getTags(file.path);
+      for (const tag of tags) {
+        if (!result[tag]) result[tag] = [];
+        result[tag].push(file.path);
+      }
+    }
+    return result;
+  }
+
+  getHeadings(path: string): Array<{ heading: string; level: number }> {
+    const file = this.getFile(path);
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (!cache?.headings) return [];
+    return cache.headings.map((h: { heading: string; level: number }) => ({
+      heading: h.heading,
+      level: h.level,
+    }));
+  }
+
+  getLinks(path: string): Array<{ link: string; displayText?: string }> {
+    const file = this.getFile(path);
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (!cache?.links) return [];
+    return cache.links.map((l: { link: string; displayText?: string }) => ({
+      link: l.link,
+      displayText: l.displayText,
+    }));
+  }
+
+  getEmbeds(path: string): Array<{ link: string; displayText?: string }> {
+    const file = this.getFile(path);
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (!cache?.embeds) return [];
+    return cache.embeds.map((e: { link: string; displayText?: string }) => ({
+      link: e.link,
+      displayText: e.displayText,
+    }));
+  }
+
+  getBacklinks(path: string): string[] {
+    const resolved = this.getResolvedLinks();
+    const backlinks: string[] = [];
+    for (const [sourcePath, links] of Object.entries(resolved)) {
+      if (path in links) {
+        backlinks.push(sourcePath);
+      }
+    }
+    return backlinks;
+  }
+
+  getResolvedLinks(): Record<string, Record<string, number>> {
+    return this.app.metadataCache.resolvedLinks;
+  }
+
+  getUnresolvedLinks(): Record<string, Record<string, number>> {
+    return this.app.metadataCache.unresolvedLinks;
+  }
+
+  getAllFiles(): string[] {
+    return (this.app.vault.getMarkdownFiles()).map((f) => f.path);
+  }
+
+  async searchContent(query: string): Promise<Array<{ path: string; matches: string[] }>> {
+    const results: Array<{ path: string; matches: string[] }> = [];
+    const files = this.app.vault.getMarkdownFiles();
+    const lowerQuery = query.toLowerCase();
+    for (const file of files) {
+      const content = await this.app.vault.read(file);
+      if (content.toLowerCase().includes(lowerQuery)) {
+        const lines = content.split('\n');
+        const matches = lines.filter((line) => line.toLowerCase().includes(lowerQuery));
+        results.push({ path: file.path, matches });
+      }
+    }
+    return results;
   }
 
   private getFile(path: string): TFile {

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -1,9 +1,18 @@
 import { FileStat, ListResult, ObsidianAdapter } from './adapter';
 
+interface MockFileMetadata {
+  frontmatter?: Record<string, unknown>;
+  tags?: string[];
+  headings?: Array<{ heading: string; level: number }>;
+  links?: Array<{ link: string; displayText?: string }>;
+  embeds?: Array<{ link: string; displayText?: string }>;
+}
+
 interface MockFile {
   content: string;
   binary?: ArrayBuffer;
   stat: FileStat;
+  metadata?: MockFileMetadata;
 }
 
 /* eslint-disable @typescript-eslint/require-await */
@@ -191,7 +200,120 @@ export class MockObsidianAdapter implements ObsidianAdapter {
     return this.vaultPath;
   }
 
+  async getFileContent(path: string): Promise<string> {
+    return this.readFile(path);
+  }
+
+  getFrontmatter(path: string): Record<string, unknown> | null {
+    const file = this.files.get(path);
+    if (!file) return null;
+    return file.metadata?.frontmatter ?? null;
+  }
+
+  getTags(path: string): string[] {
+    const file = this.files.get(path);
+    if (!file) return [];
+    return file.metadata?.tags ?? [];
+  }
+
+  getAllTags(): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    for (const [filePath, file] of this.files.entries()) {
+      const tags = file.metadata?.tags ?? [];
+      for (const tag of tags) {
+        if (!result[tag]) result[tag] = [];
+        result[tag].push(filePath);
+      }
+    }
+    return result;
+  }
+
+  getHeadings(path: string): Array<{ heading: string; level: number }> {
+    const file = this.files.get(path);
+    if (!file) return [];
+    return file.metadata?.headings ?? [];
+  }
+
+  getLinks(path: string): Array<{ link: string; displayText?: string }> {
+    const file = this.files.get(path);
+    if (!file) return [];
+    return file.metadata?.links ?? [];
+  }
+
+  getEmbeds(path: string): Array<{ link: string; displayText?: string }> {
+    const file = this.files.get(path);
+    if (!file) return [];
+    return file.metadata?.embeds ?? [];
+  }
+
+  getBacklinks(path: string): string[] {
+    const backlinks: string[] = [];
+    for (const [filePath, file] of this.files.entries()) {
+      const links = file.metadata?.links ?? [];
+      if (links.some((l) => l.link === path || l.link + '.md' === path)) {
+        backlinks.push(filePath);
+      }
+    }
+    return backlinks;
+  }
+
+  getResolvedLinks(): Record<string, Record<string, number>> {
+    const result: Record<string, Record<string, number>> = {};
+    for (const [filePath, file] of this.files.entries()) {
+      const links = file.metadata?.links ?? [];
+      if (links.length > 0) {
+        result[filePath] = {};
+        for (const link of links) {
+          const target = this.files.has(link.link) ? link.link : link.link + '.md';
+          if (this.files.has(target)) {
+            result[filePath][target] = (result[filePath][target] ?? 0) + 1;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  getUnresolvedLinks(): Record<string, Record<string, number>> {
+    const result: Record<string, Record<string, number>> = {};
+    for (const [filePath, file] of this.files.entries()) {
+      const links = file.metadata?.links ?? [];
+      for (const link of links) {
+        const target = link.link;
+        if (!this.files.has(target) && !this.files.has(target + '.md')) {
+          if (!result[filePath]) result[filePath] = {};
+          result[filePath][target] = (result[filePath][target] ?? 0) + 1;
+        }
+      }
+    }
+    return result;
+  }
+
+  getAllFiles(): string[] {
+    return Array.from(this.files.keys()).filter((p) => p.endsWith('.md'));
+  }
+
+  async searchContent(query: string): Promise<Array<{ path: string; matches: string[] }>> {
+    const results: Array<{ path: string; matches: string[] }> = [];
+    const lowerQuery = query.toLowerCase();
+    for (const [filePath, file] of this.files.entries()) {
+      if (file.content.toLowerCase().includes(lowerQuery)) {
+        const lines = file.content.split('\n');
+        const matches = lines.filter((line) => line.toLowerCase().includes(lowerQuery));
+        results.push({ path: filePath, matches });
+      }
+    }
+    return results;
+  }
+
   // Test helpers
+  setMetadata(path: string, metadata: MockFileMetadata): void {
+    const file = this.files.get(path);
+    if (file) {
+      file.metadata = metadata;
+    }
+  }
+
   setVaultPath(path: string): void {
     this.vaultPath = path;
   }

--- a/src/tools/search/handlers.ts
+++ b/src/tools/search/handlers.ts
@@ -1,0 +1,156 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+import { validateVaultPath } from '../../utils/path-guard';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): CallToolResult {
+  return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+}
+
+export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  const vaultPath = adapter.getVaultPath();
+
+  return {
+    async searchFulltext(params): Promise<CallToolResult> {
+      try {
+        const query = params.query as string;
+        const results = await adapter.searchContent(query);
+        return textResult(JSON.stringify(results));
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+
+    searchFrontmatter(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const frontmatter = adapter.getFrontmatter(path);
+        return Promise.resolve(textResult(JSON.stringify(frontmatter ?? {})));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchTags(_params): Promise<CallToolResult> {
+      try {
+        const allTags = adapter.getAllTags();
+        return Promise.resolve(textResult(JSON.stringify(allTags)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchHeadings(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const headings = adapter.getHeadings(path);
+        return Promise.resolve(textResult(JSON.stringify(headings)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchOutgoingLinks(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const links = adapter.getLinks(path);
+        return Promise.resolve(textResult(JSON.stringify(links)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchEmbeds(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const embeds = adapter.getEmbeds(path);
+        return Promise.resolve(textResult(JSON.stringify(embeds)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchBacklinks(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        const backlinks = adapter.getBacklinks(path);
+        return Promise.resolve(textResult(JSON.stringify(backlinks)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchResolvedLinks(_params): Promise<CallToolResult> {
+      try {
+        const links = adapter.getResolvedLinks();
+        return Promise.resolve(textResult(JSON.stringify(links)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchUnresolvedLinks(_params): Promise<CallToolResult> {
+      try {
+        const links = adapter.getUnresolvedLinks();
+        return Promise.resolve(textResult(JSON.stringify(links)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchBlockReferences(params): Promise<CallToolResult> {
+      try {
+        const path = validateVaultPath(params.path as string, vaultPath);
+        // Block references are lines containing ^block-id patterns
+        return adapter.getFileContent(path).then((content) => {
+          const blockRefs = content
+            .split('\n')
+            .filter((line) => /\^[\w-]+\s*$/.test(line))
+            .map((line) => {
+              const match = /\^([\w-]+)\s*$/.exec(line);
+              return match ? { id: match[1], line: line.trim() } : null;
+            })
+            .filter(Boolean);
+          return textResult(JSON.stringify(blockRefs));
+        });
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchByTag(params): Promise<CallToolResult> {
+      try {
+        const tag = params.tag as string;
+        const normalizedTag = tag.startsWith('#') ? tag : `#${tag}`;
+        const allTags = adapter.getAllTags();
+        const files = allTags[normalizedTag] ?? [];
+        return Promise.resolve(textResult(JSON.stringify(files)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+
+    searchByFrontmatter(params): Promise<CallToolResult> {
+      try {
+        const key = params.key as string;
+        const value = params.value as string;
+        const allFiles = adapter.getAllFiles();
+        const matching: string[] = [];
+        for (const filePath of allFiles) {
+          const fm = adapter.getFrontmatter(filePath);
+          if (fm && String(fm[key]) === value) {
+            matching.push(filePath);
+          }
+        }
+        return Promise.resolve(textResult(JSON.stringify(matching)));
+      } catch (error) {
+        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+      }
+    },
+  };
+}

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -1,0 +1,111 @@
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+import { createSearchHandlers } from './handlers';
+import {
+  searchFulltextSchema,
+  filePathSchema,
+  searchByTagSchema,
+  searchByFrontmatterSchema,
+} from './schemas';
+
+export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
+  const handlers = createSearchHandlers(adapter);
+
+  return {
+    metadata: {
+      id: 'search',
+      name: 'Search and Metadata',
+      description: 'Search vault contents and query file metadata, tags, links, and frontmatter',
+      supportsReadOnly: false,
+    },
+
+    tools(): ToolDefinition[] {
+      return [
+        {
+          name: 'search_fulltext',
+          description: 'Full-text search across vault contents',
+          schema: searchFulltextSchema,
+          handler: handlers.searchFulltext,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_frontmatter',
+          description: 'Query frontmatter properties for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchFrontmatter,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_tags',
+          description: 'Query all tags in the vault with file associations',
+          schema: {},
+          handler: handlers.searchTags,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_headings',
+          description: 'Query headings for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchHeadings,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_outgoing_links',
+          description: 'Query all outgoing links for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchOutgoingLinks,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_embeds',
+          description: 'Query all embeds for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchEmbeds,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_backlinks',
+          description: 'Get all backlinks for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchBacklinks,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_resolved_links',
+          description: 'Get resolved links across the vault',
+          schema: {},
+          handler: handlers.searchResolvedLinks,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_unresolved_links',
+          description: 'Get unresolved links across the vault',
+          schema: {},
+          handler: handlers.searchUnresolvedLinks,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_block_references',
+          description: 'Query block references for a given file',
+          schema: filePathSchema,
+          handler: handlers.searchBlockReferences,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_by_tag',
+          description: 'Search files by tag',
+          schema: searchByTagSchema,
+          handler: handlers.searchByTag,
+          isReadOnly: true,
+        },
+        {
+          name: 'search_by_frontmatter',
+          description: 'Search files by frontmatter property value',
+          schema: searchByFrontmatterSchema,
+          handler: handlers.searchByFrontmatter,
+          isReadOnly: true,
+        },
+      ];
+    },
+  };
+}

--- a/src/tools/search/schemas.ts
+++ b/src/tools/search/schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const searchFulltextSchema = {
+  query: z.string().min(1).describe('Search query string'),
+};
+
+export const filePathSchema = {
+  path: z.string().min(1).describe('File path relative to vault root'),
+};
+
+export const searchByTagSchema = {
+  tag: z.string().min(1).describe('Tag to search for (e.g., #project)'),
+};
+
+export const searchByFrontmatterSchema = {
+  key: z.string().min(1).describe('Frontmatter property key'),
+  value: z.string().describe('Frontmatter property value to match'),
+};

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createSearchHandlers } from '../../../src/tools/search/handlers';
+import { createSearchModule } from '../../../src/tools/search/index';
+
+function getText(result: CallToolResult): string {
+  const item = result.content[0];
+  if (item.type === 'text') return item.text;
+  return '';
+}
+
+describe('search module', () => {
+  it('should have correct metadata', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createSearchModule(adapter);
+    expect(module.metadata.id).toBe('search');
+    expect(module.metadata.supportsReadOnly).toBe(false);
+  });
+
+  it('should register 12 tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createSearchModule(adapter);
+    expect(module.tools()).toHaveLength(12);
+  });
+
+  it('should have all read-only tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createSearchModule(adapter);
+    const allReadOnly = module.tools().every((t) => t.isReadOnly);
+    expect(allReadOnly).toBe(true);
+  });
+});
+
+describe('search handlers', () => {
+  let adapter: MockObsidianAdapter;
+  let handlers: Record<string, (params: Record<string, unknown>) => Promise<CallToolResult>>;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+    handlers = createSearchHandlers(adapter);
+  });
+
+  describe('searchFulltext', () => {
+    it('should find files containing query', async () => {
+      adapter.addFile('notes/a.md', 'Hello World');
+      adapter.addFile('notes/b.md', 'Goodbye World');
+      adapter.addFile('notes/c.md', 'Nothing here');
+      const result = await handlers.searchFulltext({ query: 'World' });
+      const data = JSON.parse(getText(result)) as Array<{ path: string }>;
+      expect(data).toHaveLength(2);
+    });
+
+    it('should be case-insensitive', async () => {
+      adapter.addFile('test.md', 'Hello WORLD');
+      const result = await handlers.searchFulltext({ query: 'world' });
+      const data = JSON.parse(getText(result)) as Array<{ path: string }>;
+      expect(data).toHaveLength(1);
+    });
+  });
+
+  describe('searchFrontmatter', () => {
+    it('should return frontmatter for a file', async () => {
+      adapter.addFile('test.md', 'content');
+      adapter.setMetadata('test.md', { frontmatter: { title: 'My Note', tags: ['project'] } });
+      const result = await handlers.searchFrontmatter({ path: 'test.md' });
+      const data = JSON.parse(getText(result)) as Record<string, unknown>;
+      expect(data.title).toBe('My Note');
+    });
+
+    it('should return empty object when no frontmatter', async () => {
+      adapter.addFile('test.md', 'content');
+      const result = await handlers.searchFrontmatter({ path: 'test.md' });
+      expect(getText(result)).toBe('{}');
+    });
+  });
+
+  describe('searchTags', () => {
+    it('should return all tags with file associations', async () => {
+      adapter.addFile('a.md', 'content');
+      adapter.setMetadata('a.md', { tags: ['#project', '#work'] });
+      adapter.addFile('b.md', 'content');
+      adapter.setMetadata('b.md', { tags: ['#project'] });
+      const result = await handlers.searchTags({});
+      const data = JSON.parse(getText(result)) as Record<string, string[]>;
+      expect(data['#project']).toHaveLength(2);
+      expect(data['#work']).toHaveLength(1);
+    });
+  });
+
+  describe('searchHeadings', () => {
+    it('should return headings for a file', async () => {
+      adapter.addFile('test.md', '# Title\n## Subtitle');
+      adapter.setMetadata('test.md', {
+        headings: [
+          { heading: 'Title', level: 1 },
+          { heading: 'Subtitle', level: 2 },
+        ],
+      });
+      const result = await handlers.searchHeadings({ path: 'test.md' });
+      const data = JSON.parse(getText(result)) as Array<{ heading: string; level: number }>;
+      expect(data).toHaveLength(2);
+      expect(data[0].heading).toBe('Title');
+    });
+  });
+
+  describe('searchOutgoingLinks', () => {
+    it('should return links for a file', async () => {
+      adapter.addFile('test.md', 'content');
+      adapter.setMetadata('test.md', {
+        links: [{ link: 'other.md', displayText: 'Other' }],
+      });
+      const result = await handlers.searchOutgoingLinks({ path: 'test.md' });
+      const data = JSON.parse(getText(result)) as Array<{ link: string }>;
+      expect(data).toHaveLength(1);
+      expect(data[0].link).toBe('other.md');
+    });
+  });
+
+  describe('searchBacklinks', () => {
+    it('should return files linking to the target', async () => {
+      adapter.addFile('source.md', 'links to target');
+      adapter.setMetadata('source.md', {
+        links: [{ link: 'target.md' }],
+      });
+      adapter.addFile('target.md', 'target content');
+      const result = await handlers.searchBacklinks({ path: 'target.md' });
+      const data = JSON.parse(getText(result)) as string[];
+      expect(data).toContain('source.md');
+    });
+  });
+
+  describe('searchByTag', () => {
+    it('should find files by tag', async () => {
+      adapter.addFile('a.md', 'content');
+      adapter.setMetadata('a.md', { tags: ['#project'] });
+      adapter.addFile('b.md', 'content');
+      adapter.setMetadata('b.md', { tags: ['#personal'] });
+      const result = await handlers.searchByTag({ tag: '#project' });
+      const data = JSON.parse(getText(result)) as string[];
+      expect(data).toEqual(['a.md']);
+    });
+
+    it('should handle tag without # prefix', async () => {
+      adapter.addFile('a.md', 'content');
+      adapter.setMetadata('a.md', { tags: ['#project'] });
+      const result = await handlers.searchByTag({ tag: 'project' });
+      const data = JSON.parse(getText(result)) as string[];
+      expect(data).toEqual(['a.md']);
+    });
+  });
+
+  describe('searchByFrontmatter', () => {
+    it('should find files by frontmatter value', async () => {
+      adapter.addFile('a.md', 'content');
+      adapter.setMetadata('a.md', { frontmatter: { status: 'done' } });
+      adapter.addFile('b.md', 'content');
+      adapter.setMetadata('b.md', { frontmatter: { status: 'draft' } });
+      const result = await handlers.searchByFrontmatter({ key: 'status', value: 'done' });
+      const data = JSON.parse(getText(result)) as string[];
+      expect(data).toEqual(['a.md']);
+    });
+  });
+
+  describe('searchBlockReferences', () => {
+    it('should find block references', async () => {
+      adapter.addFile('test.md', 'Some content ^block-1\nMore text\nAnother block ^ref-2');
+      const result = await handlers.searchBlockReferences({ path: 'test.md' });
+      const data = JSON.parse(getText(result)) as Array<{ id: string }>;
+      expect(data).toHaveLength(2);
+      expect(data[0].id).toBe('block-1');
+      expect(data[1].id).toBe('ref-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add search module with 12 MCP tools (R17-R28): full-text search, frontmatter, tags, headings, links, embeds, backlinks, resolved/unresolved links, block references, search by tag/frontmatter
- Extend `ObsidianAdapter` interface with metadata cache methods
- Extend `MockObsidianAdapter` with in-memory metadata simulation
- All tools are read-only
- 15 new unit tests

Closes #38