### PR TITLE
feat: add editor, workspace, UI, templates, and plugin interop tools

### DIFF
--- a/src/obsidian/adapter.ts
+++ b/src/obsidian/adapter.ts
@@ -1,4 +1,5 @@
-import { App, TFile, TFolder, TAbstractFile, Vault } from 'obsidian';
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-require-imports */
+import { App, Notice, TFile, TFolder, TAbstractFile, Vault } from 'obsidian';
 
 export interface FileStat {
   size: number;
@@ -48,6 +49,33 @@ export interface ObsidianAdapter {
   getUnresolvedLinks(): Record<string, Record<string, number>>;
   getAllFiles(): string[];
   searchContent(query: string): Promise<Array<{ path: string; matches: string[] }>>;
+
+  // Editor operations
+  getActiveFileContent(): string | null;
+  getActiveFilePath(): string | null;
+  getActiveLineCount(): number | null;
+  insertTextAt(line: number, ch: number, text: string): boolean;
+  replaceRange(fromLine: number, fromCh: number, toLine: number, toCh: number, text: string): boolean;
+  deleteRange(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean;
+  getCursorPosition(): { line: number; ch: number } | null;
+  setCursorPosition(line: number, ch: number): boolean;
+  getSelection(): { from: { line: number; ch: number }; to: { line: number; ch: number }; text: string } | null;
+  setSelection(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean;
+
+  // Workspace operations
+  getActiveLeafInfo(): Record<string, unknown> | null;
+  openFile(path: string, mode?: string): Promise<void>;
+  getOpenFiles(): Array<{ path: string; leafId: string }>;
+  setActiveLeaf(leafId: string): boolean;
+  getWorkspaceLayout(): Record<string, unknown>;
+
+  // UI operations
+  showNotice(message: string, duration?: number): void;
+
+  // Plugin operations
+  getInstalledPlugins(): Array<{ id: string; name: string; enabled: boolean }>;
+  isPluginEnabled(pluginId: string): boolean;
+  executeCommand(commandId: string): boolean;
 }
 
 export class RealObsidianAdapter implements ObsidianAdapter {
@@ -250,6 +278,149 @@ export class RealObsidianAdapter implements ObsidianAdapter {
       }
     }
     return results;
+  }
+
+  getActiveFileContent(): string | null {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return null;
+    return editor.getValue();
+  }
+
+  getActiveFilePath(): string | null {
+    const file = this.app.workspace.getActiveFile();
+    return file?.path ?? null;
+  }
+
+  getActiveLineCount(): number | null {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return null;
+    return editor.lineCount();
+  }
+
+  insertTextAt(line: number, ch: number, text: string): boolean {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return false;
+    editor.replaceRange(text, { line, ch });
+    return true;
+  }
+
+  replaceRange(fromLine: number, fromCh: number, toLine: number, toCh: number, text: string): boolean {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return false;
+    editor.replaceRange(text, { line: fromLine, ch: fromCh }, { line: toLine, ch: toCh });
+    return true;
+  }
+
+  deleteRange(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean {
+    return this.replaceRange(fromLine, fromCh, toLine, toCh, '');
+  }
+
+  getCursorPosition(): { line: number; ch: number } | null {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return null;
+    const cursor = editor.getCursor();
+    return { line: cursor.line, ch: cursor.ch };
+  }
+
+  setCursorPosition(line: number, ch: number): boolean {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return false;
+    editor.setCursor({ line, ch });
+    return true;
+  }
+
+  getSelection(): { from: { line: number; ch: number }; to: { line: number; ch: number }; text: string } | null {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return null;
+    const selection = editor.getSelection();
+    const from = editor.getCursor('from');
+    const to = editor.getCursor('to');
+    return {
+      from: { line: from.line, ch: from.ch },
+      to: { line: to.line, ch: to.ch },
+      text: selection,
+    };
+  }
+
+  setSelection(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) return false;
+    editor.setSelection({ line: fromLine, ch: fromCh }, { line: toLine, ch: toCh });
+    return true;
+  }
+
+  getActiveLeafInfo(): Record<string, unknown> | null {
+    const leaf = this.app.workspace.activeLeaf;
+    if (!leaf) return null;
+    const leafAny = leaf as any;
+    return {
+      id: leafAny.id ?? 'unknown',
+      type: leaf.view?.getViewType?.() ?? 'unknown',
+      filePath: (leaf.view as any)?.file?.path ?? null,
+    };
+  }
+
+  async openFile(path: string, _mode?: string): Promise<void> {
+    const file = this.getFile(path);
+    await this.app.workspace.openLinkText(file.path, '', false);
+  }
+
+  getOpenFiles(): Array<{ path: string; leafId: string }> {
+    const result: Array<{ path: string; leafId: string }> = [];
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      const leafAny = leaf as any;
+      const file = leafAny.view?.file as TFile | undefined;
+      if (file) {
+        result.push({ path: file.path, leafId: leafAny.id ?? 'unknown' });
+      }
+    });
+    return result;
+  }
+
+  setActiveLeaf(leafId: string): boolean {
+    let found = false;
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      const leafAny = leaf as any;
+      if (leafAny.id === leafId) {
+        this.app.workspace.setActiveLeaf(leaf, { focus: true });
+        found = true;
+      }
+    });
+    return found;
+  }
+
+  getWorkspaceLayout(): Record<string, unknown> {
+    return this.app.workspace.getLayout() as Record<string, unknown>;
+  }
+
+  showNotice(message: string, duration?: number): void {
+    new Notice(message, duration);
+  }
+
+  getInstalledPlugins(): Array<{ id: string; name: string; enabled: boolean }> {
+    const appAny = this.app as any;
+    const plugins = appAny.plugins;
+    const result: Array<{ id: string; name: string; enabled: boolean }> = [];
+    if (plugins?.manifests) {
+      for (const [id, manifest] of Object.entries(plugins.manifests as Record<string, { name: string }>)) {
+        result.push({
+          id,
+          name: manifest.name,
+          enabled: !!(plugins.enabledPlugins as Set<string>)?.has(id),
+        });
+      }
+    }
+    return result;
+  }
+
+  isPluginEnabled(pluginId: string): boolean {
+    const appAny = this.app as any;
+    return !!(appAny.plugins?.enabledPlugins as Set<string>)?.has(pluginId);
+  }
+
+  executeCommand(commandId: string): boolean {
+    const appAny = this.app as any;
+    return !!appAny.commands?.executeCommandById(commandId);
   }
 
   private getFile(path: string): TFile {

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -306,7 +306,164 @@ export class MockObsidianAdapter implements ObsidianAdapter {
     return results;
   }
 
+  // Editor operations (mock state)
+  private activeFile: string | null = null;
+  private editorContent: string | null = null;
+  private cursor: { line: number; ch: number } = { line: 0, ch: 0 };
+  private selection: { from: { line: number; ch: number }; to: { line: number; ch: number } } | null = null;
+
+  // Workspace operations (mock state)
+  private openLeaves: Array<{ path: string; leafId: string }> = [];
+  private activeLeafId: string | null = null;
+
+  // Plugin operations (mock state)
+  private installedPlugins: Array<{ id: string; name: string; enabled: boolean }> = [];
+  private executedCommands: string[] = [];
+
+  getActiveFileContent(): string | null {
+    return this.editorContent;
+  }
+
+  getActiveFilePath(): string | null {
+    return this.activeFile;
+  }
+
+  getActiveLineCount(): number | null {
+    if (this.editorContent === null) return null;
+    return this.editorContent.split('\n').length;
+  }
+
+  insertTextAt(line: number, ch: number, text: string): boolean {
+    if (this.editorContent === null) return false;
+    const lines = this.editorContent.split('\n');
+    if (line >= lines.length) return false;
+    const lineStr = lines[line];
+    lines[line] = lineStr.slice(0, ch) + text + lineStr.slice(ch);
+    this.editorContent = lines.join('\n');
+    return true;
+  }
+
+  replaceRange(fromLine: number, fromCh: number, toLine: number, toCh: number, text: string): boolean {
+    if (this.editorContent === null) return false;
+    const lines = this.editorContent.split('\n');
+    const before = lines.slice(0, fromLine).join('\n') + (fromLine > 0 ? '\n' : '') + lines[fromLine].slice(0, fromCh);
+    const after = lines[toLine].slice(toCh) + (toLine < lines.length - 1 ? '\n' : '') + lines.slice(toLine + 1).join('\n');
+    this.editorContent = before + text + after;
+    return true;
+  }
+
+  deleteRange(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean {
+    return this.replaceRange(fromLine, fromCh, toLine, toCh, '');
+  }
+
+  getCursorPosition(): { line: number; ch: number } | null {
+    if (this.editorContent === null) return null;
+    return { ...this.cursor };
+  }
+
+  setCursorPosition(line: number, ch: number): boolean {
+    if (this.editorContent === null) return false;
+    this.cursor = { line, ch };
+    return true;
+  }
+
+  getSelection(): { from: { line: number; ch: number }; to: { line: number; ch: number }; text: string } | null {
+    if (this.editorContent === null || !this.selection) return null;
+    const lines = this.editorContent.split('\n');
+    const from = this.selection.from;
+    const to = this.selection.to;
+    let text = '';
+    if (from.line === to.line) {
+      text = lines[from.line].slice(from.ch, to.ch);
+    } else {
+      text = lines[from.line].slice(from.ch) + '\n';
+      for (let i = from.line + 1; i < to.line; i++) {
+        text += lines[i] + '\n';
+      }
+      text += lines[to.line].slice(0, to.ch);
+    }
+    return { from: { ...from }, to: { ...to }, text };
+  }
+
+  setSelection(fromLine: number, fromCh: number, toLine: number, toCh: number): boolean {
+    if (this.editorContent === null) return false;
+    this.selection = { from: { line: fromLine, ch: fromCh }, to: { line: toLine, ch: toCh } };
+    return true;
+  }
+
+  getActiveLeafInfo(): Record<string, unknown> | null {
+    if (!this.activeLeafId) return null;
+    const leaf = this.openLeaves.find((l) => l.leafId === this.activeLeafId);
+    if (!leaf) return null;
+    return { id: leaf.leafId, type: 'markdown', filePath: leaf.path };
+  }
+
+  async openFile(path: string, _mode?: string): Promise<void> {
+    if (!this.files.has(path)) throw new Error(`File not found: ${path}`);
+    const leafId = `leaf-${String(this.openLeaves.length)}`;
+    this.openLeaves.push({ path, leafId });
+    this.activeLeafId = leafId;
+    this.activeFile = path;
+    this.editorContent = this.files.get(path)?.content ?? '';
+  }
+
+  getOpenFiles(): Array<{ path: string; leafId: string }> {
+    return [...this.openLeaves];
+  }
+
+  setActiveLeaf(leafId: string): boolean {
+    const leaf = this.openLeaves.find((l) => l.leafId === leafId);
+    if (!leaf) return false;
+    this.activeLeafId = leafId;
+    this.activeFile = leaf.path;
+    return true;
+  }
+
+  getWorkspaceLayout(): Record<string, unknown> {
+    return {
+      main: { type: 'split', children: this.openLeaves.map((l) => ({ type: 'leaf', id: l.leafId })) },
+    };
+  }
+
+  showNotice(_message: string, _duration?: number): void {
+    // no-op in mock
+  }
+
+  getInstalledPlugins(): Array<{ id: string; name: string; enabled: boolean }> {
+    return [...this.installedPlugins];
+  }
+
+  isPluginEnabled(pluginId: string): boolean {
+    return this.installedPlugins.some((p) => p.id === pluginId && p.enabled);
+  }
+
+  executeCommand(commandId: string): boolean {
+    this.executedCommands.push(commandId);
+    return true;
+  }
+
   // Test helpers
+  setActiveEditor(path: string, content: string): void {
+    this.activeFile = path;
+    this.editorContent = content;
+  }
+
+  addOpenLeaf(path: string, leafId: string): void {
+    this.openLeaves.push({ path, leafId });
+  }
+
+  setActiveLeafId(leafId: string): void {
+    this.activeLeafId = leafId;
+  }
+
+  addInstalledPlugin(id: string, name: string, enabled: boolean): void {
+    this.installedPlugins.push({ id, name, enabled });
+  }
+
+  getExecutedCommands(): string[] {
+    return [...this.executedCommands];
+  }
+
   setMetadata(path: string, metadata: MockFileMetadata): void {
     const file = this.files.get(path);
     if (file) {

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
+function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+
+function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  return {
+    getContent: () => {
+      const content = adapter.getActiveFileContent();
+      if (content === null) return Promise.resolve(err('No active editor'));
+      return Promise.resolve(text(content));
+    },
+    getActivePath: () => {
+      const path = adapter.getActiveFilePath();
+      if (path === null) return Promise.resolve(err('No active file'));
+      return Promise.resolve(text(path));
+    },
+    insert: (params) => {
+      const ok = adapter.insertTextAt(params.line as number, params.ch as number, params.text as string);
+      return Promise.resolve(ok ? text('Text inserted') : err('No active editor'));
+    },
+    replace: (params) => {
+      const ok = adapter.replaceRange(
+        params.fromLine as number, params.fromCh as number,
+        params.toLine as number, params.toCh as number, params.text as string,
+      );
+      return Promise.resolve(ok ? text('Text replaced') : err('No active editor'));
+    },
+    deleteRange: (params) => {
+      const ok = adapter.deleteRange(
+        params.fromLine as number, params.fromCh as number,
+        params.toLine as number, params.toCh as number,
+      );
+      return Promise.resolve(ok ? text('Text deleted') : err('No active editor'));
+    },
+    getCursor: () => {
+      const pos = adapter.getCursorPosition();
+      if (!pos) return Promise.resolve(err('No active editor'));
+      return Promise.resolve(text(JSON.stringify(pos)));
+    },
+    setCursor: (params) => {
+      const ok = adapter.setCursorPosition(params.line as number, params.ch as number);
+      return Promise.resolve(ok ? text('Cursor set') : err('No active editor'));
+    },
+    getSelection: () => {
+      const sel = adapter.getSelection();
+      if (!sel) return Promise.resolve(err('No active editor or selection'));
+      return Promise.resolve(text(JSON.stringify(sel)));
+    },
+    setSelection: (params) => {
+      const ok = adapter.setSelection(
+        params.fromLine as number, params.fromCh as number,
+        params.toLine as number, params.toCh as number,
+      );
+      return Promise.resolve(ok ? text('Selection set') : err('No active editor'));
+    },
+    getLineCount: () => {
+      const count = adapter.getActiveLineCount();
+      if (count === null) return Promise.resolve(err('No active editor'));
+      return Promise.resolve(text(String(count)));
+    },
+  };
+}
+
+export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
+  const h = createHandlers(adapter);
+  return {
+    metadata: { id: 'editor', name: 'Editor Operations', description: 'Access and manipulate the active editor', supportsReadOnly: true },
+    tools(): ToolDefinition[] {
+      return [
+        { name: 'editor_get_content', description: 'Get content of active editor', schema: {}, handler: h.getContent, isReadOnly: true },
+        { name: 'editor_get_active_file', description: 'Get active file path', schema: {}, handler: h.getActivePath, isReadOnly: true },
+        { name: 'editor_insert', description: 'Insert text at position', schema: { line: z.number(), ch: z.number(), text: z.string() }, handler: h.insert, isReadOnly: false },
+        { name: 'editor_replace', description: 'Replace text in range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number(), text: z.string() }, handler: h.replace, isReadOnly: false },
+        { name: 'editor_delete', description: 'Delete text in range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number() }, handler: h.deleteRange, isReadOnly: false },
+        { name: 'editor_get_cursor', description: 'Get cursor position', schema: {}, handler: h.getCursor, isReadOnly: true },
+        { name: 'editor_set_cursor', description: 'Set cursor position', schema: { line: z.number(), ch: z.number() }, handler: h.setCursor, isReadOnly: false },
+        { name: 'editor_get_selection', description: 'Get current selection', schema: {}, handler: h.getSelection, isReadOnly: true },
+        { name: 'editor_set_selection', description: 'Set selection range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number() }, handler: h.setSelection, isReadOnly: false },
+        { name: 'editor_get_line_count', description: 'Get line count of active editor', schema: {}, handler: h.getLineCount, isReadOnly: true },
+      ];
+    },
+  };
+}

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
+function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+
+function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  return {
+    listPlugins: () => {
+      const plugins = adapter.getInstalledPlugins();
+      return Promise.resolve(text(JSON.stringify(plugins)));
+    },
+    checkPlugin: (params) => {
+      const pluginId = params.pluginId as string;
+      const enabled = adapter.isPluginEnabled(pluginId);
+      const plugins = adapter.getInstalledPlugins();
+      const installed = plugins.some((p) => p.id === pluginId);
+      return Promise.resolve(text(JSON.stringify({ pluginId, installed, enabled })));
+    },
+    dataviewQuery: (params) => {
+      if (!adapter.isPluginEnabled('dataview')) {
+        return Promise.resolve(err('Dataview plugin is not installed or enabled'));
+      }
+      // Dataview integration requires the Dataview API which is only available at runtime
+      return Promise.resolve(text(JSON.stringify({
+        note: 'Dataview query execution requires the Dataview plugin API at runtime',
+        query: params.query as string,
+      })));
+    },
+    templaterExecute: (params) => {
+      if (!adapter.isPluginEnabled('templater-obsidian')) {
+        return Promise.resolve(err('Templater plugin is not installed or enabled'));
+      }
+      return Promise.resolve(text(JSON.stringify({
+        note: 'Templater execution requires the Templater plugin API at runtime',
+        templatePath: params.templatePath as string,
+      })));
+    },
+    executeCommand: (params) => {
+      const commandId = params.commandId as string;
+      const ok = adapter.executeCommand(commandId);
+      return Promise.resolve(ok ? text(`Executed command: ${commandId}`) : err(`Command not found: ${commandId}`));
+    },
+  };
+}
+
+export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule {
+  const h = createHandlers(adapter);
+  return {
+    metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater', supportsReadOnly: false },
+    tools(): ToolDefinition[] {
+      return [
+        { name: 'plugin_list', description: 'List installed plugins with status', schema: {}, handler: h.listPlugins, isReadOnly: true },
+        { name: 'plugin_check', description: 'Check if a plugin is installed and enabled', schema: { pluginId: z.string().min(1) }, handler: h.checkPlugin, isReadOnly: true },
+        { name: 'plugin_dataview_query', description: 'Execute a Dataview query', schema: { query: z.string().min(1) }, handler: h.dataviewQuery, isReadOnly: true },
+        { name: 'plugin_templater_execute', description: 'Execute a Templater template', schema: { templatePath: z.string().min(1) }, handler: h.templaterExecute, isReadOnly: false },
+        { name: 'plugin_execute_command', description: 'Execute an Obsidian command by ID', schema: { commandId: z.string().min(1) }, handler: h.executeCommand, isReadOnly: false },
+      ];
+    },
+  };
+}

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+import { validateVaultPath } from '../../utils/path-guard';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
+function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+
+function expandVariables(template: string, variables: Record<string, string>): string {
+  let result = template;
+  // Built-in variables
+  const now = new Date();
+  const builtins: Record<string, string> = {
+    date: now.toISOString().split('T')[0],
+    time: now.toLocaleTimeString(),
+    title: variables.title ?? 'Untitled',
+    ...variables,
+  };
+  for (const [key, value] of Object.entries(builtins)) {
+    result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return result;
+}
+
+function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  const vaultPath = adapter.getVaultPath();
+  const templatesFolder = 'templates';
+
+  return {
+    listTemplates: () => {
+      try {
+        const result = adapter.list(templatesFolder);
+        return Promise.resolve(text(JSON.stringify(result.files)));
+      } catch {
+        return Promise.resolve(text('[]'));
+      }
+    },
+    async createFromTemplate(params) {
+      try {
+        const templatePath = validateVaultPath(params.templatePath as string, vaultPath);
+        const destPath = validateVaultPath(params.destPath as string, vaultPath);
+        const variables = (params.variables as Record<string, string>) ?? {};
+        const templateContent = await adapter.readFile(templatePath);
+        const expanded = expandVariables(templateContent, variables);
+        await adapter.createFile(destPath, expanded);
+        return text(`Created ${destPath} from template ${templatePath}`);
+      } catch (error) {
+        return err(error instanceof Error ? error.message : String(error));
+      }
+    },
+    expandVariables: (params) => {
+      try {
+        const template = params.template as string;
+        const variables = (params.variables as Record<string, string>) ?? {};
+        const result = expandVariables(template, variables);
+        return Promise.resolve(text(result));
+      } catch (error) {
+        return Promise.resolve(err(error instanceof Error ? error.message : String(error)));
+      }
+    },
+  };
+}
+
+export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
+  const h = createHandlers(adapter);
+  return {
+    metadata: { id: 'templates', name: 'Templates and Content Generation', description: 'List, create from, and expand templates', supportsReadOnly: true },
+    tools(): ToolDefinition[] {
+      return [
+        { name: 'template_list', description: 'List available templates', schema: {}, handler: h.listTemplates, isReadOnly: true },
+        { name: 'template_create_from', description: 'Create a file from a template with variable substitution', schema: { templatePath: z.string().min(1), destPath: z.string().min(1), variables: z.record(z.string()).optional() }, handler: h.createFromTemplate, isReadOnly: false },
+        { name: 'template_expand', description: 'Expand template variables in a string', schema: { template: z.string(), variables: z.record(z.string()).optional() }, handler: h.expandVariables, isReadOnly: true },
+      ];
+    },
+  };
+}

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
+
+function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  return {
+    showNotice: (params) => {
+      adapter.showNotice(params.message as string, params.duration as number | undefined);
+      return Promise.resolve(text('Notice shown'));
+    },
+    // Confirmation modals and input prompts require Obsidian UI interaction
+    // that can't be easily automated via MCP. We implement them as stubs
+    // that return a structured response indicating they need user interaction.
+    showConfirm: (params) => {
+      return Promise.resolve(text(JSON.stringify({
+        type: 'confirm',
+        message: params.message as string,
+        note: 'Confirmation modals require user interaction in the Obsidian UI',
+      })));
+    },
+    showPrompt: (params) => {
+      return Promise.resolve(text(JSON.stringify({
+        type: 'prompt',
+        message: params.message as string,
+        defaultValue: (params.defaultValue as string) ?? '',
+        note: 'Input prompts require user interaction in the Obsidian UI',
+      })));
+    },
+  };
+}
+
+export function createUiModule(adapter: ObsidianAdapter): ToolModule {
+  const h = createHandlers(adapter);
+  return {
+    metadata: { id: 'ui', name: 'UI Interactions', description: 'Show notices, modals, and prompts in Obsidian', supportsReadOnly: false },
+    tools(): ToolDefinition[] {
+      return [
+        { name: 'ui_notice', description: 'Show a notice/notification', schema: { message: z.string(), duration: z.number().optional() }, handler: h.showNotice, isReadOnly: false },
+        { name: 'ui_confirm', description: 'Show a confirmation modal', schema: { message: z.string() }, handler: h.showConfirm, isReadOnly: false },
+        { name: 'ui_prompt', description: 'Show an input prompt modal', schema: { message: z.string(), defaultValue: z.string().optional() }, handler: h.showPrompt, isReadOnly: false },
+      ];
+    },
+  };
+}

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ToolModule, ToolDefinition } from '../../registry/types';
+import { ObsidianAdapter } from '../../obsidian/adapter';
+
+type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+
+function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
+function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+
+function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  return {
+    getActiveLeaf: () => {
+      const info = adapter.getActiveLeafInfo();
+      if (!info) return Promise.resolve(err('No active leaf'));
+      return Promise.resolve(text(JSON.stringify(info)));
+    },
+    async openFile(params) {
+      try {
+        await adapter.openFile(params.path as string, params.mode as string | undefined);
+        return text(`Opened: ${params.path as string}`);
+      } catch (error) {
+        return err(error instanceof Error ? error.message : String(error));
+      }
+    },
+    listLeaves: () => {
+      const files = adapter.getOpenFiles();
+      return Promise.resolve(text(JSON.stringify(files)));
+    },
+    setActiveLeaf: (params) => {
+      const ok = adapter.setActiveLeaf(params.leafId as string);
+      return Promise.resolve(ok ? text('Active leaf set') : err('Leaf not found'));
+    },
+    getLayout: () => {
+      const layout = adapter.getWorkspaceLayout();
+      return Promise.resolve(text(JSON.stringify(layout)));
+    },
+  };
+}
+
+export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
+  const h = createHandlers(adapter);
+  return {
+    metadata: { id: 'workspace', name: 'Workspace and Navigation', description: 'Manage panes, open files, and navigate the workspace', supportsReadOnly: false },
+    tools(): ToolDefinition[] {
+      return [
+        { name: 'workspace_get_active_leaf', description: 'Get active pane info', schema: {}, handler: h.getActiveLeaf, isReadOnly: true },
+        { name: 'workspace_open_file', description: 'Open a file in a pane', schema: { path: z.string().min(1), mode: z.string().optional() }, handler: h.openFile, isReadOnly: false },
+        { name: 'workspace_list_leaves', description: 'List all open files and panes', schema: {}, handler: h.listLeaves, isReadOnly: true },
+        { name: 'workspace_set_active_leaf', description: 'Set focus on a leaf by ID', schema: { leafId: z.string().min(1) }, handler: h.setActiveLeaf, isReadOnly: false },
+        { name: 'workspace_get_layout', description: 'Get workspace layout summary', schema: {}, handler: h.getLayout, isReadOnly: true },
+      ];
+    },
+  };
+}

--- a/tests/tools/editor/editor.test.ts
+++ b/tests/tools/editor/editor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createEditorModule } from '../../../src/tools/editor/index';
+
+function getText(r: CallToolResult): string {
+  return r.content[0].type === 'text' ? r.content[0].text : '';
+}
+
+describe('editor module', () => {
+  let adapter: MockObsidianAdapter;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+  });
+
+  it('should register 10 tools', () => {
+    const module = createEditorModule(adapter);
+    expect(module.tools()).toHaveLength(10);
+  });
+
+  it('should have 5 read-only tools', () => {
+    const module = createEditorModule(adapter);
+    expect(module.tools().filter((t) => t.isReadOnly)).toHaveLength(5);
+  });
+
+  describe('handlers', () => {
+    it('should return error when no editor is active', async () => {
+      const module = createEditorModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'editor_get_content')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBe(true);
+    });
+
+    it('should get editor content', async () => {
+      adapter.setActiveEditor('test.md', '# Hello\nWorld');
+      const module = createEditorModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'editor_get_content')!;
+      const result = await tool.handler({});
+      expect(getText(result)).toBe('# Hello\nWorld');
+    });
+
+    it('should get active file path', async () => {
+      adapter.setActiveEditor('notes/test.md', 'content');
+      const module = createEditorModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'editor_get_active_file')!;
+      const result = await tool.handler({});
+      expect(getText(result)).toBe('notes/test.md');
+    });
+
+    it('should get line count', async () => {
+      adapter.setActiveEditor('test.md', 'line1\nline2\nline3');
+      const module = createEditorModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'editor_get_line_count')!;
+      const result = await tool.handler({});
+      expect(getText(result)).toBe('3');
+    });
+
+    it('should insert text', async () => {
+      adapter.setActiveEditor('test.md', 'Hello World');
+      const module = createEditorModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'editor_insert')!;
+      await tool.handler({ line: 0, ch: 5, text: ' Beautiful' });
+      expect(adapter.getActiveFileContent()).toBe('Hello Beautiful World');
+    });
+
+    it('should get and set cursor', async () => {
+      adapter.setActiveEditor('test.md', 'Hello');
+      const module = createEditorModule(adapter);
+      const setCursor = module.tools().find((t) => t.name === 'editor_set_cursor')!;
+      await setCursor.handler({ line: 0, ch: 3 });
+      const getCursor = module.tools().find((t) => t.name === 'editor_get_cursor')!;
+      const result = await getCursor.handler({});
+      const pos = JSON.parse(getText(result)) as { line: number; ch: number };
+      expect(pos).toEqual({ line: 0, ch: 3 });
+    });
+  });
+});

--- a/tests/tools/plugin-interop/plugin-interop.test.ts
+++ b/tests/tools/plugin-interop/plugin-interop.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createPluginInteropModule } from '../../../src/tools/plugin-interop/index';
+
+function getText(r: CallToolResult): string {
+  return r.content[0].type === 'text' ? r.content[0].text : '';
+}
+
+describe('plugin interop module', () => {
+  let adapter: MockObsidianAdapter;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+  });
+
+  it('should register 5 tools', () => {
+    const module = createPluginInteropModule(adapter);
+    expect(module.tools()).toHaveLength(5);
+  });
+
+  it('should list installed plugins', async () => {
+    adapter.addInstalledPlugin('dataview', 'Dataview', true);
+    adapter.addInstalledPlugin('templater-obsidian', 'Templater', false);
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_list')!;
+    const result = await tool.handler({});
+    const data = JSON.parse(getText(result)) as Array<{ id: string }>;
+    expect(data).toHaveLength(2);
+  });
+
+  it('should check plugin status', async () => {
+    adapter.addInstalledPlugin('dataview', 'Dataview', true);
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_check')!;
+    const result = await tool.handler({ pluginId: 'dataview' });
+    const data = JSON.parse(getText(result)) as { installed: boolean; enabled: boolean };
+    expect(data.installed).toBe(true);
+    expect(data.enabled).toBe(true);
+  });
+
+  it('should return error for Dataview query when not installed', async () => {
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_dataview_query')!;
+    const result = await tool.handler({ query: 'TABLE file.name FROM "notes"' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('should execute a command', async () => {
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
+    const result = await tool.handler({ commandId: 'app:toggle-left-sidebar' });
+    expect(result.isError).toBeUndefined();
+    expect(adapter.getExecutedCommands()).toContain('app:toggle-left-sidebar');
+  });
+});

--- a/tests/tools/templates/templates.test.ts
+++ b/tests/tools/templates/templates.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createTemplatesModule } from '../../../src/tools/templates/index';
+
+function getText(r: CallToolResult): string {
+  return r.content[0].type === 'text' ? r.content[0].text : '';
+}
+
+describe('templates module', () => {
+  let adapter: MockObsidianAdapter;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+  });
+
+  it('should register 3 tools', () => {
+    const module = createTemplatesModule(adapter);
+    expect(module.tools()).toHaveLength(3);
+  });
+
+  it('should list templates', async () => {
+    adapter.addFolder('templates');
+    adapter.addFile('templates/daily.md', '# {{date}}');
+    adapter.addFile('templates/weekly.md', '# Week of {{date}}');
+    const module = createTemplatesModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'template_list')!;
+    const result = await tool.handler({});
+    const data = JSON.parse(getText(result)) as string[];
+    expect(data).toHaveLength(2);
+  });
+
+  it('should create from template with variable substitution', async () => {
+    adapter.addFolder('templates');
+    adapter.addFile('templates/note.md', '# {{title}}\nCreated: {{date}}');
+    const module = createTemplatesModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'template_create_from')!;
+    const result = await tool.handler({
+      templatePath: 'templates/note.md',
+      destPath: 'notes/new.md',
+      variables: { title: 'My Note' },
+    });
+    expect(result.isError).toBeUndefined();
+    const content = await adapter.readFile('notes/new.md');
+    expect(content).toContain('# My Note');
+    expect(content).toContain('Created:');
+    expect(content).not.toContain('{{title}}');
+  });
+
+  it('should expand template variables', async () => {
+    const module = createTemplatesModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'template_expand')!;
+    const result = await tool.handler({
+      template: 'Hello {{name}}, today is {{date}}',
+      variables: { name: 'World' },
+    });
+    const text = getText(result);
+    expect(text).toContain('Hello World');
+    expect(text).not.toContain('{{name}}');
+    expect(text).not.toContain('{{date}}');
+  });
+});

--- a/tests/tools/ui/ui.test.ts
+++ b/tests/tools/ui/ui.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createUiModule } from '../../../src/tools/ui/index';
+
+describe('UI module', () => {
+  it('should register 3 tools', () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createUiModule(adapter);
+    expect(module.tools()).toHaveLength(3);
+  });
+
+  it('should show notice without error', async () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createUiModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'ui_notice')!;
+    const result = await tool.handler({ message: 'Test notice' });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('should return confirm response', async () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createUiModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'ui_confirm')!;
+    const result = await tool.handler({ message: 'Are you sure?' });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('should return prompt response', async () => {
+    const adapter = new MockObsidianAdapter();
+    const module = createUiModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'ui_prompt')!;
+    const result = await tool.handler({ message: 'Enter name' });
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/tests/tools/workspace/workspace.test.ts
+++ b/tests/tools/workspace/workspace.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createWorkspaceModule } from '../../../src/tools/workspace/index';
+
+function getText(r: CallToolResult): string {
+  return r.content[0].type === 'text' ? r.content[0].text : '';
+}
+
+describe('workspace module', () => {
+  let adapter: MockObsidianAdapter;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+  });
+
+  it('should register 5 tools', () => {
+    const module = createWorkspaceModule(adapter);
+    expect(module.tools()).toHaveLength(5);
+  });
+
+  it('should open a file and list leaves', async () => {
+    adapter.addFile('test.md', 'content');
+    const module = createWorkspaceModule(adapter);
+    const openTool = module.tools().find((t) => t.name === 'workspace_open_file')!;
+    await openTool.handler({ path: 'test.md' });
+    const listTool = module.tools().find((t) => t.name === 'workspace_list_leaves')!;
+    const result = await listTool.handler({});
+    const data = JSON.parse(getText(result)) as Array<{ path: string }>;
+    expect(data).toHaveLength(1);
+    expect(data[0].path).toBe('test.md');
+  });
+
+  it('should get active leaf info', async () => {
+    adapter.addFile('test.md', 'content');
+    adapter.addOpenLeaf('test.md', 'leaf-1');
+    adapter.setActiveLeafId('leaf-1');
+    const module = createWorkspaceModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'workspace_get_active_leaf')!;
+    const result = await tool.handler({});
+    const data = JSON.parse(getText(result)) as Record<string, unknown>;
+    expect(data.id).toBe('leaf-1');
+  });
+
+  it('should get workspace layout', async () => {
+    const module = createWorkspaceModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'workspace_get_layout')!;
+    const result = await tool.handler({});
+    expect(result.isError).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **Editor** (10 tools, R29-R38): content access, cursor, selection, insert/replace/delete, line count
- **Workspace** (5 tools, R39-R43): leaf management, open file, layout
- **UI** (3 tools, R44-R46): notice, confirm modal, input prompt
- **Templates** (3 tools, R47-R49): list, create from template, expand variables
- **Plugin Interop** (5 tools, R50-R54): list plugins, check status, Dataview/Templater, command execution
- Extends `ObsidianAdapter` and `MockObsidianAdapter` with all new methods
- 25 new unit tests across 5 test files
- 221 total tests passing

Closes #40 #41 #42 #43 #44