### PR TITLE
docs: add user and developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+## Development Setup
+
+1. Clone the repository
+2. Install dependencies: `npm install`
+3. Start dev build: `npm run dev`
+4. Copy the built files to your vault's plugin folder for testing
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Watch mode build |
+| `npm run build` | Production build |
+| `npm run test` | Run tests |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests with coverage |
+| `npm run lint` | Run ESLint |
+| `npm run lint:fix` | Auto-fix lint issues |
+| `npm run format` | Format with Prettier |
+| `npm run typecheck` | TypeScript type checking |
+
+## Architecture
+
+```
+src/
+  main.ts              Plugin entry point (onload/onunload)
+  settings.ts          Settings tab UI
+  types.ts             Shared types and defaults
+  server/              HTTP server, auth, CORS, MCP transport
+  registry/            Module registration system
+  obsidian/            Obsidian API abstraction layer
+  tools/               Feature modules (vault, search, editor, etc.)
+  utils/               Logger, path guard, validation
+```
+
+### Key Design Decisions
+
+- **Module self-registration**: Each tool module implements `ToolModule` and self-registers with the `ModuleRegistry`. Adding a new module requires zero changes to core code.
+- **Obsidian abstraction**: All Obsidian API access goes through `ObsidianAdapter`, enabling full testability via `MockObsidianAdapter`.
+- **Path traversal protection**: All file operations validate paths through `validateVaultPath()`.
+
+## Adding a New Tool Module
+
+1. Create a new directory under `src/tools/<module-name>/`
+2. Create `index.ts` exporting a factory function that returns a `ToolModule`
+3. Define Zod schemas for tool parameters
+4. Implement handlers using the `ObsidianAdapter`
+5. Write tests using `MockObsidianAdapter`
+6. Register the module in `src/main.ts` during `onload()`
+
+See existing modules (e.g., `src/tools/vault/`) for examples.
+
+## Commit Conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — New feature
+- `fix:` — Bug fix
+- `chore:` — Build, CI, dependencies
+- `docs:` — Documentation
+- `test:` — Tests
+- `refactor:` — Code refactoring
+- `ci:` — CI/CD changes
+
+## Pull Request Process
+
+1. Create a feature branch from `main`
+2. Implement with tests
+3. Ensure `npm run lint`, `npm run typecheck`, `npm run test`, and `npm run build` all pass
+4. Create a PR with a conventional commit title
+5. PR is squash-merged to `main`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,96 @@
-# Obsidian Plugin MCP
+# Obsidian MCP Plugin
 
-A plugin to provide MCP access to your vault easily.
+An Obsidian desktop plugin that runs an MCP (Model Context Protocol) server, exposing vault operations as tools over Streamable HTTP. AI agents like Claude, Codex, and others can connect and interact with your vault programmatically.
+
+## Features
+
+- **54 MCP tools** across 7 feature categories
+- **Vault Operations**: Create, read, update, delete, move, copy files and folders
+- **Search & Metadata**: Full-text search, frontmatter, tags, headings, links, backlinks
+- **Editor Operations**: Access and manipulate the active editor
+- **Workspace**: Manage panes, open files, navigate the workspace
+- **UI Interactions**: Show notices, modals, and prompts
+- **Templates**: List, create from, and expand templates
+- **Plugin Interop**: List plugins, execute commands, Dataview/Templater integration
+- **Security**: Bearer token authentication, CORS, path traversal protection
+- **Dynamic module toggles**: Enable/disable feature categories, per-module read-only mode
+
+## Installation
+
+### From Obsidian Community Plugins (coming soon)
+
+1. Open Settings > Community plugins
+2. Search for "MCP Server"
+3. Install and enable
+
+### Manual Installation
+
+1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](https://github.com/KingOfKalk/obisdian-plugin-mcp/releases)
+2. Create folder `<vault>/.obsidian/plugins/obsidian-mcp/`
+3. Copy the downloaded files into the folder
+4. Reload Obsidian and enable the plugin
+
+## Quick Start
+
+1. Open plugin settings and click **Generate** to create an access key
+2. The MCP server starts automatically on port `28741`
+3. Connect your MCP client using the configuration below
+
+## MCP Client Setup
+
+### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "obsidian": {
+      "url": "http://127.0.0.1:28741",
+      "headers": {
+        "Authorization": "Bearer YOUR_ACCESS_KEY"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add obsidian --transport http --url http://127.0.0.1:28741 --header "Authorization: Bearer YOUR_ACCESS_KEY"
+```
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Port | 28741 | HTTP port for the MCP server |
+| Access Key | (empty) | Bearer token for authentication |
+| HTTPS | Off | Enable HTTPS with self-signed certificate |
+| Debug Mode | Off | Verbose logging of requests/responses |
+
+Feature modules can be individually enabled/disabled and set to read-only mode in the settings tab.
+
+## Commands
+
+- **Start MCP Server** — Start the server
+- **Stop MCP Server** — Stop the server
+- **Restart MCP Server** — Restart the server
+- **Copy Access Key** — Copy the access key to clipboard
+
+## Security
+
+- All requests require a valid Bearer token
+- File operations are scoped to the vault directory (path traversal protection)
+- Access key is never logged, even in debug mode
+- CORS headers are restrictive by default
+- HTTPS available with locally generated self-signed certificates
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+## License
+
+GPL-3.0-only

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,39 @@
+# Configuration Reference
+
+## Server Settings
+
+### Port (`port`)
+- **Default**: `28741`
+- **Description**: HTTP port the MCP server listens on
+- **Range**: 1–65535
+
+### Access Key (`accessKey`)
+- **Default**: (empty)
+- **Description**: Bearer token for authenticating MCP clients. The server will not start without an access key configured.
+- **Generate**: Click the "Generate" button in settings to create a random 64-character hex key
+
+### HTTPS (`httpsEnabled`)
+- **Default**: `false`
+- **Description**: Enable HTTPS with a locally generated self-signed certificate
+
+### Debug Mode (`debugMode`)
+- **Default**: `false`
+- **Description**: Enable verbose logging of all MCP requests and responses. Access keys are always redacted from logs.
+
+## Feature Modules
+
+Each module can be individually enabled/disabled. Modules that support read-only mode can be restricted to only expose read operations.
+
+| Module | Tools | Read-Only Support |
+|--------|-------|-------------------|
+| Vault and File Operations | 16 | Yes |
+| Search and Metadata | 12 | No (all read-only) |
+| Editor Operations | 10 | Yes |
+| Workspace and Navigation | 5 | No |
+| UI Interactions | 3 | No |
+| Templates | 3 | Yes |
+| Plugin Interop | 5 | No |
+
+## Settings Persistence
+
+All settings are stored in Obsidian's plugin `data.json` file. Settings include a schema version for automatic migration between plugin versions.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,38 @@
+# Security Best Practices
+
+## Access Key Management
+
+- **Generate a strong key**: Use the "Generate" button to create a random 64-character hex key
+- **Don't share your key**: The access key grants full access to enabled vault operations
+- **Rotate regularly**: Generate a new key periodically, especially if you suspect exposure
+- **Don't commit keys**: Never store access keys in version control
+
+## Network Exposure
+
+- **Localhost only**: The server binds to `127.0.0.1` by default — it's not accessible from other machines
+- **Firewall**: If running on a shared machine, ensure your firewall blocks the MCP port from external access
+- **HTTPS**: Enable HTTPS for encrypted communication, even on localhost
+
+## Feature Access Control
+
+- **Disable unused modules**: Only enable the feature categories you need
+- **Use read-only mode**: For modules that support it (Vault, Editor, Templates), enable read-only mode to prevent modifications
+- **Principle of least privilege**: Start with minimal permissions and expand as needed
+
+## Path Traversal Protection
+
+All file operations validate paths to ensure they stay within the vault directory. The following are rejected:
+- `../` directory traversal
+- Backslash paths (`\`)
+- Null bytes
+- Percent-encoded traversal sequences (`%2e`, `%2f`, `%5c`)
+
+## CORS
+
+CORS headers are restrictive by default, allowing only `http://localhost` origin. This prevents unauthorized web pages from making requests to your MCP server.
+
+## Logging
+
+- Access keys are **never** included in log output, even in debug mode
+- Debug mode logs all MCP requests and responses (useful for troubleshooting)
+- Structured JSON logging with timestamps and log levels


### PR DESCRIPTION
## Summary
- Updated README with installation, quick-start, MCP client setup (Claude Desktop + Claude Code), config table, commands, security overview
- Added CONTRIBUTING.md with dev setup, architecture, module guide, commit conventions
- Added docs/configuration.md with full settings reference
- Added docs/security.md with access key management, network exposure, CORS, logging

Closes #48