### PR TITLE
claude/update-dependencies-epNgD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    labels:
-      - dependencies
 
   - package-ecosystem: github-actions
     directory: /
@@ -14,5 +12,4 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     labels:
-      - dependencies
       - ci


### PR DESCRIPTION
The `dependencies` label was never created in the repo, causing
Dependabot to warn on every PR it opens. Remove it from the config
to silence the warning. The `ci` label (which exists) is kept for
GitHub Actions updates.

https://claude.ai/code/session_01THhwDwjJF2bGH2SKgLwyo1