### PR TITLE
claude/investigate-actions-job-kVrl0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create styles.css placeholder
         if: ${{ steps.release.outputs.release_created }}
-        run: touch styles.css
+        run: echo "/* obsidian-mcp-plugin styles */" > styles.css
 
       - name: Upload release assets
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
GitHub's release upload API rejects 0-byte files with HTTP 400
"Bad Content-Length". Replace `touch styles.css` with a CSS comment
so the file has content and can be uploaded successfully.

https://claude.ai/code/session_01CZe4XuEFCbasPaPrr2QWuD