### PR TITLE
claude/add-server-controls-LINx9

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -110,6 +110,10 @@ Each category is a toggleable module. Modules self-register. The settings UI aut
 - ~~CR11~~ — ~~Toggle to enable/disable Plugin Interop~~
 - **CR12** — Dynamic feature toggle system: modules self-register with metadata (name, description, tool list), settings UI auto-discovers and renders toggles, "Refresh" button to re-discover without restart. Includes per-module read-only mode where applicable. Replaces ~~CR5~~–~~CR11~~, consolidated into dynamic system.
 
+### Server Controls
+
+- **CR16** — Settings UI provides dedicated Start, Stop, and Restart buttons for MCP server lifecycle management. The Stop button is only enabled when the server is running. The Start button is only enabled when the server is stopped. The Restart button is only enabled when the server is running.
+
 ### Settings Persistence
 
 - **CR13** — All settings persisted in Obsidian's plugin data.json

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,15 +33,30 @@ export class McpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Status')
       .setDesc(statusText)
-      .addButton((btn) =>
-        btn
-          .setButtonText(isRunning ? 'Restart' : 'Start')
-          .onClick(() => {
-            void this.plugin.restartServer().then(() => {
-              this.display();
-            });
-          }),
-      );
+      .addButton((btn) => {
+        btn.setButtonText('Start').onClick(() => {
+          void this.plugin.startServer().then(() => {
+            this.display();
+          });
+        });
+        btn.buttonEl.disabled = isRunning;
+      })
+      .addButton((btn) => {
+        btn.setButtonText('Stop').onClick(() => {
+          void this.plugin.stopServer().then(() => {
+            this.display();
+          });
+        });
+        btn.buttonEl.disabled = !isRunning;
+      })
+      .addButton((btn) => {
+        btn.setButtonText('Restart').onClick(() => {
+          void this.plugin.restartServer().then(() => {
+            this.display();
+          });
+        });
+        btn.buttonEl.disabled = !isRunning;
+      });
   }
 
   private renderServerSettings(containerEl: HTMLElement): void {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -41,8 +41,15 @@ export class PluginSettingTab {
 }
 
 export class Setting {
-  constructor(_containerEl: any) {}
-  setName(_name: string): this {
+  static instances: Setting[] = [];
+  settingName = '';
+  buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
+
+  constructor(_containerEl: any) {
+    Setting.instances.push(this);
+  }
+  setName(name: string): this {
+    this.settingName = name;
     return this;
   }
   setDesc(_desc: string): this {
@@ -54,7 +61,17 @@ export class Setting {
   addToggle(_cb: (toggle: any) => void): this {
     return this;
   }
-  addButton(_cb: (btn: any) => void): this {
+  addButton(cb: (btn: any) => void): this {
+    const record = { text: '', disabled: false, callback: null as (() => void) | null };
+    const btn = {
+      buttonEl: { disabled: false },
+      setButtonText(t: string) { record.text = t; return btn; },
+      setCta() { return btn; },
+      onClick(fn: () => void) { record.callback = fn; return btn; },
+    };
+    cb(btn);
+    record.disabled = btn.buttonEl.disabled;
+    this.buttons.push(record);
     return this;
   }
 }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { migrateSettings, generateAccessKey } from '../src/settings';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Setting } from 'obsidian';
+import { migrateSettings, generateAccessKey, McpSettingsTab } from '../src/settings';
+import { DEFAULT_SETTINGS } from '../src/types';
 
 describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to v1', () => {
@@ -62,5 +64,97 @@ describe('generateAccessKey', () => {
     const key1 = generateAccessKey();
     const key2 = generateAccessKey();
     expect(key1).not.toBe(key2);
+  });
+});
+
+describe('McpSettingsTab server controls', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockPlugin: Record<string, any>;
+
+  function createMockPlugin(isRunning: boolean, clients = 0) {
+    return {
+      settings: { ...DEFAULT_SETTINGS, accessKey: 'test-key' },
+      httpServer: isRunning
+        ? { isRunning: true, connectedClients: clients }
+        : null,
+      registry: { getModules: () => [] },
+      startServer: vi.fn().mockResolvedValue(undefined),
+      stopServer: vi.fn().mockResolvedValue(undefined),
+      restartServer: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function getStatusButtons(): Array<{ text: string; disabled: boolean; callback: (() => void) | null }> {
+    const statusSetting = (Setting as unknown as { instances: Array<{ settingName: string; buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> }> }).instances.find(
+      (s) => s.settingName === 'Status',
+    );
+    return statusSetting?.buttons ?? [];
+  }
+
+  beforeEach(() => {
+    (Setting as unknown as { instances: unknown[] }).instances = [];
+  });
+
+  function renderTab(isRunning: boolean, clients = 0): void {
+    mockPlugin = createMockPlugin(isRunning, clients);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    const tab = new McpSettingsTab({} as any, mockPlugin as any);
+    tab.display();
+  }
+
+  it('should render three buttons (Start, Stop, Restart)', () => {
+    renderTab(false);
+    const buttons = getStatusButtons();
+    expect(buttons).toHaveLength(3);
+    expect(buttons.map((b) => b.text)).toEqual(['Start', 'Stop', 'Restart']);
+  });
+
+  it('should disable Stop and Restart when server is stopped', () => {
+    renderTab(false);
+    const buttons = getStatusButtons();
+    const start = buttons.find((b) => b.text === 'Start')!;
+    const stop = buttons.find((b) => b.text === 'Stop')!;
+    const restart = buttons.find((b) => b.text === 'Restart')!;
+    expect(start.disabled).toBe(false);
+    expect(stop.disabled).toBe(true);
+    expect(restart.disabled).toBe(true);
+  });
+
+  it('should disable Start when server is running', () => {
+    renderTab(true);
+    const buttons = getStatusButtons();
+    const start = buttons.find((b) => b.text === 'Start')!;
+    const stop = buttons.find((b) => b.text === 'Stop')!;
+    const restart = buttons.find((b) => b.text === 'Restart')!;
+    expect(start.disabled).toBe(true);
+    expect(stop.disabled).toBe(false);
+    expect(restart.disabled).toBe(false);
+  });
+
+  it('Start button calls startServer()', async () => {
+    renderTab(false);
+    const start = getStatusButtons().find((b) => b.text === 'Start')!;
+    start.callback!();
+    await vi.waitFor(() => {
+      expect(mockPlugin.startServer).toHaveBeenCalled();
+    });
+  });
+
+  it('Stop button calls stopServer()', async () => {
+    renderTab(true);
+    const stop = getStatusButtons().find((b) => b.text === 'Stop')!;
+    stop.callback!();
+    await vi.waitFor(() => {
+      expect(mockPlugin.stopServer).toHaveBeenCalled();
+    });
+  });
+
+  it('Restart button calls restartServer()', async () => {
+    renderTab(true);
+    const restart = getStatusButtons().find((b) => b.text === 'Restart')!;
+    restart.callback!();
+    await vi.waitFor(() => {
+      expect(mockPlugin.restartServer).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Add dedicated Start, Stop, and Restart button requirement to the
settings UI so users can fully manage the server lifecycle.

Closes #61

https://claude.ai/code/session_01Qnwf578ouxVjxnoVT89cVK