### PR TITLE
claude/fix-release-title-c6NMw

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
Set include-component-in-tag to false so release-please generates
clean tags like "v1.2.0" instead of "obsidian-mcp-v1.2.0", and
release titles like "v1.2.0" instead of "obsidian-mcp: v1.2.0".

https://claude.ai/code/session_01SafD1YKDUEqe8PhmQca26r