### PR TITLE
refactor: move Copy URL button to Server Settings section

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,14 +34,6 @@ export class McpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Status')
       .setDesc(statusText)
-      .addButton((btn) =>
-        btn.setButtonText('Copy URL').onClick(() => {
-          const url = `http://127.0.0.1:${String(port)}/mcp`;
-          void navigator.clipboard.writeText(url).then(() => {
-            new Notice('MCP server URL copied to clipboard');
-          });
-        }),
-      )
       .addButton((btn) => {
         btn.setButtonText('Start').onClick(() => {
           void this.plugin.startServer().then(() => {
@@ -85,6 +77,18 @@ export class McpSettingsTab extends PluginSettingTab {
               await this.plugin.saveSettings();
             }
           }),
+      );
+
+    new Setting(containerEl)
+      .setName('Server URL')
+      .setDesc(`http://127.0.0.1:${String(this.plugin.settings.port)}/mcp`)
+      .addButton((btn) =>
+        btn.setButtonText('Copy URL').onClick(() => {
+          const url = `http://127.0.0.1:${String(this.plugin.settings.port)}/mcp`;
+          void navigator.clipboard.writeText(url).then(() => {
+            new Notice('MCP server URL copied to clipboard');
+          });
+        }),
       );
 
     new Setting(containerEl)

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -84,11 +84,18 @@ describe('McpSettingsTab server controls', () => {
     };
   }
 
-  function getStatusButtons(): Array<{ text: string; disabled: boolean; callback: (() => void) | null }> {
-    const statusSetting = (Setting as unknown as { instances: Array<{ settingName: string; buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> }> }).instances.find(
-      (s) => s.settingName === 'Status',
+  type ButtonInfo = { text: string; disabled: boolean; callback: (() => void) | null };
+  type SettingInstance = { settingName: string; buttons: ButtonInfo[] };
+
+  function getSettingButtons(name: string): ButtonInfo[] {
+    const setting = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+      (s) => s.settingName === name,
     );
-    return statusSetting?.buttons ?? [];
+    return setting?.buttons ?? [];
+  }
+
+  function getStatusButtons(): ButtonInfo[] {
+    return getSettingButtons('Status');
   }
 
   beforeEach(() => {
@@ -102,11 +109,18 @@ describe('McpSettingsTab server controls', () => {
     tab.display();
   }
 
-  it('should render four buttons (Copy URL, Start, Stop, Restart)', () => {
+  it('should render three status buttons (Start, Stop, Restart)', () => {
     renderTab(false);
     const buttons = getStatusButtons();
-    expect(buttons).toHaveLength(4);
-    expect(buttons.map((b) => b.text)).toEqual(['Copy URL', 'Start', 'Stop', 'Restart']);
+    expect(buttons).toHaveLength(3);
+    expect(buttons.map((b) => b.text)).toEqual(['Start', 'Stop', 'Restart']);
+  });
+
+  it('should render Copy URL button in Server URL setting', () => {
+    renderTab(false);
+    const buttons = getSettingButtons('Server URL');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].text).toBe('Copy URL');
   });
 
   it('should disable Stop and Restart when server is stopped', () => {


### PR DESCRIPTION
The Copy URL button is more logically grouped with server configuration
(port, access key) than with the runtime status controls (start/stop/restart).
Added a dedicated "Server URL" setting row that displays the URL and
provides the copy button.

https://claude.ai/code/session_01PFnNxmEaxytYkKngqzrmC2