### PR TITLE
feat: configurable MCP server IP address (CR17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ claude mcp add obsidian --transport http --url http://127.0.0.1:28741 --header "
 
 | Setting | Default | Description |
 |---------|---------|-------------|
+| Server Address | 127.0.0.1 | IP address the server binds to (localhost only by default) |
 | Port | 28741 | HTTP port for the MCP server |
 | Access Key | (empty) | Bearer token for authentication |
 | HTTPS | Off | Enable HTTPS with self-signed certificate |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -98,6 +98,7 @@ Each category is a toggleable module. Modules self-register. The settings UI aut
 - **CR2** — Access key field for authentication (user-provided, with a "Generate" button for convenience)
 - **CR3** — Toggle between HTTP and HTTPS (self-signed certificate), HTTP by default
 - **CR4** — Debug mode toggle that enables verbose logging
+- **CR17** — Configurable server IP address (default `127.0.0.1`). Must validate IPv4 format. Settings UI shows a security warning when bound to a non-localhost address. Requires server restart to take effect.
 
 ### Feature Access Control
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,11 @@
 
 ## Server Settings
 
+### Server Address (`serverAddress`)
+- **Default**: `127.0.0.1`
+- **Description**: IP address the MCP server binds to. The default `127.0.0.1` restricts access to the local machine only. Changing this to `0.0.0.0` will expose the server on all network interfaces — **use with caution** and ensure an access key is configured.
+- **Validation**: Must be a valid IPv4 address
+
 ### Port (`port`)
 - **Default**: `28741`
 - **Description**: HTTP port the MCP server listens on

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,9 +9,10 @@
 
 ## Network Exposure
 
-- **Localhost only**: The server binds to `127.0.0.1` by default — it's not accessible from other machines
-- **Firewall**: If running on a shared machine, ensure your firewall blocks the MCP port from external access
-- **HTTPS**: Enable HTTPS for encrypted communication, even on localhost
+- **Localhost by default**: The server binds to `127.0.0.1` by default — it's not accessible from other machines. This can be changed in settings via the **Server Address** option.
+- **Binding to `0.0.0.0`**: Exposes the server on all network interfaces. Only do this if you understand the security implications and have an access key configured.
+- **Firewall**: If running on a shared machine or binding to a non-localhost address, ensure your firewall blocks the MCP port from unauthorized access
+- **HTTPS**: Enable HTTPS for encrypted communication, especially when binding to a non-localhost address
 
 ## Feature Access Control
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,7 @@ export default class McpPlugin extends Plugin {
     try {
       const mcpServer = createMcpServer(this.registry, this.logger);
       this.httpServer = new HttpMcpServer(mcpServer, this.logger, {
+        host: this.settings.serverAddress,
         port: this.settings.port,
         accessKey: this.settings.accessKey,
       });

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -7,6 +7,7 @@ import { authenticateRequest, sendAuthError } from './auth';
 import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } from './cors';
 
 export interface HttpServerOptions {
+  host: string;
   port: number;
   accessKey: string;
   corsOptions?: CorsOptions;
@@ -93,8 +94,8 @@ export class HttpMcpServer {
         }
       });
 
-      this.httpServer!.listen(this.options.port, '127.0.0.1', () => {
-        this.logger.info(`MCP server listening on http://127.0.0.1:${String(this.options.port)}`);
+      this.httpServer!.listen(this.options.port, this.options.host, () => {
+        this.logger.info(`MCP server listening on http://${this.options.host}:${String(this.options.port)}`);
         resolve();
       });
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,8 +27,9 @@ export class McpSettingsTab extends PluginSettingTab {
     const port = this.plugin.settings.port;
     const clients = this.plugin.httpServer?.connectedClients ?? 0;
 
+    const address = this.plugin.settings.serverAddress;
     const statusText = isRunning
-      ? `Running on http://127.0.0.1:${String(port)} (${String(clients)} connection${clients !== 1 ? 's' : ''})`
+      ? `Running on http://${address}:${String(port)} (${String(clients)} connection${clients !== 1 ? 's' : ''})`
       : 'Stopped';
 
     new Setting(containerEl)
@@ -63,6 +64,28 @@ export class McpSettingsTab extends PluginSettingTab {
   private renderServerSettings(containerEl: HTMLElement): void {
     containerEl.createEl('h2', { text: 'Server Settings' });
 
+    const addressSetting = new Setting(containerEl)
+      .setName('Server Address')
+      .setDesc('IP address the server binds to (default: 127.0.0.1). Requires restart.')
+      .addText((text) =>
+        text
+          .setPlaceholder('127.0.0.1')
+          .setValue(this.plugin.settings.serverAddress)
+          .onChange(async (value) => {
+            if (isValidIPv4(value)) {
+              this.plugin.settings.serverAddress = value;
+              await this.plugin.saveSettings();
+            }
+          }),
+      );
+
+    if (this.plugin.settings.serverAddress !== '127.0.0.1') {
+      addressSetting.descEl.createEl('br');
+      addressSetting.descEl.createEl('strong', {
+        text: 'Warning: Non-localhost address exposes the server to the network. Ensure an access key is set.',
+      });
+    }
+
     new Setting(containerEl)
       .setName('Port')
       .setDesc('HTTP port for the MCP server (default: 28741)')
@@ -81,10 +104,10 @@ export class McpSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Server URL')
-      .setDesc(`http://127.0.0.1:${String(this.plugin.settings.port)}/mcp`)
+      .setDesc(`http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`)
       .addButton((btn) =>
         btn.setButtonText('Copy URL').onClick(() => {
-          const url = `http://127.0.0.1:${String(this.plugin.settings.port)}/mcp`;
+          const url = `http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
           void navigator.clipboard.writeText(url).then(() => {
             new Notice('MCP server URL copied to clipboard');
           });
@@ -156,9 +179,10 @@ export class McpSettingsTab extends PluginSettingTab {
   }
 
   private buildMcpConfigJson(): string {
+    const address = this.plugin.settings.serverAddress;
     const port = this.plugin.settings.port;
     const accessKey = this.plugin.settings.accessKey;
-    const url = `http://127.0.0.1:${String(port)}/mcp`;
+    const url = `http://${address}:${String(port)}/mcp`;
 
     const config: Record<string, unknown> = { url };
 
@@ -226,6 +250,15 @@ export function generateAccessKey(): string {
   return randomBytes(32).toString('hex');
 }
 
+export function isValidIPv4(value: string): boolean {
+  const parts = value.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => {
+    const num = Number(part);
+    return /^\d{1,3}$/.test(part) && num >= 0 && num <= 255;
+  });
+}
+
 export function migrateSettings(
   data: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -239,6 +272,12 @@ export function migrateSettings(
     if (data.httpsEnabled === undefined) data.httpsEnabled = false;
     if (data.debugMode === undefined) data.debugMode = false;
     if (!data.moduleStates) data.moduleStates = {};
+  }
+
+  if ((data.schemaVersion as number) < 2) {
+    data.schemaVersion = 2;
+    // V1 -> V2: add serverAddress
+    if (!data.serverAddress) data.serverAddress = '127.0.0.1';
   }
 
   return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 export interface McpPluginSettings {
   /** Schema version for settings migration */
   schemaVersion: number;
+  /** IP address the MCP server binds to */
+  serverAddress: string;
   /** HTTP port for the MCP server */
   port: number;
   /** Access key for bearer token authentication */
@@ -19,7 +21,8 @@ export interface ModuleState {
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 1,
+  schemaVersion: 2,
+  serverAddress: '127.0.0.1',
   port: 28741,
   accessKey: '',
   httpsEnabled: false,

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -83,6 +83,7 @@ describe('Integration: HTTP Server Authentication', () => {
     registry.registerModule(vaultModule);
     const mcpServer = createMcpServer(registry, logger);
     server = new HttpMcpServer(mcpServer, logger, {
+      host: '127.0.0.1',
       port: TEST_PORT,
       accessKey: ACCESS_KEY,
     });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Setting } from 'obsidian';
-import { migrateSettings, generateAccessKey, McpSettingsTab } from '../src/settings';
+import { migrateSettings, generateAccessKey, isValidIPv4, McpSettingsTab } from '../src/settings';
 import { DEFAULT_SETTINGS } from '../src/types';
 
 describe('migrateSettings', () => {
-  it('should migrate v0 (no schemaVersion) to v1', () => {
+  it('should migrate v0 (no schemaVersion) to v2', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(1);
+    expect(result.schemaVersion).toBe(2);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
     expect(result.debugMode).toBe(false);
     expect(result.moduleStates).toEqual({});
+    expect(result.serverAddress).toBe('127.0.0.1');
   });
 
   it('should preserve existing values during migration', () => {
@@ -22,15 +23,31 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(1);
+    expect(result.schemaVersion).toBe(2);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
+    expect(result.serverAddress).toBe('127.0.0.1');
   });
 
-  it('should not modify data already at v1', () => {
+  it('should migrate v1 data to v2 by adding serverAddress', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 1,
+      port: 28741,
+      accessKey: 'test',
+      httpsEnabled: false,
+      debugMode: false,
+      moduleStates: {},
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(2);
+    expect(result.serverAddress).toBe('127.0.0.1');
+  });
+
+  it('should not modify data already at v2', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 2,
+      serverAddress: '192.168.1.100',
       port: 28741,
       accessKey: 'test',
       httpsEnabled: false,
@@ -46,10 +63,11 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(1);
+    expect(result.schemaVersion).toBe(2);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
+    expect(result.serverAddress).toBe('127.0.0.1');
   });
 });
 
@@ -64,6 +82,27 @@ describe('generateAccessKey', () => {
     const key1 = generateAccessKey();
     const key2 = generateAccessKey();
     expect(key1).not.toBe(key2);
+  });
+});
+
+describe('isValidIPv4', () => {
+  it('should accept valid IPv4 addresses', () => {
+    expect(isValidIPv4('127.0.0.1')).toBe(true);
+    expect(isValidIPv4('0.0.0.0')).toBe(true);
+    expect(isValidIPv4('192.168.1.100')).toBe(true);
+    expect(isValidIPv4('255.255.255.255')).toBe(true);
+    expect(isValidIPv4('10.0.0.1')).toBe(true);
+  });
+
+  it('should reject invalid IPv4 addresses', () => {
+    expect(isValidIPv4('')).toBe(false);
+    expect(isValidIPv4('localhost')).toBe(false);
+    expect(isValidIPv4('256.0.0.1')).toBe(false);
+    expect(isValidIPv4('1.2.3')).toBe(false);
+    expect(isValidIPv4('1.2.3.4.5')).toBe(false);
+    expect(isValidIPv4('abc.def.ghi.jkl')).toBe(false);
+    expect(isValidIPv4('1.2.3.-1')).toBe(false);
+    expect(isValidIPv4('::1')).toBe(false);
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,7 +22,11 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 1', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(1);
+  it('should have schema version 2', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(2);
+  });
+
+  it('should have default server address 127.0.0.1', () => {
+    expect(DEFAULT_SETTINGS.serverAddress).toBe('127.0.0.1');
   });
 });


### PR DESCRIPTION
## Summary

- Add `serverAddress` setting (default `127.0.0.1`) to control which IP the MCP server binds to
- Add IPv4 validation, security warning for non-localhost addresses, and V1→V2 schema migration
- Update PRD (CR17), configuration docs, security docs, and README

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | New `serverAddress` field + schema version 2 |
| `src/server/http-server.ts` | `host` in `HttpServerOptions`, used in `.listen()` |
| `src/settings.ts` | Server Address input, IPv4 validation, security warning, Server URL uses setting, V1→V2 migration |
| `src/main.ts` | Passes `host` to `HttpMcpServer` |
| `docs/PRD.md` | CR17 added |
| `docs/configuration.md` | `serverAddress` setting documented |
| `docs/security.md` | Network exposure section updated |
| `README.md` | Configuration table updated |
| Tests | Migration, validation, and integration tests updated |

## Test plan

- [x] `npm run lint` — 0 errors (2 pre-existing warnings)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 243/243 passing
- [ ] Manual: change Server Address in settings UI, verify server binds to new IP
- [ ] Manual: verify security warning appears for non-localhost address
- [ ] Manual: verify Server URL display and Copy URL reflect the configured address

Closes #68