### PR TITLE
fix: per-session MCP server to prevent "Server already initialized"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,12 +98,15 @@ export default class McpPlugin extends Plugin {
 
   async startServer(): Promise<void> {
     try {
-      const mcpServer = createMcpServer(this.registry, this.logger);
-      this.httpServer = new HttpMcpServer(mcpServer, this.logger, {
-        host: this.settings.serverAddress,
-        port: this.settings.port,
-        accessKey: this.settings.accessKey,
-      });
+      this.httpServer = new HttpMcpServer(
+        () => createMcpServer(this.registry, this.logger),
+        this.logger,
+        {
+          host: this.settings.serverAddress,
+          port: this.settings.port,
+          accessKey: this.settings.accessKey,
+        },
+      );
       await this.httpServer.start();
       this.updateStatusDisplay();
       new Notice(`MCP server started on port ${String(this.settings.port)}`);

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -2,6 +2,7 @@ import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '../utils/logger';
 import { authenticateRequest, sendAuthError } from './auth';
 import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } from './cors';
@@ -13,16 +14,25 @@ export interface HttpServerOptions {
   corsOptions?: CorsOptions;
 }
 
+export type McpServerFactory = () => McpServer;
+
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
 export class HttpMcpServer {
   private httpServer: Server | null = null;
-  private transport: StreamableHTTPServerTransport | null = null;
   private logger: Logger;
-  private mcpServer: McpServer;
+  private serverFactory: McpServerFactory;
   private options: HttpServerOptions;
   private _connectedClients = 0;
+  private sessions = new Map<string, Session>();
 
-  constructor(mcpServer: McpServer, logger: Logger, options: HttpServerOptions) {
-    this.mcpServer = mcpServer;
+  constructor(serverFactory: McpServerFactory, logger: Logger, options: HttpServerOptions) {
+    this.serverFactory = serverFactory;
     this.logger = logger;
     this.options = options;
   }
@@ -39,42 +49,20 @@ export class HttpMcpServer {
     return this.options.port;
   }
 
+  get activeSessions(): number {
+    return this.sessions.size;
+  }
+
   async start(): Promise<void> {
     if (this.isRunning) {
       this.logger.warn('Server is already running');
       return;
     }
 
-    this.transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: (): string => randomUUID(),
-    });
-
-    await this.mcpServer.connect(this.transport);
-
     const corsOptions = this.options.corsOptions ?? DEFAULT_CORS_OPTIONS;
 
     this.httpServer = createServer((req: IncomingMessage, res: ServerResponse): void => {
-      // CORS preflight
-      if (handlePreflight(req, res, corsOptions)) {
-        return;
-      }
-
-      // Apply CORS headers to all responses
-      applyCorsHeaders(res, corsOptions);
-
-      // Authenticate
-      const authResult = authenticateRequest(req, this.options.accessKey);
-      if (!authResult.authenticated) {
-        this.logger.warn('Authentication failed', { error: authResult.error });
-        sendAuthError(res, authResult.error ?? 'Authentication failed');
-        return;
-      }
-
-      // Log request in debug mode
-      this.logger.debug(`${req.method ?? 'UNKNOWN'} ${req.url ?? '/'}`);
-
-      // Delegate to MCP transport
-      void this.transport!.handleRequest(req, res);
+      void this.handleRequest(req, res, corsOptions);
     });
 
     this.httpServer.on('connection', () => {
@@ -101,6 +89,123 @@ export class HttpMcpServer {
     });
   }
 
+  private async handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    corsOptions: CorsOptions,
+  ): Promise<void> {
+    if (handlePreflight(req, res, corsOptions)) {
+      return;
+    }
+
+    applyCorsHeaders(res, corsOptions);
+
+    const authResult = authenticateRequest(req, this.options.accessKey);
+    if (!authResult.authenticated) {
+      this.logger.warn('Authentication failed', { error: authResult.error });
+      sendAuthError(res, authResult.error ?? 'Authentication failed');
+      return;
+    }
+
+    this.logger.debug(`${req.method ?? 'UNKNOWN'} ${req.url ?? '/'}`);
+
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+    const method = req.method ?? 'GET';
+
+    try {
+      if (method === 'POST') {
+        await this.handlePost(req, res, sessionId);
+        return;
+      }
+
+      if (sessionId) {
+        const session = this.sessions.get(sessionId);
+        if (session) {
+          await session.transport.handleRequest(req, res);
+          return;
+        }
+      }
+
+      sendJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error handling MCP request: ${message}`);
+      if (!res.headersSent) {
+        sendJsonRpcError(res, 500, -32603, 'Internal server error');
+      }
+    }
+  }
+
+  private async handlePost(
+    req: IncomingMessage,
+    res: ServerResponse,
+    sessionId: string | undefined,
+  ): Promise<void> {
+    let parsedBody: unknown;
+    try {
+      parsedBody = await readJsonBody(req);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sendJsonRpcError(res, 400, -32700, `Parse error: ${message}`);
+      return;
+    }
+
+    if (sessionId) {
+      const session = this.sessions.get(sessionId);
+      if (!session) {
+        sendJsonRpcError(res, 404, -32001, 'Session not found');
+        return;
+      }
+      await session.transport.handleRequest(req, res, parsedBody);
+      return;
+    }
+
+    if (!isInitializeRequest(parsedBody)) {
+      sendJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
+      return;
+    }
+
+    const session = await this.createSession();
+    await session.transport.handleRequest(req, res, parsedBody);
+  }
+
+  private async createSession(): Promise<Session> {
+    const server = this.serverFactory();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: (): string => randomUUID(),
+      onsessioninitialized: (id: string): void => {
+        this.sessions.set(id, { transport, server });
+        this.logger.debug(`MCP session initialized: ${id} (active: ${String(this.sessions.size)})`);
+      },
+      onsessionclosed: (id: string): void => {
+        this.removeSession(id);
+      },
+    });
+
+    transport.onclose = (): void => {
+      if (transport.sessionId) {
+        this.removeSession(transport.sessionId);
+      }
+    };
+
+    await server.connect(transport);
+    return { transport, server };
+  }
+
+  private removeSession(id: string): void {
+    const session = this.sessions.get(id);
+    if (!session) {
+      return;
+    }
+    this.sessions.delete(id);
+    this.logger.debug(`MCP session closed: ${id} (active: ${String(this.sessions.size)})`);
+    void session.server.close().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Error closing MCP server for session ${id}: ${message}`);
+    });
+  }
+
   async stop(): Promise<void> {
     if (!this.httpServer) {
       return;
@@ -108,7 +213,24 @@ export class HttpMcpServer {
 
     this.logger.info('Stopping MCP server...');
 
-    await this.mcpServer.close();
+    const sessionsToClose = Array.from(this.sessions.values());
+    this.sessions.clear();
+    await Promise.all(
+      sessionsToClose.map(async ({ transport, server }) => {
+        try {
+          await transport.close();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`Error closing transport: ${message}`);
+        }
+        try {
+          await server.close();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`Error closing MCP server: ${message}`);
+        }
+      }),
+    );
 
     await new Promise<void>((resolve, reject) => {
       this.httpServer!.close((err) => {
@@ -121,7 +243,6 @@ export class HttpMcpServer {
     });
 
     this.httpServer = null;
-    this.transport = null;
     this._connectedClients = 0;
     this.logger.info('MCP server stopped');
   }
@@ -129,4 +250,52 @@ export class HttpMcpServer {
   updateOptions(options: Partial<HttpServerOptions>): void {
     this.options = { ...this.options, ...options };
   }
+}
+
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_BODY_BYTES) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (raw.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJsonRpcError(
+  res: ServerResponse,
+  httpStatus: number,
+  code: number,
+  message: string,
+): void {
+  if (res.headersSent) {
+    return;
+  }
+  res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code, message },
+      id: null,
+    }),
+  );
 }

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -81,12 +81,15 @@ describe('Integration: HTTP Server Authentication', () => {
     const adapter = new MockObsidianAdapter();
     const vaultModule = createVaultModule(adapter);
     registry.registerModule(vaultModule);
-    const mcpServer = createMcpServer(registry, logger);
-    server = new HttpMcpServer(mcpServer, logger, {
-      host: '127.0.0.1',
-      port: TEST_PORT,
-      accessKey: ACCESS_KEY,
-    });
+    server = new HttpMcpServer(
+      () => createMcpServer(registry, logger),
+      logger,
+      {
+        host: '127.0.0.1',
+        port: TEST_PORT,
+        accessKey: ACCESS_KEY,
+      },
+    );
     await server.start();
   });
 
@@ -152,6 +155,70 @@ describe('Integration: HTTP Server Authentication', () => {
     expect(data.jsonrpc).toBe('2.0');
     expect(data.id).toBe(1);
     expect(data.result).toBeDefined();
+    expect(res.headers['mcp-session-id']).toBeDefined();
+  });
+
+  it('should allow multiple independent clients to initialize', async () => {
+    // Regression for LM Studio "Server already initialized" error (#74).
+    // Each new client without a session ID must be able to initialize.
+    const makeInitRequest = async (
+      clientName: string,
+    ): Promise<{ status: number; headers: Record<string, string>; body: string }> => {
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: clientName, version: '1.0.0' },
+        },
+      });
+      return makeRequest('POST', '/', {
+        Authorization: `Bearer ${ACCESS_KEY}`,
+        Accept: 'application/json, text/event-stream',
+      }, body);
+    };
+
+    const first = await makeInitRequest('client-a');
+    const second = await makeInitRequest('client-b');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers['mcp-session-id']).toBeDefined();
+    expect(second.headers['mcp-session-id']).toBeDefined();
+    expect(first.headers['mcp-session-id']).not.toBe(second.headers['mcp-session-id']);
+  });
+
+  it('should reject non-initialize POST without session ID', async () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'tools/list',
+      params: {},
+    });
+    const res = await makeRequest('POST', '/', {
+      Authorization: `Bearer ${ACCESS_KEY}`,
+      Accept: 'application/json, text/event-stream',
+    }, body);
+    expect(res.status).toBe(400);
+    const data = JSON.parse(res.body) as { error?: { message?: string } };
+    expect(data.error?.message).toContain('session ID');
+  });
+
+  it('should return 404 for requests with unknown session ID', async () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    });
+    const res = await makeRequest('POST', '/', {
+      Authorization: `Bearer ${ACCESS_KEY}`,
+      Accept: 'application/json, text/event-stream',
+      'Mcp-Session-Id': 'nonexistent-session-id',
+    }, body);
+    expect(res.status).toBe(404);
   });
 
   it('should report server as running', () => {


### PR DESCRIPTION
## Summary

Fixes #74. The HTTP server previously connected a single `McpServer` to a single `StreamableHTTPServerTransport` at startup. Once any client sent an `initialize` request, the SDK marked the server as initialized and rejected any subsequent `initialize` with `-32600: Server already initialized` — which is exactly what LM Studio was hitting on reconnect.

## Changes

- `src/server/http-server.ts`: route requests by `Mcp-Session-Id`. Each new initialize request without a session ID creates a fresh `McpServer` + `StreamableHTTPServerTransport` pair. Sessions are tracked in a map and cleaned up when the transport closes or the HTTP server stops.
- `src/server/http-server.ts`: reject non-initialize POSTs without a session ID (`400`) and requests with unknown session IDs (`404`) with proper JSON-RPC error envelopes.
- `src/main.ts`: pass an `McpServer` factory to `HttpMcpServer` instead of a single pre-created instance.
- `tests/integration/server.test.ts`: regression tests covering two independent clients initializing, missing session IDs on non-initialize POSTs, and unknown session IDs.

## Test plan

- [x] `npm test` — 251 passing (was 248; +3 new integration tests)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #74