### PR TITLE
fix: auto-register discovered tool modules on plugin load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { createLogger, Logger } from './utils/logger';
 import { ModuleRegistry } from './registry/module-registry';
 import { createMcpServer } from './server/mcp-server';
 import { HttpMcpServer } from './server/http-server';
+import { RealObsidianAdapter, ObsidianAdapter } from './obsidian/adapter';
+import { discoverModules } from './tools';
 import { McpSettingsTab, migrateSettings } from './settings';
 
 const ICON_MCP = 'plug';
@@ -12,6 +14,7 @@ export default class McpPlugin extends Plugin {
   settings: McpPluginSettings = DEFAULT_SETTINGS;
   logger!: Logger;
   registry!: ModuleRegistry;
+  adapter!: ObsidianAdapter;
   httpServer: HttpMcpServer | null = null;
   private statusBarItem: { setText: (text: string) => void } | null = null;
   private ribbonIconEl: HTMLElement | null = null;
@@ -24,10 +27,10 @@ export default class McpPlugin extends Plugin {
       accessKey: this.settings.accessKey,
     });
 
+    this.adapter = new RealObsidianAdapter(this.app);
     this.registry = new ModuleRegistry(this.logger);
 
-    // Apply saved module states
-    this.registry.applyState(this.settings.moduleStates);
+    this.registerDiscoveredModules();
 
     // Add settings tab
     this.addSettingTab(new McpSettingsTab(this.app, this));
@@ -128,6 +131,18 @@ export default class McpPlugin extends Plugin {
   async restartServer(): Promise<void> {
     await this.stopServer();
     await this.startServer();
+  }
+
+  refreshModules(): void {
+    this.registry.clear();
+    this.registerDiscoveredModules();
+  }
+
+  private registerDiscoveredModules(): void {
+    for (const module of discoverModules(this.adapter)) {
+      this.registry.registerModule(module);
+    }
+    this.registry.applyState(this.settings.moduleStates);
   }
 
   private updateStatusDisplay(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -220,9 +220,15 @@ export class McpSettingsTab extends PluginSettingTab {
 
   private renderModuleToggles(containerEl: HTMLElement): void {
     const modules = this.plugin.registry.getModules();
-    if (modules.length === 0) return;
 
     containerEl.createEl('h2', { text: 'Feature Modules' });
+
+    if (modules.length === 0) {
+      containerEl.createEl('p', {
+        text: 'No modules registered. Click "Refresh Modules" to re-run discovery.',
+        cls: 'setting-item-description',
+      });
+    }
 
     for (const registration of modules) {
       const { metadata } = registration.module;
@@ -258,6 +264,7 @@ export class McpSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl).addButton((btn) =>
       btn.setButtonText('Refresh Modules').onClick(() => {
+        this.plugin.refreshModules();
         this.display();
       }),
     );

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,25 @@
+import { ObsidianAdapter } from '../obsidian/adapter';
+import { ToolModule } from '../registry/types';
+import { createEditorModule } from './editor';
+import { createPluginInteropModule } from './plugin-interop';
+import { createSearchModule } from './search';
+import { createTemplatesModule } from './templates';
+import { createUiModule } from './ui';
+import { createVaultModule } from './vault';
+import { createWorkspaceModule } from './workspace';
+
+export type ModuleFactory = (adapter: ObsidianAdapter) => ToolModule;
+
+export const MODULE_FACTORIES: ModuleFactory[] = [
+  createVaultModule,
+  createEditorModule,
+  createSearchModule,
+  createWorkspaceModule,
+  createUiModule,
+  createTemplatesModule,
+  createPluginInteropModule,
+];
+
+export function discoverModules(adapter: ObsidianAdapter): ToolModule[] {
+  return MODULE_FACTORIES.map((factory) => factory(adapter));
+}

--- a/tests/tools/discovery.test.ts
+++ b/tests/tools/discovery.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { discoverModules, MODULE_FACTORIES } from '../../src/tools';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { ModuleRegistry } from '../../src/registry/module-registry';
+import { Logger } from '../../src/utils/logger';
+
+function createSilentLogger(): Logger {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
+
+describe('tool discovery', () => {
+  it('exposes all seven module factories', () => {
+    expect(MODULE_FACTORIES).toHaveLength(7);
+  });
+
+  it('discovers modules with unique ids', () => {
+    const adapter = new MockObsidianAdapter();
+    const modules = discoverModules(adapter);
+    const ids = modules.map((m) => m.metadata.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'vault',
+        'editor',
+        'search',
+        'workspace',
+        'ui',
+        'templates',
+        'plugin-interop',
+      ]),
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('each discovered module exposes at least one tool', () => {
+    const adapter = new MockObsidianAdapter();
+    for (const module of discoverModules(adapter)) {
+      expect(module.tools().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('registering all discovered modules produces a non-empty active tool list', () => {
+    const adapter = new MockObsidianAdapter();
+    const registry = new ModuleRegistry(createSilentLogger());
+    for (const module of discoverModules(adapter)) {
+      registry.registerModule(module);
+    }
+    expect(registry.getModules().length).toBe(MODULE_FACTORIES.length);
+    expect(registry.getActiveTools().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #79

## Summary

The `ModuleRegistry` was created in `onload()` but no modules were ever registered, so `tools/list` returned empty and MCP clients saw `Method not found`. This wires up the self-registration / auto-discovery flow described in the PRD (CR12, NFR22, NFR23, TR9) — without hardcoding factory calls in `main.ts`.

## Changes

- **`src/tools/index.ts`** (new): single discovery point. Exports `MODULE_FACTORIES` (the list of every category factory) and `discoverModules(adapter)` which instantiates them all. Adding a new category = drop a factory under `src/tools/<name>/` and append it to `MODULE_FACTORIES`.
- **`src/main.ts`**: builds a `RealObsidianAdapter`, calls `discoverModules()`, registers each module, then applies saved `moduleStates`. Adds a `refreshModules()` method that clears + re-runs discovery without restarting Obsidian.
- **`src/settings.ts`**: the existing "Refresh Modules" button now calls `plugin.refreshModules()` before redrawing; an empty state hint is rendered if the registry is somehow empty.
- **`tests/tools/discovery.test.ts`** (new): 4 tests — factory count, unique ids, each module exposes tools, registry ends up non-empty after discovery.

## Effect

Settings now shows a "Feature Modules" section with a toggle per category (Vault, Editor, Search, Workspace, UI, Templates, Plugin Interop) plus a read-only sub-toggle where supported. MCP clients now see the full tool list on `tools/list`.

## Test plan

- [x] `npm test` — 255 passed (19 existing suites + new discovery suite)
- [x] `npm run lint` — 0 errors (only the 2 pre-existing warnings in `tests/settings.test.ts`)
- [x] `npm run typecheck` — clean
- [ ] Manual: install plugin in Obsidian, confirm "Feature Modules" section renders toggles and `tools/list` in an MCP client returns the full set