### PR TITLE
feat(settings): add copy-icon button next to Access Key field

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -126,6 +126,18 @@ export class McpSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           }),
       )
+      .addExtraButton((btn) =>
+        btn
+          .setIcon('copy')
+          .setTooltip('Copy access key')
+          .onClick(() => {
+            void navigator.clipboard
+              .writeText(this.plugin.settings.accessKey)
+              .then(() => {
+                new Notice('Access key copied to clipboard');
+              });
+          }),
+      )
       .addButton((btn) =>
         btn.setButtonText('Generate').onClick(async () => {
           this.plugin.settings.accessKey = generateAccessKey();

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -57,6 +57,8 @@ export class Setting {
   static instances: Setting[] = [];
   settingName = '';
   buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
+  extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> = [];
+  toggles: Array<{ value: boolean; tooltip: string; callback: ((value: boolean) => void) | null }> = [];
 
   constructor(_containerEl: any) {
     Setting.instances.push(this);
@@ -65,13 +67,21 @@ export class Setting {
     this.settingName = name;
     return this;
   }
-  setDesc(_desc: string): this {
+  setDesc(_desc: any): this {
     return this;
   }
   addText(_cb: (text: any) => void): this {
     return this;
   }
-  addToggle(_cb: (toggle: any) => void): this {
+  addToggle(cb: (toggle: any) => void): this {
+    const record = { value: false, tooltip: '', callback: null as ((value: boolean) => void) | null };
+    const toggle = {
+      setValue(v: boolean) { record.value = v; return toggle; },
+      setTooltip(t: string) { record.tooltip = t; return toggle; },
+      onChange(fn: (value: boolean) => void) { record.callback = fn; return toggle; },
+    };
+    cb(toggle);
+    this.toggles.push(record);
     return this;
   }
   addButton(cb: (btn: any) => void): this {
@@ -85,6 +95,17 @@ export class Setting {
     cb(btn);
     record.disabled = btn.buttonEl.disabled;
     this.buttons.push(record);
+    return this;
+  }
+  addExtraButton(cb: (btn: any) => void): this {
+    const record = { icon: '', tooltip: '', callback: null as (() => void) | null };
+    const btn = {
+      setIcon(icon: string) { record.icon = icon; return btn; },
+      setTooltip(t: string) { record.tooltip = t; return btn; },
+      onClick(fn: () => void) { record.callback = fn; return btn; },
+    };
+    cb(btn);
+    this.extraButtons.push(record);
     return this;
   }
 }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -319,6 +319,33 @@ describe('McpSettingsTab server controls', () => {
     expect(buttons[0].text).toBe('Copy URL');
   });
 
+  it('should render a copy icon extra button on the Access Key setting', () => {
+    renderTab(false);
+    const setting = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+      (s) => s.settingName === 'Access Key',
+    ) as unknown as { extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> };
+    expect(setting).toBeDefined();
+    expect(setting.extraButtons).toHaveLength(1);
+    expect(setting.extraButtons[0].icon).toBe('copy');
+    expect(setting.extraButtons[0].tooltip).toBe('Copy access key');
+  });
+
+  it('Access Key copy button copies accessKey to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+    renderTab(false);
+    const setting = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+      (s) => s.settingName === 'Access Key',
+    ) as unknown as { extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> };
+    setting.extraButtons[0].callback!();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('test-key');
+    });
+  });
+
   it('should disable Stop and Restart when server is stopped', () => {
     renderTab(false);
     const buttons = getStatusButtons();


### PR DESCRIPTION
## Summary

Adds a dedicated copy action on the **Access Key** row rendered as Obsidian's built-in `copy` icon. Clicking copies the current access key to the clipboard and shows a Notice. Placed before the **Generate** button.

## Changes

- `src/settings.ts`: adds `addExtraButton` with icon `copy`, tooltip `Copy access key`, and `navigator.clipboard.writeText` + `Notice`.
- `tests/__mocks__/obsidian.ts`: adds `addExtraButton` support (and `addToggle` tracking) so tests can assert on icon buttons and toggles.
- `tests/settings.test.ts`: asserts the copy extra-button exists with icon `copy`, tooltip `Copy access key`, and copies the access key.

## Acceptance

- [x] New icon button appears on the Access Key row
- [x] Clicking writes the access key to `navigator.clipboard`
- [x] Notice confirms the copy
- [x] Uses `setIcon('copy')`
- [x] Tests cover the new behaviour

Closes #83