### PR TITLE
feat(settings): replace Copy URL text button with copy icon

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -105,13 +105,16 @@ export class McpSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Server URL')
       .setDesc(`http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`)
-      .addButton((btn) =>
-        btn.setButtonText('Copy URL').onClick(() => {
-          const url = `http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
-          void navigator.clipboard.writeText(url).then(() => {
-            new Notice('MCP server URL copied to clipboard');
-          });
-        }),
+      .addExtraButton((btn) =>
+        btn
+          .setIcon('copy')
+          .setTooltip('Copy server URL')
+          .onClick(() => {
+            const url = `http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
+            void navigator.clipboard.writeText(url).then(() => {
+              new Notice('MCP server URL copied to clipboard');
+            });
+          }),
       );
 
     new Setting(containerEl)

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -338,11 +338,31 @@ describe('McpSettingsTab server controls', () => {
     expect(buttons.map((b) => b.text)).toEqual(['Start', 'Stop', 'Restart']);
   });
 
-  it('should render Copy URL button in Server URL setting', () => {
+  it('should render a copy icon extra button on the Server URL setting', () => {
     renderTab(false);
-    const buttons = getSettingButtons('Server URL');
-    expect(buttons).toHaveLength(1);
-    expect(buttons[0].text).toBe('Copy URL');
+    const setting = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+      (s) => s.settingName === 'Server URL',
+    ) as unknown as { extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> };
+    expect(setting).toBeDefined();
+    expect(setting.extraButtons).toHaveLength(1);
+    expect(setting.extraButtons[0].icon).toBe('copy');
+    expect(setting.extraButtons[0].tooltip).toBe('Copy server URL');
+  });
+
+  it('Server URL copy button copies the URL to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+    renderTab(false);
+    const setting = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+      (s) => s.settingName === 'Server URL',
+    ) as unknown as { extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> };
+    setting.extraButtons[0].callback!();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('http://127.0.0.1:28741/mcp');
+    });
   });
 
   it('should render a copy icon extra button on the Access Key setting', () => {


### PR DESCRIPTION
## Summary

Replaces the `Copy URL` text button on the **Server URL** row with Obsidian's built-in `copy` icon via `addExtraButton`. Matches the new Access Key copy icon from #83 and makes the UI more compact and consistent. Clipboard behaviour and the Notice are unchanged.

## Changes

- `src/settings.ts`: Server URL setting now uses `addExtraButton` with `setIcon('copy')` and tooltip `Copy server URL`.
- `tests/__mocks__/obsidian.ts`: adds `addExtraButton` support.
- `tests/settings.test.ts`: asserts the copy extra-button exists with icon `copy`, tooltip `Copy server URL`, and copies `http://127.0.0.1:28741/mcp`.

## Acceptance

- [x] Server URL row uses icon button (not text)
- [x] Clipboard + Notice unchanged
- [x] Tooltip is `Copy server URL`
- [x] Tests cover the new behaviour

Closes #84