### PR TITLE
feat(server): do not auto-start MCP server on plugin load; default to off

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -86,11 +86,15 @@ export default class McpPlugin extends Plugin {
       },
     });
 
-    // Start server if access key is configured
-    if (this.settings.accessKey) {
+    // Start server only when explicitly opted in and an access key is set
+    if (this.settings.autoStart && this.settings.accessKey) {
       await this.startServer();
     } else {
-      this.logger.info('MCP server not started: no access key configured');
+      if (!this.settings.accessKey) {
+        this.logger.info('MCP server not started: no access key configured');
+      } else {
+        this.logger.info('MCP server not started: auto-start is disabled');
+      }
       this.updateStatusDisplay();
     }
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -135,6 +135,18 @@ export class McpSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName('Auto-start on launch')
+      .setDesc('Start MCP server automatically when Obsidian launches')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoStart)
+          .onChange(async (value) => {
+            this.plugin.settings.autoStart = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName('Debug Mode')
       .setDesc('Enable verbose logging of MCP requests and responses')
       .addToggle((toggle) =>
@@ -303,6 +315,12 @@ export function migrateSettings(
     data.schemaVersion = 2;
     // V1 -> V2: add serverAddress
     if (!data.serverAddress) data.serverAddress = '127.0.0.1';
+  }
+
+  if ((data.schemaVersion as number) < 3) {
+    data.schemaVersion = 3;
+    // V2 -> V3: add autoStart, default off for existing installs (explicit opt-in)
+    if (data.autoStart === undefined) data.autoStart = false;
   }
 
   return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface McpPluginSettings {
   httpsEnabled: boolean;
   /** Enable verbose debug logging */
   debugMode: boolean;
+  /** Auto-start the MCP server when Obsidian launches */
+  autoStart: boolean;
   /** Per-module enabled/disabled state, keyed by module ID */
   moduleStates: Record<string, ModuleState>;
 }
@@ -21,11 +23,12 @@ export interface ModuleState {
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 2,
+  schemaVersion: 3,
   serverAddress: '127.0.0.1',
   port: 28741,
   accessKey: '',
   httpsEnabled: false,
   debugMode: false,
+  autoStart: false,
   moduleStates: {},
 };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import McpPlugin from '../src/main';
+
+interface TestPlugin extends McpPlugin {
+  loadData: () => Promise<Record<string, unknown> | null>;
+  saveData: (data: unknown) => Promise<void>;
+}
+
+function createPlugin(persisted: Record<string, unknown> | null): TestPlugin {
+  const app = {
+    vault: { adapter: { basePath: '/tmp/vault' } },
+    workspace: {},
+    metadataCache: {},
+  };
+  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+  const plugin = new McpPlugin(app as any, {} as any) as unknown as TestPlugin;
+  (plugin as any).app = app;
+  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+  plugin.loadData = vi.fn().mockResolvedValue(persisted);
+  plugin.saveData = vi.fn().mockResolvedValue(undefined);
+  return plugin;
+}
+
+describe('McpPlugin.onload autoStart behaviour', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not start the server when autoStart is false, even with an access key', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'configured-key',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: false,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it('starts the server when autoStart is true and an access key is set', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'configured-key',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: true,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(startSpy).toHaveBeenCalled();
+  });
+
+  it('does not start the server when autoStart is true but no access key is set', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: true,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it('migrates existing installs to autoStart=false so the server stays stopped on first load', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 2,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'legacy-key',
+      httpsEnabled: false,
+      debugMode: false,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(plugin.settings.autoStart).toBe(false);
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4,16 +4,17 @@ import { migrateSettings, generateAccessKey, isValidIPv4, McpSettingsTab } from 
 import { DEFAULT_SETTINGS } from '../src/types';
 
 describe('migrateSettings', () => {
-  it('should migrate v0 (no schemaVersion) to v2', () => {
+  it('should migrate v0 (no schemaVersion) to v3', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(2);
+    expect(result.schemaVersion).toBe(3);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
     expect(result.debugMode).toBe(false);
     expect(result.moduleStates).toEqual({});
     expect(result.serverAddress).toBe('127.0.0.1');
+    expect(result.autoStart).toBe(false);
   });
 
   it('should preserve existing values during migration', () => {
@@ -23,14 +24,15 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(2);
+    expect(result.schemaVersion).toBe(3);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
     expect(result.serverAddress).toBe('127.0.0.1');
+    expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v1 data to v2 by adding serverAddress', () => {
+  it('should migrate v1 data to v3 by adding serverAddress and autoStart', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 1,
       port: 28741,
@@ -40,11 +42,12 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(2);
+    expect(result.schemaVersion).toBe(3);
     expect(result.serverAddress).toBe('127.0.0.1');
+    expect(result.autoStart).toBe(false);
   });
 
-  it('should not modify data already at v2', () => {
+  it('should migrate v2 data to v3 by adding autoStart=false', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 2,
       serverAddress: '192.168.1.100',
@@ -52,6 +55,22 @@ describe('migrateSettings', () => {
       accessKey: 'test',
       httpsEnabled: false,
       debugMode: false,
+      moduleStates: {},
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(3);
+    expect(result.autoStart).toBe(false);
+  });
+
+  it('should not modify data already at v3', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 3,
+      serverAddress: '192.168.1.100',
+      port: 28741,
+      accessKey: 'test',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: true,
       moduleStates: {},
     };
     const result = migrateSettings(data);
@@ -63,11 +82,18 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(2);
+    expect(result.schemaVersion).toBe(3);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
     expect(result.serverAddress).toBe('127.0.0.1');
+    expect(result.autoStart).toBe(false);
+  });
+});
+
+describe('DEFAULT_SETTINGS', () => {
+  it('should default autoStart to false', () => {
+    expect(DEFAULT_SETTINGS.autoStart).toBe(false);
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,11 +22,15 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 2', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(2);
+  it('should have schema version 3', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(3);
   });
 
   it('should have default server address 127.0.0.1', () => {
     expect(DEFAULT_SETTINGS.serverAddress).toBe('127.0.0.1');
+  });
+
+  it('should have auto-start disabled by default', () => {
+    expect(DEFAULT_SETTINGS.autoStart).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The plugin used to silently bind a network port on load whenever an access key was configured. This PR adds an explicit `autoStart` opt-in (default: **false**). `onload()` only starts the server if `autoStart === true` **and** an access key is set.

## Changes

- `src/types.ts`: new `autoStart: boolean` on `McpPluginSettings`; `DEFAULT_SETTINGS.autoStart = false`; schema bumped to 3.
- `src/settings.ts`: adds v2 → v3 migration that sets `autoStart = false` for existing installs; exposes an **Auto-start on launch** toggle in Server Settings.
- `src/main.ts`: `onload()` only calls `startServer()` when `autoStart && accessKey`; logs the reason when skipping.
- `tests/main.test.ts`: covers onload for autoStart true/false/migrated-install cases.
- `tests/types.test.ts`: asserts the new default and schema version.
- `tests/settings.test.ts`: extends migration tests for v2 → v3.

## Acceptance

- [x] Fresh install does NOT start the server on plugin load
- [x] Turning on Auto-start persists the choice; does not immediately start the server
- [x] With auto-start on + access key, server auto-starts on next launch
- [x] Migration leaves existing users with server OFF after upgrade
- [x] Tests: migration v2 → v3, `DEFAULT_SETTINGS.autoStart === false`, onload behaviour

Closes #85