### PR TITLE
fix(settings): promote read-only module toggle to its own labelled sub-row

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -259,7 +259,7 @@ export class McpSettingsTab extends PluginSettingTab {
     for (const registration of modules) {
       const { metadata } = registration.module;
 
-      const setting = new Setting(containerEl)
+      new Setting(containerEl)
         .setName(metadata.name)
         .setDesc(metadata.description)
         .addToggle((toggle) =>
@@ -275,16 +275,17 @@ export class McpSettingsTab extends PluginSettingTab {
         );
 
       if (metadata.supportsReadOnly) {
-        setting.addToggle((toggle) =>
-          toggle
-            .setValue(registration.readOnly)
-            .setTooltip('Read-only mode')
-            .onChange(async (value) => {
+        new Setting(containerEl)
+          .setName('Read-only')
+          .setDesc('Expose only read tools for this module; hide mutating tools.')
+          .setClass('mcp-module-readonly-row')
+          .addToggle((toggle) =>
+            toggle.setValue(registration.readOnly).onChange(async (value) => {
               this.plugin.registry.setReadOnly(metadata.id, value);
               this.plugin.settings.moduleStates = this.plugin.registry.getState();
               await this.plugin.saveSettings();
             }),
-        );
+          );
       }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -52,3 +52,8 @@
   color: var(--text-success);
   border-color: var(--text-success);
 }
+
+.mcp-module-readonly-row {
+  padding-left: 2em;
+  border-top: none;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -56,18 +56,33 @@ export class PluginSettingTab {
 export class Setting {
   static instances: Setting[] = [];
   settingName = '';
+  settingDesc = '';
+  settingClass = '';
   buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
   extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> = [];
   toggles: Array<{ value: boolean; tooltip: string; callback: ((value: boolean) => void) | null }> = [];
+  settingEl: { classList: { add: (cls: string) => void } };
 
   constructor(_containerEl: any) {
     Setting.instances.push(this);
+    this.settingEl = {
+      classList: {
+        add: (cls: string): void => {
+          this.settingClass = this.settingClass ? `${this.settingClass} ${cls}` : cls;
+        },
+      },
+    };
   }
   setName(name: string): this {
     this.settingName = name;
     return this;
   }
-  setDesc(_desc: any): this {
+  setDesc(desc: any): this {
+    if (typeof desc === 'string') this.settingDesc = desc;
+    return this;
+  }
+  setClass(cls: string): this {
+    this.settingClass = this.settingClass ? `${this.settingClass} ${cls}` : cls;
     return this;
   }
   addText(_cb: (text: any) => void): this {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -449,3 +449,129 @@ describe('McpSettingsTab server controls', () => {
     });
   });
 });
+
+describe('McpSettingsTab module rows read-only rendering', () => {
+  type ToggleInfo = { value: boolean; tooltip: string; callback: ((value: boolean) => void) | null };
+  type ModuleSettingInstance = {
+    settingName: string;
+    settingDesc: string;
+    settingClass: string;
+    toggles: ToggleInfo[];
+  };
+
+  interface ModuleRegistration {
+    enabled: boolean;
+    readOnly: boolean;
+    module: {
+      metadata: {
+        id: string;
+        name: string;
+        description: string;
+        supportsReadOnly: boolean;
+      };
+    };
+  }
+
+  function createRegistry(modules: ModuleRegistration[]): {
+    getModules: () => ModuleRegistration[];
+    enableModule: ReturnType<typeof vi.fn>;
+    disableModule: ReturnType<typeof vi.fn>;
+    setReadOnly: ReturnType<typeof vi.fn>;
+    getState: () => Record<string, unknown>;
+  } {
+    return {
+      getModules: () => modules,
+      enableModule: vi.fn(),
+      disableModule: vi.fn(),
+      setReadOnly: vi.fn(),
+      getState: () => ({}),
+    };
+  }
+
+  function renderModules(modules: ModuleRegistration[]): ReturnType<typeof createRegistry> {
+    const registry = createRegistry(modules);
+    const plugin = {
+      settings: { ...DEFAULT_SETTINGS, accessKey: 'k' },
+      httpServer: null,
+      registry,
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+      logger: { updateOptions: (): void => {} },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    const tab = new McpSettingsTab({} as any, plugin as any);
+    tab.display();
+    return registry;
+  }
+
+  function getSetting(name: string): ModuleSettingInstance | undefined {
+    return (Setting as unknown as { instances: ModuleSettingInstance[] }).instances.find(
+      (s) => s.settingName === name,
+    );
+  }
+
+  beforeEach(() => {
+    (Setting as unknown as { instances: unknown[] }).instances = [];
+  });
+
+  it('renders the module enable-toggle with exactly one toggle on the module row', () => {
+    renderModules([
+      {
+        enabled: true,
+        readOnly: false,
+        module: {
+          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
+        },
+      },
+    ]);
+    const moduleRow = getSetting('Vault');
+    expect(moduleRow).toBeDefined();
+    expect(moduleRow!.toggles).toHaveLength(1);
+  });
+
+  it('renders a dedicated Read-only sub-row with its own name, description and toggle', () => {
+    renderModules([
+      {
+        enabled: true,
+        readOnly: false,
+        module: {
+          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
+        },
+      },
+    ]);
+    const readOnlyRow = getSetting('Read-only');
+    expect(readOnlyRow).toBeDefined();
+    expect(readOnlyRow!.settingDesc.length).toBeGreaterThan(0);
+    expect(readOnlyRow!.toggles).toHaveLength(1);
+    expect(readOnlyRow!.settingClass).toContain('mcp-module-readonly-row');
+  });
+
+  it('does not render a Read-only sub-row for modules that do not support it', () => {
+    renderModules([
+      {
+        enabled: true,
+        readOnly: false,
+        module: {
+          metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
+        },
+      },
+    ]);
+    expect(getSetting('Read-only')).toBeUndefined();
+  });
+
+  it('toggling the Read-only sub-row calls registry.setReadOnly', async () => {
+    const registry = renderModules([
+      {
+        enabled: true,
+        readOnly: false,
+        module: {
+          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
+        },
+      },
+    ]);
+    const readOnlyRow = getSetting('Read-only')!;
+    readOnlyRow.toggles[0].callback!(true);
+    await vi.waitFor(() => {
+      expect(registry.setReadOnly).toHaveBeenCalledWith('vault', true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Module rows that supported read-only rendered **two unlabelled toggles** side-by-side, with only a tooltip to distinguish them. This PR promotes the read-only toggle to its own sub-row directly underneath the module row, with a proper name ("Read-only"), a description, and an indent class so the parent/child relationship is clear without hovering.

## Changes

- `src/settings.ts`: read-only renders as a separate `Setting` with its own `setName`, `setDesc`, and `setClass('mcp-module-readonly-row')`.
- `styles.css`: `.mcp-module-readonly-row` indents the sub-row under its parent module.
- `tests/__mocks__/obsidian.ts`: adds toggle tracking, `setClass`, and `setDesc` recording on the `Setting` mock.
- `tests/settings.test.ts`: four new tests verifying (1) module row has exactly one toggle, (2) Read-only sub-row has name + description + toggle + indent class, (3) no Read-only row for modules without `supportsReadOnly`, (4) toggling Read-only calls `registry.setReadOnly`.

## Acceptance

- [x] No module row has two unlabelled toggles
- [x] Read-only mode is visibly named on the row
- [x] Enable vs read-only is clear without hovering for a tooltip
- [x] Tests cover the new sub-row rendering

Closes #87