### PR TITLE
fix(settings): group module + read-only toggles into a bordered card

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -259,9 +259,12 @@ export class McpSettingsTab extends PluginSettingTab {
     for (const registration of modules) {
       const { metadata } = registration.module;
 
-      new Setting(containerEl)
+      const card = containerEl.createDiv({ cls: 'mcp-module-card' });
+
+      new Setting(card)
         .setName(metadata.name)
         .setDesc(metadata.description)
+        .setClass('mcp-module-card-header')
         .addToggle((toggle) =>
           toggle.setValue(registration.enabled).onChange(async (value) => {
             if (value) {
@@ -275,7 +278,7 @@ export class McpSettingsTab extends PluginSettingTab {
         );
 
       if (metadata.supportsReadOnly) {
-        new Setting(containerEl)
+        new Setting(card)
           .setName('Read-only')
           .setDesc('Expose only read tools for this module; hide mutating tools.')
           .setClass('mcp-module-readonly-row')

--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,26 @@
   border-color: var(--text-success);
 }
 
+.mcp-module-card {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  padding: 0 16px;
+  margin-bottom: 12px;
+  background-color: var(--background-secondary);
+}
+
+.mcp-module-card .setting-item {
+  border-top: none;
+}
+
+.mcp-module-card .setting-item + .setting-item {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.mcp-module-card-header .setting-item-name {
+  font-weight: 600;
+}
+
 .mcp-module-readonly-row {
   padding-left: 2em;
   border-top: none;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -58,13 +58,15 @@ export class Setting {
   settingName = '';
   settingDesc = '';
   settingClass = '';
+  container: any;
   buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
   extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> = [];
   toggles: Array<{ value: boolean; tooltip: string; callback: ((value: boolean) => void) | null }> = [];
   settingEl: { classList: { add: (cls: string) => void } };
 
-  constructor(_containerEl: any) {
+  constructor(containerEl: any) {
     Setting.instances.push(this);
+    this.container = containerEl;
     this.settingEl = {
       classList: {
         add: (cls: string): void => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -456,6 +456,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     settingName: string;
     settingDesc: string;
     settingClass: string;
+    container: unknown;
     toggles: ToggleInfo[];
   };
 
@@ -488,7 +489,10 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     };
   }
 
-  function renderModules(modules: ModuleRegistration[]): ReturnType<typeof createRegistry> {
+  function renderModules(modules: ModuleRegistration[]): {
+    registry: ReturnType<typeof createRegistry>;
+    container: TrackingEl;
+  } {
     const registry = createRegistry(modules);
     const plugin = {
       settings: { ...DEFAULT_SETTINGS, accessKey: 'k' },
@@ -499,8 +503,20 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
     const tab = new McpSettingsTab({} as any, plugin as any);
+    const container = createTrackingEl();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (tab as any).containerEl = container;
     tab.display();
-    return registry;
+    return { registry, container };
+  }
+
+  function findAllByClass(root: TrackingEl, cls: string): TrackingEl[] {
+    const results: TrackingEl[] = [];
+    for (const child of root.children) {
+      if (child.className === cls) results.push(child);
+      results.push(...findAllByClass(child, cls));
+    }
+    return results;
   }
 
   function getSetting(name: string): ModuleSettingInstance | undefined {
@@ -509,35 +525,27 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     );
   }
 
+  const vaultModule: ModuleRegistration = {
+    enabled: true,
+    readOnly: false,
+    module: {
+      metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
+    },
+  };
+
   beforeEach(() => {
     (Setting as unknown as { instances: unknown[] }).instances = [];
   });
 
   it('renders the module enable-toggle with exactly one toggle on the module row', () => {
-    renderModules([
-      {
-        enabled: true,
-        readOnly: false,
-        module: {
-          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
-        },
-      },
-    ]);
+    renderModules([vaultModule]);
     const moduleRow = getSetting('Vault');
     expect(moduleRow).toBeDefined();
     expect(moduleRow!.toggles).toHaveLength(1);
   });
 
   it('renders a dedicated Read-only sub-row with its own name, description and toggle', () => {
-    renderModules([
-      {
-        enabled: true,
-        readOnly: false,
-        module: {
-          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
-        },
-      },
-    ]);
+    renderModules([vaultModule]);
     const readOnlyRow = getSetting('Read-only');
     expect(readOnlyRow).toBeDefined();
     expect(readOnlyRow!.settingDesc.length).toBeGreaterThan(0);
@@ -559,19 +567,39 @@ describe('McpSettingsTab module rows read-only rendering', () => {
   });
 
   it('toggling the Read-only sub-row calls registry.setReadOnly', async () => {
-    const registry = renderModules([
-      {
-        enabled: true,
-        readOnly: false,
-        module: {
-          metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
-        },
-      },
-    ]);
+    const { registry } = renderModules([vaultModule]);
     const readOnlyRow = getSetting('Read-only')!;
     readOnlyRow.toggles[0].callback!(true);
     await vi.waitFor(() => {
       expect(registry.setReadOnly).toHaveBeenCalledWith('vault', true);
     });
+  });
+
+  it('wraps each module in its own .mcp-module-card container', () => {
+    const { container } = renderModules([
+      vaultModule,
+      {
+        enabled: false,
+        readOnly: false,
+        module: {
+          metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
+        },
+      },
+    ]);
+    const cards = findAllByClass(container, 'mcp-module-card');
+    expect(cards).toHaveLength(2);
+  });
+
+  it('places the module row and its Read-only sub-row inside the same card', () => {
+    const { container } = renderModules([vaultModule]);
+    const card = findAllByClass(container, 'mcp-module-card')[0];
+    expect(card).toBeDefined();
+    expect(getSetting('Vault')!.container).toBe(card);
+    expect(getSetting('Read-only')!.container).toBe(card);
+  });
+
+  it('marks the module header row with the mcp-module-card-header class', () => {
+    renderModules([vaultModule]);
+    expect(getSetting('Vault')!.settingClass).toContain('mcp-module-card-header');
   });
 });


### PR DESCRIPTION
## Summary

After #94, each module with `supportsReadOnly` rendered as two sibling `Setting` rows — the module row, followed by a "Read-only" sub-row. Even with an indent, the two rows looked visually indistinguishable from independent modules in the list, so "Read-only" read as yet another module rather than a sub-option of the module above it.

This PR wraps each module in a bordered, rounded `.mcp-module-card` container so the module header and its read-only sub-row are visibly enclosed together, making the parent/child relationship unambiguous.

## Changes

- `src/settings.ts`: `renderModuleToggles` creates a `mcp-module-card` div per module and renders both the enable row and the read-only sub-row inside it. The header row also gets a `mcp-module-card-header` class for font weight.
- `styles.css`: adds `.mcp-module-card` (border, rounded corners, padding, margin, secondary background), resets internal `.setting-item` top borders and restores a subtle divider between stacked rows inside the card, and bolds the header name.
- `tests/__mocks__/obsidian.ts`: `Setting` now records the container element passed to its constructor so tests can verify which card a setting belongs to.
- `tests/settings.test.ts`: existing Read-only tests still pass and are tightened; three new tests verify that (1) each module gets its own `.mcp-module-card`, (2) the module row and its Read-only sub-row share the same card container, and (3) the module header row carries the `mcp-module-card-header` class.

## Acceptance

- [x] Each module is visually enclosed in its own card
- [x] The Read-only toggle is clearly inside the same card as its parent module
- [x] No regression in toggle behaviour (enable/disable, read-only)
- [x] Tests cover the new card structure (274 passing, 3 new)
- [x] `npm run lint`, `npm run typecheck`, `npm test` all pass

Closes #96