### PR TITLE
refactor(settings): render MCP config as pre/code card instead of textarea

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -195,12 +195,8 @@ export class McpSettingsTab extends PluginSettingTab {
 
     const wrapper = containerEl.createDiv({ cls: 'mcp-config-preview' });
 
-    const textarea = wrapper.createEl('textarea', {
-      cls: 'mcp-config-textarea',
-    });
-    textarea.value = config;
-    textarea.rows = config.split('\n').length + 1;
-    textarea.spellcheck = false;
+    const pre = wrapper.createEl('pre', { cls: 'mcp-config-code' });
+    const code = pre.createEl('code', { text: config });
 
     const actions = wrapper.createDiv({ cls: 'mcp-config-actions' });
 
@@ -210,7 +206,7 @@ export class McpSettingsTab extends PluginSettingTab {
     });
     setIcon(copyBtn, 'copy');
     copyBtn.addEventListener('click', () => {
-      void navigator.clipboard.writeText(textarea.value).then(() => {
+      void navigator.clipboard.writeText(code.textContent ?? '').then(() => {
         setIcon(copyBtn, 'check');
         copyBtn.classList.add('mcp-config-btn--copied');
         setTimeout(() => {
@@ -226,9 +222,7 @@ export class McpSettingsTab extends PluginSettingTab {
     });
     setIcon(regenBtn, 'refresh-cw');
     regenBtn.addEventListener('click', () => {
-      const newConfig = this.buildMcpConfigJson();
-      textarea.value = newConfig;
-      textarea.rows = newConfig.split('\n').length + 1;
+      code.textContent = this.buildMcpConfigJson();
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2,30 +2,32 @@
   margin-bottom: 1em;
 }
 
-.mcp-config-textarea {
+.mcp-config-code {
   display: block;
   width: 100%;
+  margin: 0;
   padding: 12px;
   border-radius: 8px;
   background-color: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
+  box-sizing: border-box;
+  overflow-x: auto;
+}
+
+.mcp-config-code code {
   font-family: var(--font-monospace);
   font-size: var(--font-smaller);
   line-height: 1.5;
   color: var(--text-normal);
-  resize: vertical;
-  box-sizing: border-box;
   white-space: pre;
-  overflow-x: auto;
-}
-
-.mcp-config-textarea:focus {
-  border-color: var(--interactive-accent);
-  outline: none;
+  background: transparent;
+  padding: 0;
 }
 
 .mcp-config-actions {
   display: flex;
+  flex-direction: row;
+  align-items: center;
   gap: 4px;
   margin-top: 8px;
 }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -246,18 +246,19 @@ describe('McpSettingsTab MCP config display', () => {
     };
   }
 
-  it('should render a textarea with the MCP config JSON', () => {
+  it('should render a <pre><code> card with the MCP config JSON', () => {
     const { container } = renderWithTracking();
-    const textarea = findByClass(container, 'mcp-config-textarea');
-    expect(textarea).toBeDefined();
-    expect(textarea!.tagName).toBe('textarea');
-    expect(textarea!.value).toContain('"url"');
-    expect(textarea!.value).toContain('28741');
-    expect(textarea!.value).toContain('Bearer test-key-abc');
-    expect(textarea!.spellcheck).toBe(false);
+    const pre = findByClass(container, 'mcp-config-code');
+    expect(pre).toBeDefined();
+    expect(pre!.tagName).toBe('pre');
+    const code = pre!.children[0];
+    expect(code.tagName).toBe('code');
+    expect(code.textContent).toContain('"url"');
+    expect(code.textContent).toContain('28741');
+    expect(code.textContent).toContain('Bearer test-key-abc');
   });
 
-  it('should render Copy and Regenerate as icon buttons with tooltips', () => {
+  it('should render Copy and Regenerate as icon buttons on one line', () => {
     const { container } = renderWithTracking();
     const actions = findByClass(container, 'mcp-config-actions');
     expect(actions).toBeDefined();
@@ -274,36 +275,29 @@ describe('McpSettingsTab MCP config display', () => {
     expect(regenBtn._icon).toBe('refresh-cw');
   });
 
-  it('Regenerate button should update textarea with current settings', () => {
+  it('Regenerate button should update the code block with current settings', () => {
     const { container, plugin } = renderWithTracking();
-    const textarea = findByClass(container, 'mcp-config-textarea')!;
+    const code = findByClass(container, 'mcp-config-code')!.children[0];
     const actions = findByClass(container, 'mcp-config-actions')!;
     const regenBtn = actions.children[1];
 
-    expect(textarea.value).toContain('28741');
+    expect(code.textContent).toContain('28741');
 
     plugin.settings.port = 9999;
     plugin.settings.accessKey = 'new-key-xyz';
     regenBtn.handlers['click'][0]();
 
-    expect(textarea.value).toContain('9999');
-    expect(textarea.value).toContain('Bearer new-key-xyz');
-    expect(textarea.value).not.toContain('28741');
-  });
-
-  it('should set textarea rows based on config line count', () => {
-    const { container } = renderWithTracking();
-    const textarea = findByClass(container, 'mcp-config-textarea')!;
-    const lineCount = textarea.value.split('\n').length;
-    expect(textarea.rows).toBe(lineCount + 1);
+    expect(code.textContent).toContain('9999');
+    expect(code.textContent).toContain('Bearer new-key-xyz');
+    expect(code.textContent).not.toContain('28741');
   });
 
   it('should omit headers when access key is empty', () => {
     const { container } = renderWithTracking({ accessKey: '' });
-    const textarea = findByClass(container, 'mcp-config-textarea')!;
-    expect(textarea.value).toContain('"url"');
-    expect(textarea.value).not.toContain('Authorization');
-    expect(textarea.value).not.toContain('headers');
+    const code = findByClass(container, 'mcp-config-code')!.children[0];
+    expect(code.textContent).toContain('"url"');
+    expect(code.textContent).not.toContain('Authorization');
+    expect(code.textContent).not.toContain('headers');
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #104. The merged version uses a `<textarea>` for the read-only config block, which still looks editable (resize handle, focus ring). Replaces it with a `<pre><code>` card.

- Render the config as a `<pre class="mcp-config-code"><code>…</code></pre>` (rounded, padded, full-width, monospace, horizontal scroll on overflow).
- Drop textarea-specific styles (`resize`, focus border, `rows`/`spellcheck` JS).
- Copy reads `code.textContent`; Regenerate writes `code.textContent`.
- `Copy` and `Regenerate` icon buttons stay on a single flex row beneath the card.

## Files changed

- `src/settings.ts` — `renderMcpConfig()` builds pre/code; copy/regen handlers operate on `code.textContent`.
- `styles.css` — `.mcp-config-textarea` rules removed; new `.mcp-config-code` + `.mcp-config-code code` rules; `.mcp-config-actions` made an explicit `flex-direction: row`.
- `tests/settings.test.ts` — assertions updated to pre/code + textContent.

## Test plan

- [x] `npm test` (282 tests passing)
- [x] `npm run lint` (no new warnings/errors; only the 2 pre-existing warnings called out in CLAUDE.md)
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Visual check inside Obsidian (`npm run visual:before` on `main`, `npm run visual:after` on this branch — requires a working Docker daemon, can't run from the agent sandbox)