### PR TITLE
ci(e2e): wire capture-after + diff-baseline, drop missing compare service

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Build Docker image
         run: docker compose -f docker/docker-compose.yml build visual-test
 
-      - name: Run visual comparison
-        run: docker compose -f docker/docker-compose.yml run --rm compare
+      - name: Capture current screenshots
+        run: docker compose -f docker/docker-compose.yml run --rm capture-after
+
+      - name: Diff against baseline
+        run: docker compose -f docker/docker-compose.yml run --rm diff-baseline
 
       - name: Upload screenshots on failure
         if: failure()
@@ -43,7 +46,7 @@ jobs:
         with:
           name: visual-regression-screenshots
           path: |
-            docker/screenshots/current/
+            docker/screenshots/after/
             docker/screenshots/diff/
           retention-days: 30
 


### PR DESCRIPTION
## Summary

Fixes the `visual-regression` job in `.github/workflows/e2e.yml`, which referenced a non-existent `compare` compose service and never captured screenshots (see #107).

Implements **Option A** from the issue:
- Replace the broken `compare` step with two real services: `capture-after` then `diff-baseline`.
- Fix the failure-artifact path (`docker/screenshots/current/` → `docker/screenshots/after/`) to match what `capture-after` actually writes.

## Note on baseline images

`docker/screenshots/baseline/` is committed but currently only contains `.gitkeep`. The first CI run will pass trivially — `run_visual_test.py diff` skips any `after/*.png` with no matching baseline. To make the diff meaningful, run locally:

```
docker compose -f docker/docker-compose.yml run --rm capture-baseline
```

…and commit the resulting PNGs. That's the one-time, on-demand refresh step Option A describes.

## Test plan

- [ ] CI `E2E Tests` workflow runs to completion (no `no such service: compare`).
- [ ] `capture-after` produces `docker/screenshots/after/*.png`.
- [ ] `diff-baseline` exits 0 when there is no visual regression.
- [ ] On failure, `visual-regression-screenshots` artifact is non-empty.

Closes #107