### PR TITLE
feat!: remove per-module read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An Obsidian desktop plugin that runs an MCP (Model Context Protocol) server, exp
 - **Templates**: List, create from, and expand templates
 - **Plugin Interop**: List plugins, execute commands, Dataview/Templater integration
 - **Security**: Bearer token authentication, CORS, path traversal protection
-- **Dynamic module toggles**: Enable/disable feature categories, per-module read-only mode
+- **Dynamic module toggles**: Enable/disable feature categories with a single per-module switch
 
 ## Installation
 
@@ -71,7 +71,7 @@ claude mcp add obsidian --transport http --url http://127.0.0.1:28741 --header "
 | HTTPS | Off | Enable HTTPS with self-signed certificate |
 | Debug Mode | Off | Verbose logging of requests/responses |
 
-Feature modules can be individually enabled/disabled and set to read-only mode in the settings tab.
+Feature modules can be individually enabled or disabled in the settings tab. When a module is enabled, all of its tools are exposed.
 
 ## Commands
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -13,7 +13,7 @@ This Obsidian plugin runs an MCP (Model Context Protocol) server inside Obsidian
 
 ## Feature Categories
 
-Each category is a toggleable module. Modules self-register. The settings UI auto-discovers them. A "Refresh" button re-discovers modules without restarting Obsidian. Each category can be set to read-only where applicable.
+Each category is a toggleable module. Modules self-register. The settings UI auto-discovers them. A "Refresh" button re-discovers modules without restarting Obsidian. Toggling a module is all-or-nothing — when on, every tool the module ships is exposed.
 
 ### Vault and File Operations
 
@@ -115,7 +115,7 @@ Utility tools that do not mirror an Obsidian API. Modules in this group render u
 - ~~CR9~~ — ~~Toggle to enable/disable UI Interactions~~
 - ~~CR10~~ — ~~Toggle to enable/disable Templates and Content Generation~~
 - ~~CR11~~ — ~~Toggle to enable/disable Plugin Interop~~
-- **CR12** — Dynamic feature toggle system: modules self-register with metadata (name, description, tool list), settings UI auto-discovers and renders toggles, "Refresh" button to re-discover without restart. Includes per-module read-only mode where applicable. Replaces ~~CR5~~–~~CR11~~, consolidated into dynamic system.
+- **CR12** — Dynamic feature toggle system: modules self-register with metadata (name, description, tool list), settings UI auto-discovers and renders one enable/disable toggle per module, "Refresh" button to re-discover without restart. Replaces ~~CR5~~–~~CR11~~, consolidated into dynamic system. (Per-module read-only mode was removed in v4 settings — see schema migration.)
 
 ### Server Controls
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,17 +27,17 @@
 
 ## Feature Modules
 
-Each module can be individually enabled/disabled. Modules that support read-only mode can be restricted to only expose read operations.
+Each module can be individually enabled or disabled. When a module is enabled, all of its tools are exposed; there is no per-module read-only mode. Tools still advertise an `isReadOnly` hint in their MCP metadata so clients can present them appropriately.
 
-| Module | Tools | Read-Only Support |
-|--------|-------|-------------------|
-| Vault and File Operations | 16 | Yes |
-| Search and Metadata | 12 | No (all read-only) |
-| Editor Operations | 10 | Yes |
-| Workspace and Navigation | 5 | No |
-| UI Interactions | 3 | No |
-| Templates | 3 | Yes |
-| Plugin Interop | 5 | No |
+| Module | Tools |
+|--------|-------|
+| Vault and File Operations | 16 |
+| Search and Metadata | 12 |
+| Editor Operations | 10 |
+| Workspace and Navigation | 5 |
+| UI Interactions | 3 |
+| Templates | 3 |
+| Plugin Interop | 5 |
 
 ## Settings Persistence
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,8 +16,7 @@
 
 ## Feature Access Control
 
-- **Disable unused modules**: Only enable the feature categories you need
-- **Use read-only mode**: For modules that support it (Vault, Editor, Templates), enable read-only mode to prevent modifications
+- **Disable unused modules**: Only enable the feature categories you need. Each module is all-or-nothing — when enabled, every tool it ships is exposed.
 - **Principle of least privilege**: Start with minimal permissions and expand as needed
 
 ## Path Traversal Protection

--- a/src/registry/module-registry.ts
+++ b/src/registry/module-registry.ts
@@ -3,7 +3,7 @@ import { ModuleRegistration, ToolDefinition, ToolModule } from './types';
 
 export type ModuleStateMap = Record<
   string,
-  { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
+  { enabled: boolean; toolStates?: Record<string, boolean> }
 >;
 
 export type RegistryChangeHandler = () => void;
@@ -35,7 +35,6 @@ export class ModuleRegistry {
       // Extras modules are always "enabled" at the module level — individual
       // tools are gated by toolStates instead.
       enabled: isExtras ? true : (module.metadata.defaultEnabled ?? true),
-      readOnly: false,
       toolStates,
     });
     this.logger.info(`Registered module: ${module.metadata.name}`, { id });
@@ -69,19 +68,6 @@ export class ModuleRegistry {
     }
     registration.enabled = false;
     this.logger.info(`Disabled module: ${id}`);
-    this.notifyChange();
-  }
-
-  setReadOnly(id: string, readOnly: boolean): void {
-    const registration = this.modules.get(id);
-    if (!registration) {
-      throw new Error(`Module "${id}" is not registered`);
-    }
-    if (!registration.module.metadata.supportsReadOnly) {
-      throw new Error(`Module "${id}" does not support read-only mode`);
-    }
-    registration.readOnly = readOnly;
-    this.logger.info(`Set module "${id}" read-only: ${String(readOnly)}`);
     this.notifyChange();
   }
 
@@ -134,7 +120,6 @@ export class ModuleRegistry {
       const isExtras = registration.module.metadata.group === 'extras';
       const moduleTools = registration.module.tools();
       for (const tool of moduleTools) {
-        if (registration.readOnly && !tool.isReadOnly) continue;
         if (isExtras && !(registration.toolStates[tool.name] ?? false)) continue;
         tools.push(tool);
       }
@@ -163,9 +148,6 @@ export class ModuleRegistry {
         }
       } else {
         registration.enabled = moduleState.enabled;
-        if (registration.module.metadata.supportsReadOnly) {
-          registration.readOnly = moduleState.readOnly;
-        }
       }
     }
     this.notifyChange();
@@ -177,7 +159,6 @@ export class ModuleRegistry {
       const isExtras = registration.module.metadata.group === 'extras';
       state[id] = {
         enabled: registration.enabled,
-        readOnly: registration.readOnly,
         ...(isExtras ? { toolStates: { ...registration.toolStates } } : {}),
       };
     }

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -15,7 +15,6 @@ export interface ModuleMetadata {
   id: string;
   name: string;
   description: string;
-  supportsReadOnly: boolean;
   group?: ModuleGroup;
   defaultEnabled?: boolean;
 }
@@ -28,7 +27,6 @@ export interface ToolModule {
 export interface ModuleRegistration {
   module: ToolModule;
   enabled: boolean;
-  readOnly: boolean;
   /** Per-tool enabled state, keyed by tool name. Only used for modules in the 'extras' group. */
   toolStates: Record<string, boolean>;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -335,20 +335,6 @@ export class McpSettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }),
       );
-
-    if (metadata.supportsReadOnly) {
-      new Setting(card)
-        .setName('Read-only')
-        .setDesc('Expose only read tools for this module; hide mutating tools.')
-        .setClass('mcp-module-readonly-row')
-        .addToggle((toggle) =>
-          toggle.setValue(registration.readOnly).onChange(async (value) => {
-            this.plugin.registry.setReadOnly(metadata.id, value);
-            this.plugin.settings.moduleStates = this.plugin.registry.getState();
-            await this.plugin.saveSettings();
-          }),
-        );
-    }
   }
 }
 
@@ -394,13 +380,21 @@ export function migrateSettings(
 
   if ((data.schemaVersion as number) < 4) {
     data.schemaVersion = 4;
-    // V3 -> V4: extras moves from module-level enable to per-tool enable.
-    // Preserve behavior: if the extras module was previously enabled, enable
-    // its known tools; otherwise leave them off.
+    // V3 -> V4:
+    //   - drop per-module readOnly flag; keep only `enabled`
+    //   - extras moves from module-level enable to per-tool enable. Preserve
+    //     behavior: if the extras module was previously enabled, enable its
+    //     known tools; otherwise leave them off.
     const moduleStates = (data.moduleStates ?? {}) as Record<
       string,
       { enabled?: boolean; readOnly?: boolean; toolStates?: Record<string, boolean> }
     >;
+    for (const id of Object.keys(moduleStates)) {
+      const entry = moduleStates[id];
+      if (entry && typeof entry === 'object') {
+        delete entry.readOnly;
+      }
+    }
     const extras = moduleStates.extras;
     if (extras && extras.toolStates === undefined) {
       extras.toolStates = extras.enabled ? { get_date: true } : {};

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -70,7 +70,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
 export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
   const h = createHandlers(adapter);
   return {
-    metadata: { id: 'editor', name: 'Editor Operations', description: 'Access and manipulate the active editor', supportsReadOnly: true },
+    metadata: { id: 'editor', name: 'Editor Operations', description: 'Access and manipulate the active editor' },
     tools(): ToolDefinition[] {
       return [
         { name: 'editor_get_content', description: 'Get content of active editor', schema: {}, handler: h.getContent, isReadOnly: true },

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -53,7 +53,6 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
       id: 'extras',
       name: 'Extras',
       description: 'Utility tools that do not mirror an Obsidian API (disabled by default).',
-      supportsReadOnly: true,
       group: 'extras',
       defaultEnabled: false,
     },

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -51,7 +51,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
 export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule {
   const h = createHandlers(adapter);
   return {
-    metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater', supportsReadOnly: false },
+    metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater' },
     tools(): ToolDefinition[] {
       return [
         { name: 'plugin_list', description: 'List installed plugins with status', schema: {}, handler: h.listPlugins, isReadOnly: true },

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -16,7 +16,6 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
       id: 'search',
       name: 'Search and Metadata',
       description: 'Search vault contents and query file metadata, tags, links, and frontmatter',
-      supportsReadOnly: false,
     },
 
     tools(): ToolDefinition[] {

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -67,7 +67,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
 export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
   const h = createHandlers(adapter);
   return {
-    metadata: { id: 'templates', name: 'Templates and Content Generation', description: 'List, create from, and expand templates', supportsReadOnly: true },
+    metadata: { id: 'templates', name: 'Templates and Content Generation', description: 'List, create from, and expand templates' },
     tools(): ToolDefinition[] {
       return [
         { name: 'template_list', description: 'List available templates', schema: {}, handler: h.listTemplates, isReadOnly: true },

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -37,7 +37,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
 export function createUiModule(adapter: ObsidianAdapter): ToolModule {
   const h = createHandlers(adapter);
   return {
-    metadata: { id: 'ui', name: 'UI Interactions', description: 'Show notices, modals, and prompts in Obsidian', supportsReadOnly: false },
+    metadata: { id: 'ui', name: 'UI Interactions', description: 'Show notices, modals, and prompts in Obsidian' },
     tools(): ToolDefinition[] {
       return [
         { name: 'ui_notice', description: 'Show a notice/notification', schema: { message: z.string(), duration: z.number().optional() }, handler: h.showNotice, isReadOnly: false },

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -29,7 +29,6 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
       id: 'vault',
       name: 'Vault and File Operations',
       description: 'Create, read, update, delete, and manage files in the vault',
-      supportsReadOnly: true,
     },
 
     tools(): ToolDefinition[] {

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -41,7 +41,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
 export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
   const h = createHandlers(adapter);
   return {
-    metadata: { id: 'workspace', name: 'Workspace and Navigation', description: 'Manage panes, open files, and navigate the workspace', supportsReadOnly: false },
+    metadata: { id: 'workspace', name: 'Workspace and Navigation', description: 'Manage panes, open files, and navigate the workspace' },
     tools(): ToolDefinition[] {
       return [
         { name: 'workspace_get_active_leaf', description: 'Get active pane info', schema: {}, handler: h.getActiveLeaf, isReadOnly: true },

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export interface McpPluginSettings {
 
 export interface ModuleState {
   enabled: boolean;
-  readOnly: boolean;
   /** Per-tool enabled state, keyed by tool name. Only populated for modules in the 'extras' group. */
   toolStates?: Record<string, boolean>;
 }

--- a/styles.css
+++ b/styles.css
@@ -65,15 +65,6 @@
   border-top: none;
 }
 
-.mcp-module-card .setting-item + .setting-item {
-  border-top: 1px solid var(--background-modifier-border);
-}
-
 .mcp-module-card-header .setting-item-name {
   font-weight: 600;
-}
-
-.mcp-module-readonly-row {
-  padding-left: 2em;
-  border-top: none;
 }

--- a/tests/registry/module-registry.test.ts
+++ b/tests/registry/module-registry.test.ts
@@ -28,7 +28,6 @@ function createMockTool(name: string, isReadOnly: boolean): ToolDefinition {
 function createMockModule(
   id: string,
   tools: ToolDefinition[],
-  supportsReadOnly = false,
   defaultEnabled?: boolean,
 ): ToolModule {
   return {
@@ -36,7 +35,6 @@ function createMockModule(
       id,
       name: `Mock ${id}`,
       description: `Mock module: ${id}`,
-      supportsReadOnly,
       ...(defaultEnabled !== undefined ? { defaultEnabled } : {}),
     },
     tools: () => tools,
@@ -67,7 +65,7 @@ describe('ModuleRegistry', () => {
     });
 
     it('should honor defaultEnabled: false on registration', () => {
-      const module = createMockModule('extras', [], true, false);
+      const module = createMockModule('extras', [], false);
       registry.registerModule(module);
       expect(registry.isModuleEnabled('extras')).toBe(false);
     });
@@ -118,26 +116,6 @@ describe('ModuleRegistry', () => {
     });
   });
 
-  describe('setReadOnly', () => {
-    it('should set a module to read-only', () => {
-      const module = createMockModule('vault', [], true);
-      registry.registerModule(module);
-      registry.setReadOnly('vault', true);
-      const reg = registry.getModule('vault');
-      expect(reg?.readOnly).toBe(true);
-    });
-
-    it('should throw when module does not support read-only', () => {
-      const module = createMockModule('search', [], false);
-      registry.registerModule(module);
-      expect(() => registry.setReadOnly('search', true)).toThrow('does not support read-only');
-    });
-
-    it('should throw for non-existent module', () => {
-      expect(() => registry.setReadOnly('missing', true)).toThrow('not registered');
-    });
-  });
-
   describe('getActiveTools', () => {
     it('should return tools from enabled modules', () => {
       const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
@@ -153,21 +131,13 @@ describe('ModuleRegistry', () => {
       expect(registry.getActiveTools()).toHaveLength(0);
     });
 
-    it('should exclude write tools in read-only mode', () => {
+    it('should expose mutating tools from enabled modules regardless of isReadOnly metadata', () => {
       const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
-      const module = createMockModule('vault', tools, true);
+      const module = createMockModule('vault', tools);
       registry.registerModule(module);
-      registry.setReadOnly('vault', true);
       const active = registry.getActiveTools();
-      expect(active).toHaveLength(1);
-      expect(active[0].name).toBe('vault_read');
-    });
-
-    it('should include all tools when read-only is off', () => {
-      const tools = [createMockTool('vault_read', true), createMockTool('vault_create', false)];
-      const module = createMockModule('vault', tools, true);
-      registry.registerModule(module);
-      expect(registry.getActiveTools()).toHaveLength(2);
+      expect(active).toHaveLength(2);
+      expect(active.map((t) => t.name).sort()).toEqual(['vault_create', 'vault_read']);
     });
 
     it('should aggregate tools from multiple modules', () => {
@@ -183,26 +153,25 @@ describe('ModuleRegistry', () => {
 
   describe('applyState / getState', () => {
     it('should apply state from settings', () => {
-      const module = createMockModule('vault', [], true);
+      const module = createMockModule('vault', []);
       registry.registerModule(module);
       registry.applyState({
-        vault: { enabled: false, readOnly: true },
+        vault: { enabled: false },
       });
       expect(registry.isModuleEnabled('vault')).toBe(false);
-      expect(registry.getModule('vault')?.readOnly).toBe(true);
     });
 
     it('should ignore state for unregistered modules', () => {
-      registry.applyState({ missing: { enabled: false, readOnly: false } });
+      registry.applyState({ missing: { enabled: false } });
       expect(registry.getModules()).toHaveLength(0);
     });
 
     it('should return current state', () => {
-      const module = createMockModule('vault', [], true);
+      const module = createMockModule('vault', []);
       registry.registerModule(module);
       registry.disableModule('vault');
       const state = registry.getState();
-      expect(state.vault).toEqual({ enabled: false, readOnly: false });
+      expect(state.vault).toEqual({ enabled: false });
     });
   });
 
@@ -216,7 +185,6 @@ describe('ModuleRegistry', () => {
           id,
           name: `Mock ${id}`,
           description: `Mock extras: ${id}`,
-          supportsReadOnly: true,
           group: 'extras',
           defaultEnabled: false,
         },
@@ -298,7 +266,6 @@ describe('ModuleRegistry', () => {
       registry.applyState({
         extras: {
           enabled: true,
-          readOnly: false,
           toolStates: { get_date: true },
         },
       });
@@ -311,7 +278,7 @@ describe('ModuleRegistry', () => {
         createExtrasModule('extras', [createMockTool('get_date', true)]),
       );
       registry.applyState({
-        extras: { enabled: true, readOnly: false },
+        extras: { enabled: true },
       });
       expect(registry.isToolEnabled('extras', 'get_date')).toBe(false);
     });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -62,6 +62,28 @@ describe('migrateSettings', () => {
     expect(result.autoStart).toBe(false);
   });
 
+  it('should migrate v3 data to v4 by stripping per-module readOnly flags', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'test',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: false,
+      moduleStates: {
+        vault: { enabled: true, readOnly: true },
+        editor: { enabled: false, readOnly: false },
+      },
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(4);
+    expect(result.moduleStates).toEqual({
+      vault: { enabled: true },
+      editor: { enabled: false },
+    });
+  });
+
   it('should not modify data already at v4', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 4,
@@ -553,7 +575,7 @@ describe('McpSettingsTab server controls', () => {
   });
 });
 
-describe('McpSettingsTab module rows read-only rendering', () => {
+describe('McpSettingsTab module rows rendering', () => {
   type ToggleInfo = { value: boolean; tooltip: string; callback: ((value: boolean) => void) | null };
   type ModuleSettingInstance = {
     settingName: string;
@@ -571,14 +593,12 @@ describe('McpSettingsTab module rows read-only rendering', () => {
 
   interface ModuleRegistration {
     enabled: boolean;
-    readOnly: boolean;
     toolStates: Record<string, boolean>;
     module: {
       metadata: {
         id: string;
         name: string;
         description: string;
-        supportsReadOnly: boolean;
         group?: 'extras';
       };
       tools?: () => ToolEntry[];
@@ -589,7 +609,6 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     getModules: () => ModuleRegistration[];
     enableModule: ReturnType<typeof vi.fn>;
     disableModule: ReturnType<typeof vi.fn>;
-    setReadOnly: ReturnType<typeof vi.fn>;
     setToolEnabled: ReturnType<typeof vi.fn>;
     getState: () => Record<string, unknown>;
   } {
@@ -597,7 +616,6 @@ describe('McpSettingsTab module rows read-only rendering', () => {
       getModules: () => modules,
       enableModule: vi.fn(),
       disableModule: vi.fn(),
-      setReadOnly: vi.fn(),
       setToolEnabled: vi.fn(),
       getState: () => ({}),
     };
@@ -641,10 +659,9 @@ describe('McpSettingsTab module rows read-only rendering', () => {
 
   const vaultModule: ModuleRegistration = {
     enabled: true,
-    readOnly: false,
     toolStates: {},
     module: {
-      metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
+      metadata: { id: 'vault', name: 'Vault', description: 'Vault ops' },
     },
   };
 
@@ -659,36 +676,9 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     expect(moduleRow!.toggles).toHaveLength(1);
   });
 
-  it('renders a dedicated Read-only sub-row with its own name, description and toggle', () => {
+  it('does not render a Read-only sub-row for any module', () => {
     renderModules([vaultModule]);
-    const readOnlyRow = getSetting('Read-only');
-    expect(readOnlyRow).toBeDefined();
-    expect(readOnlyRow!.settingDesc.length).toBeGreaterThan(0);
-    expect(readOnlyRow!.toggles).toHaveLength(1);
-    expect(readOnlyRow!.settingClass).toContain('mcp-module-readonly-row');
-  });
-
-  it('does not render a Read-only sub-row for modules that do not support it', () => {
-    renderModules([
-      {
-        enabled: true,
-        readOnly: false,
-        toolStates: {},
-        module: {
-          metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
-        },
-      },
-    ]);
     expect(getSetting('Read-only')).toBeUndefined();
-  });
-
-  it('toggling the Read-only sub-row calls registry.setReadOnly', async () => {
-    const { registry } = renderModules([vaultModule]);
-    const readOnlyRow = getSetting('Read-only')!;
-    readOnlyRow.toggles[0].callback!(true);
-    await vi.waitFor(() => {
-      expect(registry.setReadOnly).toHaveBeenCalledWith('vault', true);
-    });
   });
 
   it('wraps each module in its own .mcp-module-card container', () => {
@@ -696,23 +686,14 @@ describe('McpSettingsTab module rows read-only rendering', () => {
       vaultModule,
       {
         enabled: false,
-        readOnly: false,
         toolStates: {},
         module: {
-          metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
+          metadata: { id: 'ui', name: 'UI', description: 'UI ops' },
         },
       },
     ]);
     const cards = findAllByClass(container, 'mcp-module-card');
     expect(cards).toHaveLength(2);
-  });
-
-  it('places the module row and its Read-only sub-row inside the same card', () => {
-    const { container } = renderModules([vaultModule]);
-    const card = findAllByClass(container, 'mcp-module-card')[0];
-    expect(card).toBeDefined();
-    expect(getSetting('Vault')!.container).toBe(card);
-    expect(getSetting('Read-only')!.container).toBe(card);
   });
 
   it('marks the module header row with the mcp-module-card-header class', () => {
@@ -723,14 +704,12 @@ describe('McpSettingsTab module rows read-only rendering', () => {
   describe('extras group per-tool rendering', () => {
     const extrasModule: ModuleRegistration = {
       enabled: true,
-      readOnly: false,
       toolStates: { get_date: false },
       module: {
         metadata: {
           id: 'extras',
           name: 'Extras',
           description: 'Utility tools',
-          supportsReadOnly: true,
           group: 'extras',
         },
         tools: () => [

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -15,7 +15,6 @@ describe('search module', () => {
     const adapter = new MockObsidianAdapter();
     const module = createSearchModule(adapter);
     expect(module.metadata.id).toBe('search');
-    expect(module.metadata.supportsReadOnly).toBe(false);
   });
 
   it('should register 12 tools', () => {

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -8,7 +8,6 @@ describe('vault module', () => {
     const module = createVaultModule(adapter);
     expect(module.metadata.id).toBe('vault');
     expect(module.metadata.name).toBe('Vault and File Operations');
-    expect(module.metadata.supportsReadOnly).toBe(true);
   });
 
   it('should register 16 tools', () => {


### PR DESCRIPTION
Each feature module now exposes a single enable/disable toggle. When a module is enabled, every tool it ships is registered. Tools still carry the `isReadOnly` hint in their MCP metadata so clients can present them appropriately, but the registry no longer filters by it.

Settings schema bumps to v4: existing v3 installs are migrated by stripping `readOnly` from each entry under `moduleStates`, leaving only `{ enabled }`.

BREAKING CHANGE: `ModuleState`, `ModuleRegistration`, and `ModuleStateMap` no longer have a `readOnly` field. `ModuleMetadata` no longer has `supportsReadOnly`. `ModuleRegistry.setReadOnly()` is removed.