### PR TITLE
Add per-tool enable/disable for extras group modules

### DIFF
--- a/src/registry/module-registry.ts
+++ b/src/registry/module-registry.ts
@@ -1,7 +1,10 @@
 import { Logger } from '../utils/logger';
 import { ModuleRegistration, ToolDefinition, ToolModule } from './types';
 
-export type ModuleStateMap = Record<string, { enabled: boolean; readOnly: boolean }>;
+export type ModuleStateMap = Record<
+  string,
+  { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
+>;
 
 export type RegistryChangeHandler = () => void;
 
@@ -20,10 +23,20 @@ export class ModuleRegistry {
       this.logger.warn(`Module "${id}" is already registered, skipping`);
       return;
     }
+    const isExtras = module.metadata.group === 'extras';
+    const toolStates: Record<string, boolean> = {};
+    if (isExtras) {
+      for (const tool of module.tools()) {
+        toolStates[tool.name] = false;
+      }
+    }
     this.modules.set(id, {
       module,
-      enabled: module.metadata.defaultEnabled ?? true,
+      // Extras modules are always "enabled" at the module level — individual
+      // tools are gated by toolStates instead.
+      enabled: isExtras ? true : (module.metadata.defaultEnabled ?? true),
       readOnly: false,
+      toolStates,
     });
     this.logger.info(`Registered module: ${module.metadata.name}`, { id });
     this.notifyChange();
@@ -72,6 +85,40 @@ export class ModuleRegistry {
     this.notifyChange();
   }
 
+  setToolEnabled(moduleId: string, toolName: string, enabled: boolean): void {
+    const registration = this.modules.get(moduleId);
+    if (!registration) {
+      throw new Error(`Module "${moduleId}" is not registered`);
+    }
+    if (registration.module.metadata.group !== 'extras') {
+      throw new Error(
+        `Module "${moduleId}" does not support per-tool enable/disable`,
+      );
+    }
+    const hasTool = registration.module
+      .tools()
+      .some((t) => t.name === toolName);
+    if (!hasTool) {
+      throw new Error(
+        `Tool "${toolName}" is not defined by module "${moduleId}"`,
+      );
+    }
+    registration.toolStates[toolName] = enabled;
+    this.logger.info(
+      `Set tool "${moduleId}/${toolName}" enabled: ${String(enabled)}`,
+    );
+    this.notifyChange();
+  }
+
+  isToolEnabled(moduleId: string, toolName: string): boolean {
+    const registration = this.modules.get(moduleId);
+    if (!registration) return false;
+    if (registration.module.metadata.group !== 'extras') {
+      return registration.enabled;
+    }
+    return registration.toolStates[toolName] ?? false;
+  }
+
   getModules(): ModuleRegistration[] {
     return Array.from(this.modules.values());
   }
@@ -84,9 +131,11 @@ export class ModuleRegistry {
     const tools: ToolDefinition[] = [];
     for (const registration of this.modules.values()) {
       if (!registration.enabled) continue;
+      const isExtras = registration.module.metadata.group === 'extras';
       const moduleTools = registration.module.tools();
       for (const tool of moduleTools) {
         if (registration.readOnly && !tool.isReadOnly) continue;
+        if (isExtras && !(registration.toolStates[tool.name] ?? false)) continue;
         tools.push(tool);
       }
     }
@@ -101,7 +150,18 @@ export class ModuleRegistry {
   applyState(state: ModuleStateMap): void {
     for (const [id, moduleState] of Object.entries(state)) {
       const registration = this.modules.get(id);
-      if (registration) {
+      if (!registration) continue;
+      const isExtras = registration.module.metadata.group === 'extras';
+      if (isExtras) {
+        // Extras: keep module-level enabled=true; honor per-tool state.
+        const toolNames = new Set(
+          registration.module.tools().map((t) => t.name),
+        );
+        const incoming = moduleState.toolStates ?? {};
+        for (const name of toolNames) {
+          registration.toolStates[name] = incoming[name] ?? false;
+        }
+      } else {
         registration.enabled = moduleState.enabled;
         if (registration.module.metadata.supportsReadOnly) {
           registration.readOnly = moduleState.readOnly;
@@ -114,9 +174,11 @@ export class ModuleRegistry {
   getState(): ModuleStateMap {
     const state: ModuleStateMap = {};
     for (const [id, registration] of this.modules.entries()) {
+      const isExtras = registration.module.metadata.group === 'extras';
       state[id] = {
         enabled: registration.enabled,
         readOnly: registration.readOnly,
+        ...(isExtras ? { toolStates: { ...registration.toolStates } } : {}),
       };
     }
     return state;

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -29,4 +29,6 @@ export interface ModuleRegistration {
   module: ToolModule;
   enabled: boolean;
   readOnly: boolean;
+  /** Per-tool enabled state, keyed by tool name. Only used for modules in the 'extras' group. */
+  toolStates: Record<string, boolean>;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -275,7 +275,7 @@ export class McpSettingsTab extends PluginSettingTab {
         cls: 'setting-item-description',
       });
       for (const registration of extrasModules) {
-        this.renderModuleRow(containerEl, registration);
+        this.renderExtrasToolRows(containerEl, registration);
       }
     }
 
@@ -285,6 +285,31 @@ export class McpSettingsTab extends PluginSettingTab {
         this.display();
       }),
     );
+  }
+
+  private renderExtrasToolRows(
+    containerEl: HTMLElement,
+    registration: ModuleRegistration,
+  ): void {
+    const moduleId = registration.module.metadata.id;
+    const tools = registration.module.tools();
+
+    for (const tool of tools) {
+      const card = containerEl.createDiv({ cls: 'mcp-module-card' });
+      new Setting(card)
+        .setName(tool.name)
+        .setDesc(tool.description)
+        .setClass('mcp-module-card-header')
+        .addToggle((toggle) =>
+          toggle
+            .setValue(registration.toolStates[tool.name] ?? false)
+            .onChange(async (value) => {
+              this.plugin.registry.setToolEnabled(moduleId, tool.name, value);
+              this.plugin.settings.moduleStates = this.plugin.registry.getState();
+              await this.plugin.saveSettings();
+            }),
+        );
+    }
   }
 
   private renderModuleRow(
@@ -365,6 +390,22 @@ export function migrateSettings(
     data.schemaVersion = 3;
     // V2 -> V3: add autoStart, default off for existing installs (explicit opt-in)
     if (data.autoStart === undefined) data.autoStart = false;
+  }
+
+  if ((data.schemaVersion as number) < 4) {
+    data.schemaVersion = 4;
+    // V3 -> V4: extras moves from module-level enable to per-tool enable.
+    // Preserve behavior: if the extras module was previously enabled, enable
+    // its known tools; otherwise leave them off.
+    const moduleStates = (data.moduleStates ?? {}) as Record<
+      string,
+      { enabled?: boolean; readOnly?: boolean; toolStates?: Record<string, boolean> }
+    >;
+    const extras = moduleStates.extras;
+    if (extras && extras.toolStates === undefined) {
+      extras.toolStates = extras.enabled ? { get_date: true } : {};
+    }
+    data.moduleStates = moduleStates;
   }
 
   return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,10 +20,12 @@ export interface McpPluginSettings {
 export interface ModuleState {
   enabled: boolean;
   readOnly: boolean;
+  /** Per-tool enabled state, keyed by tool name. Only populated for modules in the 'extras' group. */
+  toolStates?: Record<string, boolean>;
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 3,
+  schemaVersion: 4,
   serverAddress: '127.0.0.1',
   port: 28741,
   accessKey: '',

--- a/tests/registry/module-registry.test.ts
+++ b/tests/registry/module-registry.test.ts
@@ -206,6 +206,117 @@ describe('ModuleRegistry', () => {
     });
   });
 
+  describe('extras group per-tool toggles', () => {
+    function createExtrasModule(
+      id: string,
+      tools: ToolDefinition[],
+    ): ToolModule {
+      return {
+        metadata: {
+          id,
+          name: `Mock ${id}`,
+          description: `Mock extras: ${id}`,
+          supportsReadOnly: true,
+          group: 'extras',
+          defaultEnabled: false,
+        },
+        tools: () => tools,
+      };
+    }
+
+    it('initializes tool states to disabled on registration', () => {
+      const mod = createExtrasModule('extras', [
+        createMockTool('get_date', true),
+      ]);
+      registry.registerModule(mod);
+      expect(registry.isToolEnabled('extras', 'get_date')).toBe(false);
+    });
+
+    it('setToolEnabled toggles a single tool', () => {
+      const mod = createExtrasModule('extras', [
+        createMockTool('get_date', true),
+        createMockTool('get_uuid', true),
+      ]);
+      registry.registerModule(mod);
+      registry.setToolEnabled('extras', 'get_date', true);
+      expect(registry.isToolEnabled('extras', 'get_date')).toBe(true);
+      expect(registry.isToolEnabled('extras', 'get_uuid')).toBe(false);
+    });
+
+    it('setToolEnabled throws for non-extras modules', () => {
+      registry.registerModule(
+        createMockModule('vault', [createMockTool('vault_read', true)]),
+      );
+      expect(() =>
+        registry.setToolEnabled('vault', 'vault_read', true),
+      ).toThrow('does not support per-tool');
+    });
+
+    it('setToolEnabled throws for unknown tool names', () => {
+      registry.registerModule(
+        createExtrasModule('extras', [createMockTool('get_date', true)]),
+      );
+      expect(() =>
+        registry.setToolEnabled('extras', 'nope', true),
+      ).toThrow('is not defined by');
+    });
+
+    it('getActiveTools excludes disabled extras tools', () => {
+      const mod = createExtrasModule('extras', [
+        createMockTool('get_date', true),
+        createMockTool('get_uuid', true),
+      ]);
+      registry.registerModule(mod);
+      registry.setToolEnabled('extras', 'get_date', true);
+      const active = registry.getActiveTools();
+      expect(active.map((t) => t.name)).toEqual(['get_date']);
+    });
+
+    it('getActiveTools returns nothing when no extras tool is enabled', () => {
+      registry.registerModule(
+        createExtrasModule('extras', [createMockTool('get_date', true)]),
+      );
+      expect(registry.getActiveTools()).toHaveLength(0);
+    });
+
+    it('getState includes per-tool states for extras', () => {
+      registry.registerModule(
+        createExtrasModule('extras', [createMockTool('get_date', true)]),
+      );
+      registry.setToolEnabled('extras', 'get_date', true);
+      const state = registry.getState();
+      expect(state.extras.toolStates).toEqual({ get_date: true });
+    });
+
+    it('applyState restores per-tool states', () => {
+      registry.registerModule(
+        createExtrasModule('extras', [
+          createMockTool('get_date', true),
+          createMockTool('get_uuid', true),
+        ]),
+      );
+      registry.applyState({
+        extras: {
+          enabled: true,
+          readOnly: false,
+          toolStates: { get_date: true },
+        },
+      });
+      expect(registry.isToolEnabled('extras', 'get_date')).toBe(true);
+      expect(registry.isToolEnabled('extras', 'get_uuid')).toBe(false);
+    });
+
+    it('applyState without toolStates leaves extras tools disabled', () => {
+      registry.registerModule(
+        createExtrasModule('extras', [createMockTool('get_date', true)]),
+      );
+      registry.applyState({
+        extras: { enabled: true, readOnly: false },
+      });
+      expect(registry.isToolEnabled('extras', 'get_date')).toBe(false);
+    });
+  });
+
   describe('onChange', () => {
     it('should notify on module registration', () => {
       const handler = vi.fn();

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4,10 +4,10 @@ import { migrateSettings, generateAccessKey, isValidIPv4, McpSettingsTab } from 
 import { DEFAULT_SETTINGS } from '../src/types';
 
 describe('migrateSettings', () => {
-  it('should migrate v0 (no schemaVersion) to v3', () => {
+  it('should migrate v0 (no schemaVersion) to v4', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(3);
+    expect(result.schemaVersion).toBe(4);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -24,7 +24,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(3);
+    expect(result.schemaVersion).toBe(4);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -32,7 +32,7 @@ describe('migrateSettings', () => {
     expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v1 data to v3 by adding serverAddress and autoStart', () => {
+  it('should migrate v1 data to v4 by adding serverAddress and autoStart', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 1,
       port: 28741,
@@ -42,12 +42,12 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(3);
+    expect(result.schemaVersion).toBe(4);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v2 data to v3 by adding autoStart=false', () => {
+  it('should migrate v2 data to v4 by adding autoStart=false', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 2,
       serverAddress: '192.168.1.100',
@@ -58,13 +58,13 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(3);
+    expect(result.schemaVersion).toBe(4);
     expect(result.autoStart).toBe(false);
   });
 
-  it('should not modify data already at v3', () => {
+  it('should not modify data already at v4', () => {
     const data: Record<string, unknown> = {
-      schemaVersion: 3,
+      schemaVersion: 4,
       serverAddress: '192.168.1.100',
       port: 28741,
       accessKey: 'test',
@@ -82,12 +82,67 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(3);
+    expect(result.schemaVersion).toBe(4);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
+  });
+
+  it('should migrate v3 extras state to per-tool states (enabled -> get_date on)', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'k',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: false,
+      moduleStates: { extras: { enabled: true, readOnly: false } },
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(4);
+    const states = result.moduleStates as Record<
+      string,
+      { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
+    >;
+    expect(states.extras.toolStates).toEqual({ get_date: true });
+  });
+
+  it('should migrate v3 extras state to per-tool states (disabled -> empty)', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 3,
+      moduleStates: { extras: { enabled: false, readOnly: false } },
+    };
+    const result = migrateSettings(data);
+    const states = result.moduleStates as Record<
+      string,
+      { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
+    >;
+    expect(states.extras.toolStates).toEqual({});
+  });
+
+  it('should leave existing v4 toolStates untouched', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 4,
+      moduleStates: {
+        extras: {
+          enabled: true,
+          readOnly: false,
+          toolStates: { get_date: true, something_else: false },
+        },
+      },
+    };
+    const result = migrateSettings(data);
+    const states = result.moduleStates as Record<
+      string,
+      { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
+    >;
+    expect(states.extras.toolStates).toEqual({
+      get_date: true,
+      something_else: false,
+    });
   });
 });
 
@@ -508,16 +563,25 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     toggles: ToggleInfo[];
   };
 
+  interface ToolEntry {
+    name: string;
+    description: string;
+    isReadOnly: boolean;
+  }
+
   interface ModuleRegistration {
     enabled: boolean;
     readOnly: boolean;
+    toolStates: Record<string, boolean>;
     module: {
       metadata: {
         id: string;
         name: string;
         description: string;
         supportsReadOnly: boolean;
+        group?: 'extras';
       };
+      tools?: () => ToolEntry[];
     };
   }
 
@@ -526,6 +590,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
     enableModule: ReturnType<typeof vi.fn>;
     disableModule: ReturnType<typeof vi.fn>;
     setReadOnly: ReturnType<typeof vi.fn>;
+    setToolEnabled: ReturnType<typeof vi.fn>;
     getState: () => Record<string, unknown>;
   } {
     return {
@@ -533,6 +598,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
       enableModule: vi.fn(),
       disableModule: vi.fn(),
       setReadOnly: vi.fn(),
+      setToolEnabled: vi.fn(),
       getState: () => ({}),
     };
   }
@@ -576,6 +642,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
   const vaultModule: ModuleRegistration = {
     enabled: true,
     readOnly: false,
+    toolStates: {},
     module: {
       metadata: { id: 'vault', name: 'Vault', description: 'Vault ops', supportsReadOnly: true },
     },
@@ -606,6 +673,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
       {
         enabled: true,
         readOnly: false,
+        toolStates: {},
         module: {
           metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
         },
@@ -629,6 +697,7 @@ describe('McpSettingsTab module rows read-only rendering', () => {
       {
         enabled: false,
         readOnly: false,
+        toolStates: {},
         module: {
           metadata: { id: 'ui', name: 'UI', description: 'UI ops', supportsReadOnly: false },
         },
@@ -649,5 +718,81 @@ describe('McpSettingsTab module rows read-only rendering', () => {
   it('marks the module header row with the mcp-module-card-header class', () => {
     renderModules([vaultModule]);
     expect(getSetting('Vault')!.settingClass).toContain('mcp-module-card-header');
+  });
+
+  describe('extras group per-tool rendering', () => {
+    const extrasModule: ModuleRegistration = {
+      enabled: true,
+      readOnly: false,
+      toolStates: { get_date: false },
+      module: {
+        metadata: {
+          id: 'extras',
+          name: 'Extras',
+          description: 'Utility tools',
+          supportsReadOnly: true,
+          group: 'extras',
+        },
+        tools: () => [
+          { name: 'get_date', description: 'Get the current date', isReadOnly: true },
+        ],
+      },
+    };
+
+    it('renders one toggle row per extras tool (not a module-level row)', () => {
+      renderModules([extrasModule]);
+      expect(getSetting('get_date')).toBeDefined();
+      expect(getSetting('Extras')).toBeUndefined();
+    });
+
+    it('uses the tool description on the per-tool row', () => {
+      renderModules([extrasModule]);
+      const row = getSetting('get_date')!;
+      expect(row.settingDesc).toBe('Get the current date');
+    });
+
+    it('does not render a Read-only sub-row for the extras group', () => {
+      renderModules([extrasModule]);
+      expect(getSetting('Read-only')).toBeUndefined();
+    });
+
+    it('reflects the stored per-tool state in the toggle value', () => {
+      const mod: ModuleRegistration = {
+        ...extrasModule,
+        toolStates: { get_date: true },
+      };
+      renderModules([mod]);
+      expect(getSetting('get_date')!.toggles[0].value).toBe(true);
+    });
+
+    it('toggling a tool row calls registry.setToolEnabled', async () => {
+      const { registry } = renderModules([extrasModule]);
+      const row = getSetting('get_date')!;
+      row.toggles[0].callback!(true);
+      await vi.waitFor(() => {
+        expect(registry.setToolEnabled).toHaveBeenCalledWith(
+          'extras',
+          'get_date',
+          true,
+        );
+      });
+    });
+
+    it('renders one card per tool', () => {
+      const two: ModuleRegistration = {
+        ...extrasModule,
+        toolStates: { get_date: false, get_uuid: false },
+        module: {
+          ...extrasModule.module,
+          tools: () => [
+            { name: 'get_date', description: 'd1', isReadOnly: true },
+            { name: 'get_uuid', description: 'd2', isReadOnly: true },
+          ],
+        },
+      };
+      const { container } = renderModules([two]);
+      const cards = findAllByClass(container, 'mcp-module-card');
+      expect(cards).toHaveLength(2);
+    });
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 3', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(3);
+  it('should have schema version 4', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(4);
   });
 
   it('should have default server address 127.0.0.1', () => {


### PR DESCRIPTION
## Summary
This PR introduces per-tool granular control for modules in the 'extras' group, allowing individual tools within extras to be enabled/disabled independently rather than as a single module unit. It also bumps the settings schema version from 3 to 4 with appropriate migration logic.

## Key Changes

- **Schema Version Bump (v3 → v4)**: Updated `DEFAULT_SETTINGS.schemaVersion` to 4 and added migration logic to convert v3 extras module state to per-tool state (preserving previous enabled/disabled behavior)

- **ModuleRegistry Enhancements**:
  - Added `toolStates` field to track per-tool enabled state for extras modules
  - Implemented `setToolEnabled(moduleId, toolName, enabled)` to toggle individual tools
  - Implemented `isToolEnabled(moduleId, toolName)` to query tool state
  - Modified `getActiveTools()` to filter out disabled extras tools
  - Updated `applyState()` and `getState()` to handle per-tool state persistence
  - Extras modules are now always "enabled" at the module level; individual tools are gated by `toolStates`

- **Settings UI Updates**:
  - Added `renderExtrasToolRows()` method to render one toggle card per tool instead of a single module card
  - Extras modules now display individual tool toggles with tool-specific descriptions
  - Tool toggles call `registry.setToolEnabled()` and persist state

- **Type Updates**:
  - Extended `ModuleState` interface with optional `toolStates` field
  - Extended `ModuleRegistration` interface with `toolStates` field
  - Updated `ModuleStateMap` type to include `toolStates`

- **Test Coverage**: Added comprehensive tests for per-tool state management, migration, and UI rendering

## Implementation Details

- Extras modules initialize all tools with `toolStates[toolName] = false` on registration
- The migration from v3 to v4 preserves behavior: if extras was previously enabled, `get_date` tool is enabled; otherwise all tools remain disabled
- Non-extras modules continue to work as before with module-level enable/disable
- The extras group is identified via `module.metadata.group === 'extras'`

https://claude.ai/code/session_01XUDEXmaMfmwBNarSxjVvbV