### PR TITLE
fix(ci): upload plugin assets before screenshot pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,20 @@ jobs:
             fs.writeFileSync('versions.json', JSON.stringify(versions, null, '\t') + '\n');
           "
 
+      - name: Upload plugin release assets
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.release.outputs.tag_name }} \
+            main.js \
+            manifest.json \
+            styles.css \
+            versions.json
+
       - name: Install screenshot system deps
         if: ${{ steps.release.outputs.release_created }}
+        continue-on-error: true
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -62,10 +74,12 @@ jobs:
 
       - name: Install websocket-client
         if: ${{ steps.release.outputs.release_created }}
+        continue-on-error: true
         run: pip install websocket-client
 
       - name: Download Obsidian AppImage
         if: ${{ steps.release.outputs.release_created }}
+        continue-on-error: true
         run: |
           sudo mkdir -p /opt
           sudo wget -q \
@@ -76,7 +90,9 @@ jobs:
           sudo ln -sf /opt/squashfs-root/obsidian /usr/local/bin/obsidian
 
       - name: Capture release screenshots
+        id: screenshots
         if: ${{ steps.release.outputs.release_created }}
+        continue-on-error: true
         run: |
           export DISPLAY=:99
           Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset \
@@ -106,22 +122,20 @@ jobs:
           python3 docker/scripts/release_screenshots.py \
             --out-dir /tmp/shots --port 9222
 
-      - name: Upload release assets
-        if: ${{ steps.release.outputs.release_created }}
+      - name: Upload screenshot release assets
+        if: ${{ steps.release.outputs.release_created && steps.screenshots.outcome == 'success' }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ steps.release.outputs.tag_name }} \
-            main.js \
-            manifest.json \
-            styles.css \
-            versions.json \
             /tmp/shots/release-main.png \
             /tmp/shots/release-plugin-settings.png \
             /tmp/shots/release-server-running.png
 
       - name: Append Screenshots section to release notes
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created && steps.screenshots.outcome == 'success' }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Fixes the race / crash that shipped v2.0.0 with zero release assets (see #119).

`release-please-action` publishes the GitHub release synchronously at tag-creation time, then the rest of `release.yml` (build → screenshot capture → `gh release upload`) runs afterwards. Any crash between tag-creation and the upload step left the published release with no `main.js` / `manifest.json` / `styles.css` / `versions.json` attached, breaking BRAT installs and the community plugins flow. That's exactly what happened on v2.0.0 — the job crashed during the screenshot capture phase and never reached the single unified upload step.

This PR:

- **Splits the upload step in two.** Plugin assets (`main.js`, `manifest.json`, `styles.css`, `versions.json`) are now uploaded immediately after `Build` + `Update versions.json`, well before the slow and failure-prone Xvfb + Obsidian AppImage + CDP screenshot pipeline. The race window shrinks from ~5–7 minutes to ~30–60 seconds.
- **Makes the screenshot pipeline best-effort.** Every screenshot-related step (`apt-get` system deps, `pip install websocket-client`, Obsidian AppImage download, `Capture release screenshots`) now has `continue-on-error: true`. A crash anywhere in that pipeline no longer aborts the job — plugin files stay uploaded and the release remains installable.
- **Gates screenshot-dependent steps on capture success.** The new `Upload screenshot release assets` step and the `Append Screenshots section to release notes` step are both gated on `steps.screenshots.outcome == 'success'`, so we don't upload missing PNGs or rewrite release notes with image links that would 404.

## Test plan

- [ ] CI passes on this PR
- [ ] Next release (cut by release-please after merge) has `main.js`, `manifest.json`, `styles.css`, `versions.json` attached
- [ ] If the screenshot pipeline fails, the job still succeeds and the plugin assets are still attached (release body simply has no `## Screenshots` section)
- [ ] If the screenshot pipeline succeeds, the three PNGs are attached and the release body ends with the `## Screenshots` section as before

## Notes

- v2.0.0 stays broken and will be deleted manually.
- A future hardening could move the release to a `draft: true` in `release-please-config.json` and flip it to published only after all uploads finish — that would close the residual ~30–60s window entirely. Not done here to keep this PR focused on the crash.

Closes #119