### PR TITLE
fix(settings): render extras as a flat group

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -270,10 +270,6 @@ export class McpSettingsTab extends PluginSettingTab {
 
     if (extrasModules.length > 0) {
       containerEl.createEl('h2', { text: 'Extras' });
-      containerEl.createEl('p', {
-        text: 'Utility tools that do not mirror an Obsidian API. Disabled by default — enable individually as needed.',
-        cls: 'setting-item-description',
-      });
       for (const registration of extrasModules) {
         this.renderExtrasToolRows(containerEl, registration);
       }
@@ -295,11 +291,9 @@ export class McpSettingsTab extends PluginSettingTab {
     const tools = registration.module.tools();
 
     for (const tool of tools) {
-      const card = containerEl.createDiv({ cls: 'mcp-module-card' });
-      new Setting(card)
+      new Setting(containerEl)
         .setName(tool.name)
         .setDesc(tool.description)
-        .setClass('mcp-module-card-header')
         .addToggle((toggle) =>
           toggle
             .setValue(registration.toolStates[tool.name] ?? false)

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -757,7 +757,7 @@ describe('McpSettingsTab module rows rendering', () => {
       });
     });
 
-    it('renders one card per tool', () => {
+    it('renders one flat row per tool with no mcp-module-card wrapper', () => {
       const two: ModuleRegistration = {
         ...extrasModule,
         toolStates: { get_date: false, get_uuid: false },
@@ -769,9 +769,29 @@ describe('McpSettingsTab module rows rendering', () => {
           ],
         },
       };
-      const { container } = renderModules([two]);
+      renderModules([two]);
+      expect(getSetting('get_date')).toBeDefined();
+      expect(getSetting('get_uuid')).toBeDefined();
+      expect(getSetting('get_date')!.settingClass).not.toContain(
+        'mcp-module-card-header',
+      );
+      expect(getSetting('get_uuid')!.settingClass).not.toContain(
+        'mcp-module-card-header',
+      );
+    });
+
+    it('does not wrap extras tool rows in a .mcp-module-card container', () => {
+      // When only an extras module is present, no module cards should be
+      // created (cards are reserved for core module rows).
+      const { container } = renderModules([extrasModule]);
       const cards = findAllByClass(container, 'mcp-module-card');
-      expect(cards).toHaveLength(2);
+      expect(cards).toHaveLength(0);
+    });
+
+    it('defaults the get_date toggle to off on a fresh install', () => {
+      // Fresh install: registry initialises toolStates[get_date] = false
+      renderModules([extrasModule]);
+      expect(getSetting('get_date')!.toggles[0].value).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- The "Extras" section in the plugin's Settings tab rendered an `<h2>` heading, a description paragraph, and then each extras tool wrapped in its own `.mcp-module-card` container — producing a nested "extras-within-extras" look (a category inside a category).
- Make "Extras" behave like the other settings groups: a single `<h2>` heading followed by one flat `Setting` row per tool (name + description on the left, on/off toggle on the right). No card wrapper, no redundant group-level description paragraph.
- Rendering-only change — registry, settings model, migration, and per-tool state are untouched. `get_date` still defaults to **off** on a fresh install.

Target layout:

```
--------- Extras ------------------------------------------
| get_date (explaining)             - On/Off Toggle -    |
-----------------------------------------------------------
```

Closes #120

## Test plan

- [x] `npm test` — 296/296 passing (added 2 new extras rendering tests: no `.mcp-module-card` wrapper, toggle defaults to off)
- [x] `npm run lint` — 0 errors (only pre-existing warnings about return types in `tests/settings.test.ts`)
- [x] `npm run typecheck` — clean
- [x] Before/after screenshots captured on the host screenshot pipeline and attached to the PR thread for visual diff
- [ ] CI green