### PR TITLE
feat(server): wire up HTTPS with cached self-signed certificate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,12 @@
 
 ### HTTPS (`httpsEnabled`)
 - **Default**: `false`
-- **Description**: Enable HTTPS with a locally generated self-signed certificate
+- **Description**: Enable HTTPS with a locally generated self-signed certificate. The certificate is generated on first server start and cached in plugin data; MCP clients must trust it explicitly (or disable certificate verification). Requires a server restart after toggling.
+- **Regenerate**: Click the refresh button on the "TLS Certificate" row in settings to produce a fresh certificate (e.g. after changing the server address). Existing clients will need to re-trust the new certificate.
+
+### TLS Certificate (`tlsCertificate`)
+- **Default**: `null`
+- **Description**: Cached self-signed certificate and private key (PEM) used when HTTPS is enabled. Generated automatically; regenerated on demand via the settings UI. Included in `data.json` — treat it like the access key.
 
 ### Debug Mode (`debugMode`)
 - **Default**: `false`

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,7 +12,11 @@
 - **Localhost by default**: The server binds to `127.0.0.1` by default — it's not accessible from other machines. This can be changed in settings via the **Server Address** option.
 - **Binding to `0.0.0.0`**: Exposes the server on all network interfaces. Only do this if you understand the security implications and have an access key configured.
 - **Firewall**: If running on a shared machine or binding to a non-localhost address, ensure your firewall blocks the MCP port from unauthorized access
-- **HTTPS**: Enable HTTPS for encrypted communication, especially when binding to a non-localhost address
+- **HTTPS**: Enable HTTPS for encrypted communication, especially when binding to a non-localhost address. The plugin generates and caches a self-signed certificate; clients must explicitly trust it (e.g. Node clients need `--cafile` or the `ca` option, curl `--cacert`). Since the certificate is locally issued it cannot be verified against a public CA.
+
+## TLS Certificate
+
+When HTTPS is enabled, a self-signed RSA-2048 certificate (SHA-256, 365-day validity) is generated on first start and cached in `data.json`. The subject alternative name list includes `localhost`, `127.0.0.1`, `::1`, and the configured server address. Use the **Regenerate certificate** button in settings if you rotate the server address or want a fresh key pair; clients that previously trusted the old certificate must re-trust the new one.
 
 ## Feature Access Control
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "obsidian": "^1.7.2",
+        "selfsigned": "^5.5.0",
         "zod": "^4.3.0"
       },
       "devDependencies": {
@@ -836,6 +837,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -844,6 +857,154 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1640,6 +1801,20 @@
         }
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1729,6 +1904,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3475,6 +3659,23 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -3553,6 +3754,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
@@ -3591,6 +3810,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -3656,6 +3881,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3944,9 +4182,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,19 +23,20 @@
   "author": "KingOfKalk",
   "license": "GPL-3.0-only",
   "devDependencies": {
-    "typescript-eslint": "^8.0.0",
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "builtin-modules": "^5.1.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.2.0",
     "prettier": "^3.4.0",
     "typescript": "^6.0.0",
-    "vitest": "^4.1.0",
-    "@vitest/coverage-v8": "^4.1.0",
-    "@types/node": "^25.6.0"
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "obsidian": "^1.7.2",
+    "selfsigned": "^5.5.0",
     "zod": "^4.3.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import { Notice, Plugin } from 'obsidian';
-import { DEFAULT_SETTINGS, McpPluginSettings } from './types';
+import { DEFAULT_SETTINGS, McpPluginSettings, TlsCertificateData } from './types';
 import { createLogger, Logger } from './utils/logger';
 import { ModuleRegistry } from './registry/module-registry';
 import { createMcpServer } from './server/mcp-server';
 import { HttpMcpServer } from './server/http-server';
+import { generateSelfSignedCert } from './server/tls';
 import { RealObsidianAdapter, ObsidianAdapter } from './obsidian/adapter';
 import { discoverModules } from './tools';
 import { McpSettingsTab, migrateSettings } from './settings';
@@ -105,6 +106,10 @@ export default class McpPlugin extends Plugin {
 
   async startServer(): Promise<void> {
     try {
+      const tls = this.settings.httpsEnabled
+        ? await this.ensureTlsCertificate()
+        : undefined;
+
       this.httpServer = new HttpMcpServer(
         () => createMcpServer(this.registry, this.logger),
         this.logger,
@@ -112,6 +117,7 @@ export default class McpPlugin extends Plugin {
           host: this.settings.serverAddress,
           port: this.settings.port,
           accessKey: this.settings.accessKey,
+          tls,
         },
       );
       await this.httpServer.start();
@@ -122,6 +128,25 @@ export default class McpPlugin extends Plugin {
       this.logger.error(`Failed to start MCP server: ${message}`);
       new Notice(`Failed to start MCP server: ${message}`);
     }
+  }
+
+  async regenerateTlsCertificate(): Promise<void> {
+    this.settings.tlsCertificate = null;
+    await this.saveSettings();
+    await this.ensureTlsCertificate();
+  }
+
+  private async ensureTlsCertificate(): Promise<TlsCertificateData> {
+    if (this.settings.tlsCertificate) {
+      return this.settings.tlsCertificate;
+    }
+    this.logger.info('Generating self-signed TLS certificate');
+    const cert = await generateSelfSignedCert({
+      hosts: [this.settings.serverAddress],
+    });
+    this.settings.tlsCertificate = cert;
+    await this.saveSettings();
+    return cert;
   }
 
   async stopServer(): Promise<void> {

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -1,4 +1,5 @@
-import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { createServer as createHttpServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { createServer as createHttpsServer } from 'https';
 import { randomUUID } from 'crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -12,6 +13,8 @@ export interface HttpServerOptions {
   port: number;
   accessKey: string;
   corsOptions?: CorsOptions;
+  /** When provided, the server uses HTTPS with these PEM-encoded credentials. */
+  tls?: { cert: string; key: string };
 }
 
 export type McpServerFactory = () => McpServer;
@@ -53,6 +56,10 @@ export class HttpMcpServer {
     return this.sessions.size;
   }
 
+  get scheme(): 'http' | 'https' {
+    return this.options.tls ? 'https' : 'http';
+  }
+
   async start(): Promise<void> {
     if (this.isRunning) {
       this.logger.warn('Server is already running');
@@ -61,9 +68,16 @@ export class HttpMcpServer {
 
     const corsOptions = this.options.corsOptions ?? DEFAULT_CORS_OPTIONS;
 
-    this.httpServer = createServer((req: IncomingMessage, res: ServerResponse): void => {
+    const handler = (req: IncomingMessage, res: ServerResponse): void => {
       void this.handleRequest(req, res, corsOptions);
-    });
+    };
+
+    this.httpServer = this.options.tls
+      ? createHttpsServer(
+          { cert: this.options.tls.cert, key: this.options.tls.key },
+          handler,
+        )
+      : createHttpServer(handler);
 
     this.httpServer.on('connection', () => {
       this._connectedClients++;
@@ -83,7 +97,9 @@ export class HttpMcpServer {
       });
 
       this.httpServer!.listen(this.options.port, this.options.host, () => {
-        this.logger.info(`MCP server listening on http://${this.options.host}:${String(this.options.port)}`);
+        this.logger.info(
+          `MCP server listening on ${this.scheme}://${this.options.host}:${String(this.options.port)}`,
+        );
         resolve();
       });
     });

--- a/src/server/tls.ts
+++ b/src/server/tls.ts
@@ -1,44 +1,61 @@
-import { generateKeyPairSync, createSign, randomBytes } from 'crypto';
+import { generate } from 'selfsigned';
 
 export interface TlsCertificate {
   cert: string;
   key: string;
 }
 
-export function generateSelfSignedCert(): TlsCertificate {
-  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-    modulusLength: 2048,
-  });
+export interface GenerateOptions {
+  /** Hostnames/IPs to include in subjectAltName. Defaults cover loopback. */
+  hosts?: string[];
+  /** Validity in days. Defaults to 365. */
+  validityDays?: number;
+}
 
-  // Create a simple self-signed certificate
-  // This is a minimal X.509 v3 certificate for local use
-  const serialNumber = randomBytes(16).toString('hex');
-  const notBefore = new Date();
-  const notAfter = new Date();
-  notAfter.setFullYear(notAfter.getFullYear() + 10);
+const DEFAULT_HOSTS = ['localhost', '127.0.0.1', '::1'];
 
-  // Use Node.js crypto to create a self-signed cert
-  // For simplicity in a local-only context, we generate PEM-encoded key pair
-  const pubPem = publicKey.export({ type: 'spki', format: 'pem' });
-  const privPem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+export async function generateSelfSignedCert(
+  options: GenerateOptions = {},
+): Promise<TlsCertificate> {
+  const hosts = Array.from(new Set([...DEFAULT_HOSTS, ...(options.hosts ?? [])]));
+  const validityDays = options.validityDays ?? 365;
 
-  // Create a minimal self-signed certificate using the sign API
-  const sign = createSign('SHA256');
-  const certInfo = [
-    `Serial: ${serialNumber}`,
-    `Not Before: ${notBefore.toISOString()}`,
-    `Not After: ${notAfter.toISOString()}`,
-    `Subject: CN=localhost`,
-    `Issuer: CN=localhost`,
-  ].join('\n');
-  sign.update(certInfo);
-  sign.sign(privateKey, 'base64');
+  const now = new Date();
+  const notAfter = new Date(now.getTime() + validityDays * 24 * 60 * 60 * 1000);
 
-  // For a production-quality implementation, we'd use a proper X.509 library
-  // For local-only self-signed use, the key pair is sufficient
-  // Node's https.createServer accepts { key, cert } where cert can be self-signed
-  return {
-    cert: pubPem,
-    key: privPem,
-  };
+  const pems = await generate(
+    [{ name: 'commonName', value: 'Obsidian MCP Plugin (localhost)' }],
+    {
+      keySize: 2048,
+      algorithm: 'sha256',
+      notBeforeDate: now,
+      notAfterDate: notAfter,
+      extensions: [
+        { name: 'basicConstraints', cA: false, critical: true },
+        {
+          name: 'keyUsage',
+          digitalSignature: true,
+          keyEncipherment: true,
+          critical: true,
+        },
+        { name: 'extKeyUsage', serverAuth: true },
+        {
+          name: 'subjectAltName',
+          altNames: hosts.map((host) =>
+            isIpAddress(host)
+              ? { type: 7, ip: host }
+              : { type: 2, value: host },
+          ),
+        },
+      ],
+    },
+  );
+
+  return { cert: pems.cert, key: pems.private };
+}
+
+function isIpAddress(value: string): boolean {
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(value)) return true;
+  if (value.includes(':')) return true;
+  return false;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,10 @@ export class McpSettingsTab extends PluginSettingTab {
     this.renderModuleToggles(containerEl);
   }
 
+  private scheme(): 'http' | 'https' {
+    return this.plugin.settings.httpsEnabled ? 'https' : 'http';
+  }
+
   private renderServerStatus(containerEl: HTMLElement): void {
     containerEl.createEl('h2', { text: 'Server Status' });
 
@@ -30,7 +34,7 @@ export class McpSettingsTab extends PluginSettingTab {
 
     const address = this.plugin.settings.serverAddress;
     const statusText = isRunning
-      ? `Running on http://${address}:${String(port)} (${String(clients)} connection${clients !== 1 ? 's' : ''})`
+      ? `Running on ${this.scheme()}://${address}:${String(port)} (${String(clients)} connection${clients !== 1 ? 's' : ''})`
       : 'Stopped';
 
     const setting = new Setting(containerEl)
@@ -105,16 +109,16 @@ export class McpSettingsTab extends PluginSettingTab {
           }),
       );
 
+    const serverUrl = `${this.scheme()}://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
     new Setting(containerEl)
       .setName('Server URL')
-      .setDesc(`http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`)
+      .setDesc(serverUrl)
       .addExtraButton((btn) =>
         btn
           .setIcon('copy')
           .setTooltip('Copy server URL')
           .onClick(() => {
-            const url = `http://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
-            void navigator.clipboard.writeText(url).then(() => {
+            void navigator.clipboard.writeText(serverUrl).then(() => {
               new Notice('MCP server URL copied to clipboard');
             });
           }),
@@ -155,6 +159,43 @@ export class McpSettingsTab extends PluginSettingTab {
             });
           }),
       );
+
+    new Setting(containerEl)
+      .setName('HTTPS')
+      .setDesc(
+        'Serve MCP over HTTPS with a locally generated self-signed certificate. Clients must trust the certificate (or disable certificate verification). Requires restart.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.httpsEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.httpsEnabled = value;
+            await this.plugin.saveSettings();
+            this.display();
+          }),
+      );
+
+    if (this.plugin.settings.httpsEnabled) {
+      const hasCert = this.plugin.settings.tlsCertificate !== null;
+      new Setting(containerEl)
+        .setName('TLS Certificate')
+        .setDesc(
+          hasCert
+            ? 'A self-signed certificate is cached. Regenerate to replace it (e.g. after changing the server address).'
+            : 'No certificate cached yet — one will be generated on the next server start.',
+        )
+        .addExtraButton((btn) =>
+          btn
+            .setIcon('refresh-cw')
+            .setTooltip('Regenerate certificate')
+            .onClick(() => {
+              void this.plugin.regenerateTlsCertificate().then(() => {
+                new Notice('TLS certificate regenerated. Restart the server to apply.');
+                this.display();
+              });
+            }),
+        );
+    }
 
     new Setting(containerEl)
       .setName('Auto-start on launch')
@@ -208,7 +249,7 @@ export class McpSettingsTab extends PluginSettingTab {
     const address = this.plugin.settings.serverAddress;
     const port = this.plugin.settings.port;
     const accessKey = this.plugin.settings.accessKey;
-    const url = `http://${address}:${String(port)}/mcp`;
+    const url = `${this.scheme()}://${address}:${String(port)}/mcp`;
 
     const config: Record<string, unknown> = { url };
 
@@ -372,6 +413,12 @@ export function migrateSettings(
       extras.toolStates = extras.enabled ? { get_date: true } : {};
     }
     data.moduleStates = moduleStates;
+  }
+
+  if ((data.schemaVersion as number) < 5) {
+    data.schemaVersion = 5;
+    // V4 -> V5: introduce cached self-signed TLS certificate.
+    if (data.tlsCertificate === undefined) data.tlsCertificate = null;
   }
 
   return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,19 @@ export interface McpPluginSettings {
   accessKey: string;
   /** Enable HTTPS with self-signed certificate */
   httpsEnabled: boolean;
+  /** Cached self-signed TLS certificate (PEM). Regenerated on demand. */
+  tlsCertificate: TlsCertificateData | null;
   /** Enable verbose debug logging */
   debugMode: boolean;
   /** Auto-start the MCP server when Obsidian launches */
   autoStart: boolean;
   /** Per-module enabled/disabled state, keyed by module ID */
   moduleStates: Record<string, ModuleState>;
+}
+
+export interface TlsCertificateData {
+  cert: string;
+  key: string;
 }
 
 export interface ModuleState {
@@ -24,11 +31,12 @@ export interface ModuleState {
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 4,
+  schemaVersion: 5,
   serverAddress: '127.0.0.1',
   port: 28741,
   accessKey: '',
   httpsEnabled: false,
+  tlsCertificate: null,
   debugMode: false,
   autoStart: false,
   moduleStates: {},

--- a/tests/integration/https-server.test.ts
+++ b/tests/integration/https-server.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import https from 'https';
+
+const TEST_PORT = 38742;
+const ACCESS_KEY = 'https-integration-test-key';
+
+function makeRequest(
+  method: string,
+  path: string,
+  caCert: string,
+  headers: Record<string, string> = {},
+  body?: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: '127.0.0.1',
+        port: TEST_PORT,
+        path,
+        method,
+        ca: caCert,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on('end', () => {
+          resolve({ status: res.statusCode ?? 0, body: data });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+describe('Integration: HTTPS server', () => {
+  let server: import('../../src/server/http-server').HttpMcpServer;
+  let caCert: string;
+
+  beforeAll(async () => {
+    const httpMod = await import('../../src/server/http-server');
+    const mcpMod = await import('../../src/server/mcp-server');
+    const regMod = await import('../../src/registry/module-registry');
+    const logMod = await import('../../src/utils/logger');
+    const mockMod = await import('../../src/obsidian/mock-adapter');
+    const vaultMod = await import('../../src/tools/vault/index');
+    const tlsMod = await import('../../src/server/tls');
+
+    const logger = new logMod.Logger('test', { debugMode: false, accessKey: ACCESS_KEY });
+    const registry = new regMod.ModuleRegistry(logger);
+    const adapter = new mockMod.MockObsidianAdapter();
+    registry.registerModule(vaultMod.createVaultModule(adapter));
+
+    const tls = await tlsMod.generateSelfSignedCert();
+    caCert = tls.cert;
+
+    server = new httpMod.HttpMcpServer(
+      () => mcpMod.createMcpServer(registry, logger),
+      logger,
+      {
+        host: '127.0.0.1',
+        port: TEST_PORT,
+        accessKey: ACCESS_KEY,
+        tls,
+      },
+    );
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('reports scheme as https', () => {
+    expect(server.scheme).toBe('https');
+  });
+
+  it('rejects requests over HTTPS without Authorization', async () => {
+    const res = await makeRequest('POST', '/', caCert);
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts Bearer-authenticated requests over HTTPS', async () => {
+    const res = await makeRequest(
+      'POST',
+      '/',
+      caCert,
+      { Authorization: `Bearer ${ACCESS_KEY}` },
+      JSON.stringify({}),
+    );
+    // 400 because body is not a valid JSON-RPC initialize, but auth passed
+    expect(res.status).not.toBe(401);
+  });
+
+  it('refuses plain HTTP on an HTTPS port', async () => {
+    const http = await import('http');
+    await new Promise<void>((resolve) => {
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: TEST_PORT,
+          path: '/',
+          method: 'GET',
+        },
+        () => resolve(),
+      );
+      req.on('error', () => resolve());
+      req.on('close', () => resolve());
+      req.end();
+    });
+    // Just verify it doesn't hang — HTTPS server either drops the connection
+    // or returns an error; we don't care which.
+    expect(server.isRunning).toBe(true);
+  });
+});

--- a/tests/server/tls.test.ts
+++ b/tests/server/tls.test.ts
@@ -1,28 +1,54 @@
 import { describe, it, expect } from 'vitest';
+import { X509Certificate } from 'crypto';
 import { generateSelfSignedCert } from '../../src/server/tls';
 
 describe('TLS certificate generation', () => {
-  it('should generate a cert and key pair', () => {
-    const result = generateSelfSignedCert();
-    expect(result.cert).toBeDefined();
-    expect(result.key).toBeDefined();
-  });
-
-  it('should generate PEM-formatted key', () => {
-    const result = generateSelfSignedCert();
+  it('returns PEM-encoded cert and private key', async () => {
+    const result = await generateSelfSignedCert();
+    expect(result.cert).toContain('-----BEGIN CERTIFICATE-----');
+    expect(result.cert).toContain('-----END CERTIFICATE-----');
     expect(result.key).toContain('-----BEGIN PRIVATE KEY-----');
     expect(result.key).toContain('-----END PRIVATE KEY-----');
   });
 
-  it('should generate PEM-formatted cert', () => {
-    const result = generateSelfSignedCert();
-    expect(result.cert).toContain('-----BEGIN PUBLIC KEY-----');
-    expect(result.cert).toContain('-----END PUBLIC KEY-----');
+  it('produces a parseable X.509 certificate', async () => {
+    const { cert } = await generateSelfSignedCert();
+    const x509 = new X509Certificate(cert);
+    expect(x509.subject).toContain('Obsidian MCP Plugin');
+    // self-signed: issuer equals subject
+    expect(x509.issuer).toBe(x509.subject);
   });
 
-  it('should generate unique certs each time', () => {
-    const cert1 = generateSelfSignedCert();
-    const cert2 = generateSelfSignedCert();
-    expect(cert1.key).not.toBe(cert2.key);
+  it('includes loopback hosts in subjectAltName by default', async () => {
+    const { cert } = await generateSelfSignedCert();
+    const x509 = new X509Certificate(cert);
+    const san = x509.subjectAltName ?? '';
+    expect(san).toContain('localhost');
+    expect(san).toContain('127.0.0.1');
+  });
+
+  it('adds custom hosts to subjectAltName', async () => {
+    const { cert } = await generateSelfSignedCert({ hosts: ['192.168.1.42'] });
+    const x509 = new X509Certificate(cert);
+    const san = x509.subjectAltName ?? '';
+    expect(san).toContain('192.168.1.42');
+    expect(san).toContain('localhost');
+  });
+
+  it('generates unique certs each call', async () => {
+    const a = await generateSelfSignedCert();
+    const b = await generateSelfSignedCert();
+    expect(a.key).not.toBe(b.key);
+    expect(a.cert).not.toBe(b.cert);
+  });
+
+  it('honors the validity window', async () => {
+    const { cert } = await generateSelfSignedCert({ validityDays: 30 });
+    const x509 = new X509Certificate(cert);
+    const notBefore = new Date(x509.validFrom).getTime();
+    const notAfter = new Date(x509.validTo).getTime();
+    const span = (notAfter - notBefore) / (1000 * 60 * 60 * 24);
+    expect(span).toBeGreaterThan(29);
+    expect(span).toBeLessThan(31);
   });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,7 +7,7 @@ describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to v4', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -24,7 +24,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -42,7 +42,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
@@ -58,7 +58,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.autoStart).toBe(false);
   });
 
@@ -77,14 +77,14 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
     });
   });
 
-  it('should not modify data already at v4', () => {
+  it('should migrate v4 data to v5 by adding tlsCertificate=null', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 4,
       serverAddress: '192.168.1.100',
@@ -96,7 +96,37 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(5);
+    expect(result.tlsCertificate).toBeNull();
+  });
+
+  it('should not modify data already at v5', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 5,
+      serverAddress: '192.168.1.100',
+      port: 28741,
+      accessKey: 'test',
+      httpsEnabled: true,
+      tlsCertificate: { cert: 'C', key: 'K' },
+      debugMode: false,
+      autoStart: true,
+      moduleStates: {},
+    };
+    const result = migrateSettings(data);
     expect(result).toEqual(data);
+  });
+
+  it('preserves an existing tlsCertificate across migration', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 4,
+      tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(5);
+    expect(result.tlsCertificate).toEqual({
+      cert: 'EXISTING_CERT',
+      key: 'EXISTING_KEY',
+    });
   });
 
   it('should handle partially populated v0 data', () => {
@@ -104,7 +134,7 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
@@ -124,7 +154,7 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(4);
+    expect(result.schemaVersion).toBe(5);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,12 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 4', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(4);
+  it('should have schema version 5', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(5);
+  });
+
+  it('should have a null TLS certificate by default', () => {
+    expect(DEFAULT_SETTINGS.tlsCertificate).toBeNull();
   });
 
   it('should have default server address 127.0.0.1', () => {


### PR DESCRIPTION
Closes #131.

Part of the PRD-vs-code audit follow-ups tracked in #130 (item **A1**).

## Summary

- Rewrites `src/server/tls.ts` to produce a real X.509 self-signed certificate. The previous implementation exported the raw RSA public key as `cert`, which `https.createServer` would have rejected — HTTPS was never actually wired up. The new implementation uses `selfsigned` (runtime dep) to generate a proper SHA-256 / RSA-2048 cert with `localhost`, `127.0.0.1`, `::1` and the configured server address in `subjectAltName`.
- `HttpMcpServer` now switches between `http.createServer` and `https.createServer` based on a new optional `tls: { cert, key }` in `HttpServerOptions`, and exposes a `scheme` getter.
- The plugin caches `{ cert, key }` in `data.json` under a new `tlsCertificate` field (schema v4 → v5 migration) so certificates survive restarts. A Regenerate button on the new **TLS Certificate** row clears the cache; the next server start generates a fresh cert.
- Settings UI gains an **HTTPS** toggle under Server Settings. The status row, Server URL row, and MCP client-configuration copy snippet now reflect `https://` when the toggle is on.

## Notes

- Screenshots: the host screenshot pipeline (Obsidian AppImage + Xvfb) isn't set up in this sandbox, so before/after PNGs were skipped — the settings UI change is one toggle row plus one conditional row (Regenerate button). Happy to re-capture locally if you want them attached to the PR before merge.
- Self-signed certs won't validate against public CAs — clients must trust the cert explicitly. Added a note to `docs/configuration.md` and `docs/security.md`.

## Test plan

- [x] `npm test` — 306 tests pass (was 297; added 6 TLS unit tests, 4 HTTPS integration tests, 3 settings/migration tests)
- [x] `npm run lint` — 0 errors (2 pre-existing warnings)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Manual: enable HTTPS in settings, restart server, confirm `https://127.0.0.1:28741/mcp` reachable with `curl --cacert` and that the MCP config snippet emits the `https://` URL
- [ ] Manual: click Regenerate, restart, confirm old cert is replaced (`X509Certificate.validFrom` changes)