### PR TITLE
refactor(extras): return plain ISO-8601 string from get_date

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -94,7 +94,7 @@ Each category is a toggleable module. Modules self-register. The settings UI aut
 
 Utility tools that do not mirror an Obsidian API. Modules in this group render under a separate "Extras" heading in the settings UI (not under "Feature Modules") and are disabled by default — users opt in individually.
 
-- **R55** — `get_date` tool returns the current local datetime as an ISO-8601 string with timezone offset (e.g. `2026-04-16T14:32:05.123+02:00`), along with the IANA timezone name and UTC offset in minutes. Disabled by default. Belongs to the "Extras" module group.
+- **R55** — `get_date` tool returns the current local datetime as a plain ISO-8601 string with timezone offset (e.g. `2026-04-16T14:32:05.123+02:00`). The offset is already encoded in the string, so no additional fields are returned. Disabled by default. Belongs to the "Extras" module group.
 
 ## Configuration
 

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -28,20 +28,10 @@ function formatIsoWithOffset(now: Date): string {
   return `${String(y)}-${mo}-${d}T${h}:${mi}:${s}.${ms}${formatOffset(offsetMinutes)}`;
 }
 
-function resolveTimezone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone;
-}
-
 function createHandlers(_adapter: ObsidianAdapter): Record<string, Handler> {
   return {
     getDate: (): Promise<CallToolResult> => {
-      const now = new Date();
-      const payload = {
-        iso: formatIsoWithOffset(now),
-        timezone: resolveTimezone(),
-        utcOffsetMinutes: -now.getTimezoneOffset(),
-      };
-      return Promise.resolve(text(JSON.stringify(payload)));
+      return Promise.resolve(text(formatIsoWithOffset(new Date())));
     },
   };
 }
@@ -60,7 +50,7 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'get_date',
-          description: 'Get the current local datetime as an ISO-8601 string with timezone offset, plus the IANA timezone name and UTC offset in minutes.',
+          description: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
           schema: {},
           handler: h.getDate,
           isReadOnly: true,

--- a/tests/tools/extras/extras.test.ts
+++ b/tests/tools/extras/extras.test.ts
@@ -7,12 +7,6 @@ interface TextContent {
   text: string;
 }
 
-interface GetDatePayload {
-  iso: string;
-  timezone: string;
-  utcOffsetMinutes: number;
-}
-
 const ISO_WITH_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/;
 
 describe('Extras module', () => {
@@ -38,7 +32,7 @@ describe('Extras module', () => {
     expect(tool.isReadOnly).toBe(true);
   });
 
-  it('get_date returns a valid ISO-8601 string with timezone offset', async () => {
+  it('get_date returns a plain ISO-8601 string with timezone offset', async () => {
     const adapter = new MockObsidianAdapter();
     const module = createExtrasModule(adapter);
     const tool = module.tools().find((t) => t.name === 'get_date')!;
@@ -46,14 +40,11 @@ describe('Extras module', () => {
     expect(result.isError).toBeUndefined();
 
     const content = result.content[0] as TextContent;
-    const payload = JSON.parse(content.text) as GetDatePayload;
-    expect(payload.iso).toMatch(ISO_WITH_OFFSET);
-    expect(typeof payload.timezone).toBe('string');
-    expect(payload.timezone.length).toBeGreaterThan(0);
-    expect(typeof payload.utcOffsetMinutes).toBe('number');
+    expect(content.type).toBe('text');
+    expect(content.text).toMatch(ISO_WITH_OFFSET);
   });
 
-  it('utcOffsetMinutes matches the current local offset', async () => {
+  it('get_date encodes the current local UTC offset in the ISO string', async () => {
     const adapter = new MockObsidianAdapter();
     const module = createExtrasModule(adapter);
     const tool = module.tools().find((t) => t.name === 'get_date')!;
@@ -62,22 +53,11 @@ describe('Extras module', () => {
     const after = new Date().getTimezoneOffset();
 
     const content = result.content[0] as TextContent;
-    const payload = JSON.parse(content.text) as GetDatePayload;
-    expect([-before, -after]).toContain(payload.utcOffsetMinutes);
-  });
-
-  it('get_date iso encodes the same offset as utcOffsetMinutes', async () => {
-    const adapter = new MockObsidianAdapter();
-    const module = createExtrasModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'get_date')!;
-    const result = await tool.handler({});
-    const content = result.content[0] as TextContent;
-    const payload = JSON.parse(content.text) as GetDatePayload;
-
-    const offsetToken = payload.iso.slice(-6);
+    const iso = content.text;
+    const offsetToken = iso.slice(-6);
     const sign = offsetToken.startsWith('+') ? 1 : -1;
     const [hh, mm] = offsetToken.slice(1).split(':');
     const encodedMinutes = sign * (parseInt(hh, 10) * 60 + parseInt(mm, 10));
-    expect(encodedMinutes).toBe(payload.utcOffsetMinutes);
+    expect([-before, -after]).toContain(encodedMinutes);
   });
 });


### PR DESCRIPTION
## Summary

- Change the `get_date` MCP tool to return a plain ISO-8601 string (e.g. `2026-04-17T14:32:05.123+02:00`) instead of a JSON object with `iso`, `timezone`, and `utcOffsetMinutes` fields. The offset is already encoded in the ISO string, so the extra fields are redundant for the common case.
- Drop the now-unused `resolveTimezone` helper.
- Update the tool's `description` to match the simpler output.
- Update PRD **R55** in-place to describe the plain-string output. Per the PRD's ID Governance rules, this is a narrowing of an existing contract (not a replacement of semantics), so R55 is reworded in place rather than struck and reassigned a new ID.
- Update `tests/tools/extras/extras.test.ts` to assert against the plain string payload.

This is follow-up **A15** from audit #130.

## Test plan

- [x] `npm test` passes (296 tests, down from 297 because two near-duplicate offset-checking tests were consolidated into one).
- [x] `npm run lint` passes (only pre-existing warnings in `tests/settings.test.ts`).
- [x] `npm run typecheck` passes.

Closes #133