### PR TITLE
fix(settings): surface validation errors for invalid IP and port input

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,18 +69,22 @@ export class McpSettingsTab extends PluginSettingTab {
 
     const addressSetting = new Setting(containerEl)
       .setName('Server Address')
-      .setDesc('IP address the server binds to (default: 127.0.0.1). Requires restart.')
-      .addText((text) =>
-        text
-          .setPlaceholder('127.0.0.1')
-          .setValue(this.plugin.settings.serverAddress)
-          .onChange(async (value) => {
-            if (isValidIPv4(value)) {
-              this.plugin.settings.serverAddress = value;
-              await this.plugin.saveSettings();
-            }
-          }),
-      );
+      .setDesc('IP address the server binds to (default: 127.0.0.1). Requires restart.');
+    const addressError = createValidationError(addressSetting);
+    addressSetting.addText((text) =>
+      text
+        .setPlaceholder('127.0.0.1')
+        .setValue(this.plugin.settings.serverAddress)
+        .onChange(async (value) => {
+          if (isValidIPv4(value)) {
+            addressError.clear();
+            this.plugin.settings.serverAddress = value;
+            await this.plugin.saveSettings();
+          } else {
+            addressError.show('Invalid IPv4 address. Expected format: 127.0.0.1');
+          }
+        }),
+    );
 
     if (this.plugin.settings.serverAddress !== '127.0.0.1') {
       addressSetting.descEl.createEl('br');
@@ -89,21 +93,25 @@ export class McpSettingsTab extends PluginSettingTab {
       });
     }
 
-    new Setting(containerEl)
+    const portSetting = new Setting(containerEl)
       .setName('Port')
-      .setDesc('HTTP port for the MCP server (default: 28741)')
-      .addText((text) =>
-        text
-          .setPlaceholder('28741')
-          .setValue(String(this.plugin.settings.port))
-          .onChange(async (value) => {
-            const port = parseInt(value, 10);
-            if (!isNaN(port) && port > 0 && port < 65536) {
-              this.plugin.settings.port = port;
-              await this.plugin.saveSettings();
-            }
-          }),
-      );
+      .setDesc('HTTP port for the MCP server (default: 28741)');
+    const portError = createValidationError(portSetting);
+    portSetting.addText((text) =>
+      text
+        .setPlaceholder('28741')
+        .setValue(String(this.plugin.settings.port))
+        .onChange(async (value) => {
+          const port = parseInt(value, 10);
+          if (/^\d+$/.test(value) && !isNaN(port) && port > 0 && port < 65536) {
+            portError.clear();
+            this.plugin.settings.port = port;
+            await this.plugin.saveSettings();
+          } else {
+            portError.show('Invalid port. Enter a whole number between 1 and 65535.');
+          }
+        }),
+    );
 
     new Setting(containerEl)
       .setName('Server URL')
@@ -308,6 +316,33 @@ export class McpSettingsTab extends PluginSettingTab {
         }),
       );
   }
+}
+
+interface ValidationErrorController {
+  show: (message: string) => void;
+  clear: () => void;
+}
+
+function createValidationError(setting: Setting): ValidationErrorController {
+  let errorEl: HTMLElement | null = null;
+  return {
+    show: (message: string): void => {
+      if (errorEl) {
+        errorEl.textContent = message;
+        return;
+      }
+      errorEl = setting.descEl.createEl('div', {
+        cls: 'mcp-settings-error',
+        text: message,
+      });
+    },
+    clear: (): void => {
+      if (errorEl) {
+        errorEl.remove();
+        errorEl = null;
+      }
+    },
+  };
 }
 
 export function generateAccessKey(): string {

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,9 @@
 .mcp-module-card-header .setting-item-name {
   font-weight: 600;
 }
+
+.mcp-settings-error {
+  color: var(--text-error);
+  font-size: var(--font-ui-smaller);
+  margin-top: 4px;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/require-await, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/require-await, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unsafe-call */
 
 export class Plugin {
   app: any;
@@ -24,15 +24,46 @@ export class Plugin {
 }
 
 function mockEl(): any {
-  return {
+  const el: any = {
     setText: () => {},
     style: {},
     textContent: '',
+    className: '',
+    tagName: '',
+    attributes: {} as Record<string, string>,
     classList: { add: () => {}, remove: () => {} },
     addEventListener: () => {},
-    createEl: () => mockEl(),
-    createDiv: (_opts?: any) => mockEl(),
+    children: [] as any[],
+    empty: () => {
+      el.children.length = 0;
+    },
+    remove: () => {},
+    createEl: (tag?: string, opts?: { text?: string; cls?: string; attr?: Record<string, string> }) => {
+      const child = mockEl();
+      if (tag) child.tagName = tag;
+      if (opts?.text) child.textContent = opts.text;
+      if (opts?.cls) child.className = opts.cls;
+      if (opts?.attr) Object.assign(child.attributes, opts.attr);
+      el.children.push(child);
+      child.remove = () => {
+        const idx = el.children.indexOf(child);
+        if (idx >= 0) el.children.splice(idx, 1);
+      };
+      return child;
+    },
+    createDiv: (opts?: { cls?: string }) => {
+      const child = mockEl();
+      child.tagName = 'div';
+      if (opts?.cls) child.className = opts.cls;
+      el.children.push(child);
+      child.remove = () => {
+        const idx = el.children.indexOf(child);
+        if (idx >= 0) el.children.splice(idx, 1);
+      };
+      return child;
+    },
   };
+  return el;
 }
 
 export class PluginSettingTab {
@@ -59,14 +90,21 @@ export class Setting {
   settingDesc = '';
   settingClass = '';
   container: any;
+  descEl: any;
   buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
   extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> = [];
   toggles: Array<{ value: boolean; tooltip: string; callback: ((value: boolean) => void) | null }> = [];
+  texts: Array<{
+    placeholder: string;
+    value: string;
+    callback: ((value: string) => void | Promise<void>) | null;
+  }> = [];
   settingEl: { classList: { add: (cls: string) => void } };
 
   constructor(containerEl: any) {
     Setting.instances.push(this);
     this.container = containerEl;
+    this.descEl = mockEl();
     this.settingEl = {
       classList: {
         add: (cls: string): void => {
@@ -87,7 +125,19 @@ export class Setting {
     this.settingClass = this.settingClass ? `${this.settingClass} ${cls}` : cls;
     return this;
   }
-  addText(_cb: (text: any) => void): this {
+  addText(cb: (text: any) => void): this {
+    const record = {
+      placeholder: '',
+      value: '',
+      callback: null as ((value: string) => void | Promise<void>) | null,
+    };
+    const text = {
+      setPlaceholder(p: string) { record.placeholder = p; return text; },
+      setValue(v: string) { record.value = v; return text; },
+      onChange(fn: (value: string) => void | Promise<void>) { record.callback = fn; return text; },
+    };
+    cb(text);
+    this.texts.push(record);
     return this;
   }
   addToggle(cb: (toggle: any) => void): this {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -810,3 +810,147 @@ describe('McpSettingsTab module rows rendering', () => {
     });
   });
 });
+
+describe('McpSettingsTab server settings validation', () => {
+  interface TextInfo {
+    placeholder: string;
+    value: string;
+    callback: ((value: string) => void | Promise<void>) | null;
+  }
+  interface ValidationSettingInstance {
+    settingName: string;
+    texts: TextInfo[];
+    descEl: TrackingEl;
+  }
+
+  beforeEach(() => {
+    (Setting as unknown as { instances: unknown[] }).instances = [];
+  });
+
+  function createValidationMockPlugin(): {
+    settings: typeof DEFAULT_SETTINGS & { accessKey: string };
+    httpServer: null;
+    registry: { getModules: () => [] };
+    logger: { updateOptions: () => void };
+    saveSettings: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      settings: { ...DEFAULT_SETTINGS, accessKey: 'k' },
+      httpServer: null,
+      registry: { getModules: () => [] },
+      logger: { updateOptions: (): void => {} },
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function renderValidationTab(): ReturnType<typeof createValidationMockPlugin> {
+    const plugin = createValidationMockPlugin();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    const tab = new McpSettingsTab({} as any, plugin as any);
+    const container = createTrackingEl();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (tab as any).containerEl = container;
+    tab.display();
+    return plugin;
+  }
+
+  function getSettingByName(name: string): ValidationSettingInstance {
+    return (Setting as unknown as { instances: ValidationSettingInstance[] }).instances.find(
+      (s) => s.settingName === name,
+    )!;
+  }
+
+  function errorElements(setting: ValidationSettingInstance): TrackingEl[] {
+    const results: TrackingEl[] = [];
+    for (const child of setting.descEl.children) {
+      if (child.className === 'mcp-settings-error') results.push(child);
+    }
+    return results;
+  }
+
+  describe('Server Address (IP) validation', () => {
+    it('does not show an error element on initial render with a valid IP', () => {
+      renderValidationTab();
+      const setting = getSettingByName('Server Address');
+      expect(errorElements(setting)).toHaveLength(0);
+    });
+
+    it('shows an error element when an invalid IP is typed', async () => {
+      renderValidationTab();
+      const setting = getSettingByName('Server Address');
+      await setting.texts[0].callback!('not-an-ip');
+      const errors = errorElements(setting);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].textContent).toMatch(/invalid/i);
+    });
+
+    it('does not persist invalid IP values', async () => {
+      const plugin = renderValidationTab();
+      const setting = getSettingByName('Server Address');
+      await setting.texts[0].callback!('256.256.256.256');
+      expect(plugin.settings.serverAddress).toBe('127.0.0.1');
+      expect(plugin.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('clears the error element when a valid IP is typed after an invalid one', async () => {
+      const plugin = renderValidationTab();
+      const setting = getSettingByName('Server Address');
+      await setting.texts[0].callback!('bogus');
+      expect(errorElements(setting)).toHaveLength(1);
+      await setting.texts[0].callback!('10.0.0.1');
+      expect(errorElements(setting)).toHaveLength(0);
+      expect(plugin.settings.serverAddress).toBe('10.0.0.1');
+      expect(plugin.saveSettings).toHaveBeenCalled();
+    });
+  });
+
+  describe('Port validation', () => {
+    it('does not show an error element on initial render with a valid port', () => {
+      renderValidationTab();
+      const setting = getSettingByName('Port');
+      expect(errorElements(setting)).toHaveLength(0);
+    });
+
+    it('shows an error when the port is 0', async () => {
+      renderValidationTab();
+      const setting = getSettingByName('Port');
+      await setting.texts[0].callback!('0');
+      const errors = errorElements(setting);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].textContent).toMatch(/invalid/i);
+    });
+
+    it('shows an error when the port is out of range (99999)', async () => {
+      renderValidationTab();
+      const setting = getSettingByName('Port');
+      await setting.texts[0].callback!('99999');
+      expect(errorElements(setting)).toHaveLength(1);
+    });
+
+    it('shows an error for a non-numeric port', async () => {
+      renderValidationTab();
+      const setting = getSettingByName('Port');
+      await setting.texts[0].callback!('abc');
+      expect(errorElements(setting)).toHaveLength(1);
+    });
+
+    it('does not persist invalid port values', async () => {
+      const plugin = renderValidationTab();
+      const setting = getSettingByName('Port');
+      await setting.texts[0].callback!('0');
+      expect(plugin.settings.port).toBe(28741);
+      expect(plugin.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('clears the error when a valid port is typed after an invalid one', async () => {
+      const plugin = renderValidationTab();
+      const setting = getSettingByName('Port');
+      await setting.texts[0].callback!('99999');
+      expect(errorElements(setting)).toHaveLength(1);
+      await setting.texts[0].callback!('3000');
+      expect(errorElements(setting)).toHaveLength(0);
+      expect(plugin.settings.port).toBe(3000);
+      expect(plugin.saveSettings).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Previously the Server Address and Port text fields silently discarded invalid input — the user typed something bad, the value wasn't saved, and there was no feedback. Now each field shows an inline error message directly under the field label when the input is invalid.
- The error element is appended to the Setting's `descEl` with the class `mcp-settings-error` (red-ish `--text-error`, `--font-ui-smaller`, small top margin). As soon as the input becomes valid and is saved, the element is removed.
- Invalid values still do NOT persist to settings (behavior preserved).
- Port validation was tightened slightly: `parseInt("3000abc", 10)` returns `3000` which would previously have been accepted; the new check uses a `/^\d+$/` regex on top of the range check so non-numeric tails are rejected.

This is follow-up A18 from the audit in #130.

## Test plan

- [x] `npm test` — 307 pass (297 baseline + 10 new validation tests)
- [x] `npm run lint` — clean (only the two pre-existing `explicit-function-return-type` warnings in `tests/settings.test.ts`)
- [x] `npm run typecheck` — clean
- [x] New tests cover: invalid IP shows error / valid IP clears it / invalid IP does not persist; port `0` / `99999` / non-numeric each show an error; valid port after an invalid one clears the error and persists.

Screenshots were skipped — the sandbox doesn't have the host Xvfb/CDP pipeline available. The change is purely a small `<div class="mcp-settings-error">…</div>` that appears under the "Server Address" and "Port" rows in the settings tab while the user is typing an invalid value, and disappears as soon as the value is valid.

Closes #134
