### PR TITLE
fix(ui): swap ribbon icon glyph on server state change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin } from 'obsidian';
+import { Notice, Plugin, setIcon } from 'obsidian';
 import { DEFAULT_SETTINGS, McpPluginSettings, TlsCertificateData } from './types';
 import { createLogger, Logger } from './utils/logger';
 import { ModuleRegistry } from './registry/module-registry';
@@ -10,6 +10,7 @@ import { discoverModules } from './tools';
 import { McpSettingsTab, migrateSettings } from './settings';
 
 const ICON_MCP = 'plug';
+const ICON_MCP_RUNNING = 'plug-zap';
 
 export default class McpPlugin extends Plugin {
   settings: McpPluginSettings = DEFAULT_SETTINGS;
@@ -184,8 +185,9 @@ export default class McpPlugin extends Plugin {
       );
     }
 
-    // Update ribbon icon
+    // Update ribbon icon glyph + aria label
     if (this.ribbonIconEl) {
+      setIcon(this.ribbonIconEl, isRunning ? ICON_MCP_RUNNING : ICON_MCP);
       this.ribbonIconEl.ariaLabel = isRunning
         ? `MCP Server (running on :${String(this.settings.port)})`
         : 'MCP Server (stopped)';

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -80,6 +80,56 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(startSpy).not.toHaveBeenCalled();
   });
 
+  it('swaps the ribbon icon glyph when the server transitions between stopped and running', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 3,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'configured-key',
+      httpsEnabled: false,
+      debugMode: false,
+      autoStart: false,
+      moduleStates: {},
+    });
+
+    interface RibbonStub {
+      _icon: string;
+      ariaLabel: string;
+    }
+    interface InternalPlugin {
+      addRibbonIcon: (icon: string, title: string, cb: () => void) => RibbonStub;
+      httpServer: { isRunning: boolean } | null;
+      updateStatusDisplay: () => void;
+    }
+
+    const ribbonEl: RibbonStub = { _icon: '', ariaLabel: '' };
+    const internals = plugin as unknown as InternalPlugin;
+    internals.addRibbonIcon = (icon: string): RibbonStub => {
+      ribbonEl._icon = icon;
+      return ribbonEl;
+    };
+
+    await plugin.onload();
+
+    // Initial render: server stopped, so the ribbon should show the default plug glyph.
+    expect(ribbonEl._icon).toBe('plug');
+    expect(ribbonEl.ariaLabel).toBe('MCP Server (stopped)');
+
+    // Simulate the server becoming running, then refresh the status display.
+    internals.httpServer = { isRunning: true };
+    internals.updateStatusDisplay();
+
+    expect(ribbonEl._icon).toBe('plug-zap');
+    expect(ribbonEl.ariaLabel).toBe('MCP Server (running on :28741)');
+
+    // Simulate the server being stopped again.
+    internals.httpServer = null;
+    internals.updateStatusDisplay();
+
+    expect(ribbonEl._icon).toBe('plug');
+    expect(ribbonEl.ariaLabel).toBe('MCP Server (stopped)');
+  });
+
   it('migrates existing installs to autoStart=false so the server stays stopped on first load', async () => {
     const plugin = createPlugin({
       schemaVersion: 2,


### PR DESCRIPTION
## Summary

- The ribbon icon previously stayed on the `plug` Lucide glyph regardless of server state; only the aria label changed, so users had no visual cue from the ribbon. PRD TR15 says the ribbon icon should reflect server status.
- `updateStatusDisplay()` in `src/main.ts` now swaps the glyph via Obsidian's `setIcon` helper: `plug` when stopped, `plug-zap` when running. The existing aria-label update is preserved.
- Added an `ICON_MCP_RUNNING` constant alongside the existing `ICON_MCP`.
- New unit test in `tests/main.test.ts` asserts the ribbon glyph flips on every state transition (stopped -> running -> stopped). The existing `setIcon` export in `tests/__mocks__/obsidian.ts` already records the last icon passed, so no mock changes were needed.

Follow-up A4 from the audit in #130.

## Test plan

- [x] `npm test` — 298 passed (was 297, +1 new test)
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in `tests/settings.test.ts` only)
- [x] `npm run typecheck` — clean

## Known skipped

- Before/after screenshots are skipped: the host screenshot pipeline (Xvfb + CDP) is not available in this sandbox. The change is a 2-line glyph swap driven by `setIcon`, fully covered by the new unit test.

Closes #132