### PR TITLE
feat(i18n): add multi-language support with English and German locales

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -96,6 +96,15 @@ Utility tools that do not mirror an Obsidian API. Modules in this group render u
 
 - **R55** — `get_date` tool returns the current local datetime as a plain ISO-8601 string with timezone offset (e.g. `2026-04-16T14:32:05.123+02:00`). The offset is already encoded in the string, so no additional fields are returned. Disabled by default. Belongs to the "Extras" module group.
 
+### Internationalization (I18N)
+
+The plugin UI is translated via a tiny in-house i18n helper modelled on the [obsidian-kanban pattern](https://github.com/mgmeyers/obsidian-kanban/blob/main/src/lang/helpers.ts) — zero runtime dependencies, all translations compiled into the plugin bundle. See `src/lang/helpers.ts` for the `t()` function and `src/lang/locale/` for per-locale maps.
+
+- **I1** — Plugin UI strings support multiple locales. English and German ship out of the box (`src/lang/locale/en.ts`, `src/lang/locale/de.ts`). `en` is the source of truth; other locales are `Partial<Record<keyof typeof en, string>>` maps.
+- **I2** — The active locale is auto-detected via `window.localStorage.getItem('language')` (the key Obsidian itself writes). No in-plugin settings override in this iteration — the plugin simply follows Obsidian's own language setting.
+- **I3** — Missing keys in non-English locales fall back to the English value at runtime. If the detected locale is not registered in the locale map, `t()` logs a single `console.error` and returns the English value. `t()` is typed as `t(key: keyof typeof en, params?: Record<string, string | number>): string`, so a missing/misspelled key is a TypeScript compile error.
+- **I4** — MCP tool names, tool descriptions, input schemas, and MCP error payloads remain English-only. These surfaces are LLM-facing (agents, not humans), and keeping them English maximizes tool-selection quality and MCP interop stability. Structured log output is also English by convention.
+
 ## Configuration
 
 ### Server Settings

--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -1,0 +1,53 @@
+import en from './locale/en';
+import de from './locale/de';
+
+export type TranslationKey = keyof typeof en;
+
+type LocaleMap = Partial<Record<TranslationKey, string>>;
+
+// Registry of supported locales. Add a new entry here when a new translation
+// file is introduced; `t()` looks up by the raw value of Obsidian's
+// `localStorage.getItem('language')`.
+const locales: Record<string, LocaleMap> = {
+  en,
+  de,
+};
+
+function detectLocale(): string {
+  if (typeof window === 'undefined') return 'en';
+  try {
+    return window.localStorage.getItem('language') ?? 'en';
+  } catch {
+    return 'en';
+  }
+}
+
+function interpolate(
+  template: string,
+  params: Record<string, string | number>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_match, key: string) => {
+    const value = params[key];
+    return value === undefined ? `{${key}}` : String(value);
+  });
+}
+
+export function t(
+  key: TranslationKey,
+  params?: Record<string, string | number>,
+): string {
+  const lang = detectLocale();
+  const map = locales[lang];
+  if (!map) {
+    // Unknown locale → surface a one-line console error so the user/dev
+    // can tell why their translations aren't showing up, then fall back
+    // to English. The logger module is intentionally not used here to
+    // keep this module dependency-free.
+    // eslint-disable-next-line no-console
+    console.error(
+      `[obsidian-mcp] locale "${lang}" is not registered, falling back to en`,
+    );
+  }
+  const raw = map?.[key] ?? en[key];
+  return params ? interpolate(raw, params) : raw;
+}

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -1,0 +1,86 @@
+import type en from './en';
+
+// German translation. Keys are constrained to `keyof typeof en` so a typo
+// fails the build, but the value type stays `string` so translations don't
+// have to mimic the English literal. Missing keys fall back to English at
+// runtime (see `src/lang/helpers.ts`).
+
+const de: Partial<Record<keyof typeof en, string>> = {
+  // Server Status section
+  heading_server_status: 'Serverstatus',
+  setting_status_name: 'Status',
+  status_stopped: 'Gestoppt',
+  status_running_one: 'Läuft auf {url} (1 Verbindung)',
+  status_running_many: 'Läuft auf {url} ({count} Verbindungen)',
+  tooltip_start_server: 'MCP-Server starten',
+  tooltip_stop_server: 'MCP-Server stoppen',
+  tooltip_restart_server: 'Server neu starten',
+
+  // Server Settings section
+  heading_server_settings: 'Servereinstellungen',
+  setting_server_address_name: 'Serveradresse',
+  setting_server_address_desc:
+    'IP-Adresse, an die der Server gebunden wird (Standard: 127.0.0.1). Neustart erforderlich.',
+  warning_non_localhost:
+    'Warnung: Eine Nicht-Localhost-Adresse macht den Server im Netzwerk erreichbar. Stelle sicher, dass ein Zugriffsschlüssel gesetzt ist.',
+  error_invalid_ipv4: 'Ungültige IPv4-Adresse. Erwartetes Format: 127.0.0.1',
+  setting_port_name: 'Port',
+  setting_port_desc: 'HTTP-Port für den MCP-Server (Standard: 28741)',
+  error_invalid_port: 'Ungültiger Port. Gib eine ganze Zahl zwischen 1 und 65535 ein.',
+  setting_server_url_name: 'Server-URL',
+  tooltip_copy_server_url: 'Server-URL kopieren',
+  notice_server_url_copied: 'MCP-Server-URL in die Zwischenablage kopiert',
+  setting_access_key_name: 'Zugriffsschlüssel',
+  setting_access_key_desc: 'Bearer-Token zur Authentifizierung von MCP-Clients',
+  placeholder_access_key: 'Zugriffsschlüssel eingeben',
+  tooltip_copy_access_key: 'Zugriffsschlüssel kopieren',
+  notice_access_key_copied: 'Zugriffsschlüssel in die Zwischenablage kopiert',
+  tooltip_generate: 'Generieren',
+  setting_https_name: 'HTTPS',
+  setting_https_desc:
+    'MCP über HTTPS mit einem lokal erzeugten selbstsignierten Zertifikat ausliefern. Clients müssen dem Zertifikat vertrauen (oder die Zertifikatsprüfung deaktivieren). Neustart erforderlich.',
+  setting_tls_cert_name: 'TLS-Zertifikat',
+  setting_tls_cert_desc_present:
+    'Ein selbstsigniertes Zertifikat ist gecacht. Neu erzeugen, um es zu ersetzen (z. B. nach Änderung der Serveradresse).',
+  setting_tls_cert_desc_absent:
+    'Noch kein Zertifikat gecacht — beim nächsten Serverstart wird eines erzeugt.',
+  tooltip_regenerate_cert: 'Zertifikat neu erzeugen',
+  notice_tls_regenerated:
+    'TLS-Zertifikat neu erzeugt. Starte den Server neu, damit es aktiv wird.',
+  setting_autostart_name: 'Beim Start automatisch starten',
+  setting_autostart_desc: 'MCP-Server automatisch starten, wenn Obsidian gestartet wird',
+  setting_debug_name: 'Debug-Modus',
+  setting_debug_desc: 'Ausführliches Protokollieren von MCP-Anfragen und -Antworten',
+
+  // MCP Client Configuration section
+  heading_mcp_client_config: 'MCP-Client-Konfiguration',
+  setting_client_config_name: 'Client-Konfiguration',
+  setting_client_config_desc:
+    'Kopiere das JSON-Snippet für deinen MCP-Client und füge es in den mcpServers-Abschnitt seiner Konfiguration ein (Claude Desktop, Claude Code, …).',
+  tooltip_copy_config: 'Konfiguration kopieren',
+  notice_config_copied: 'MCP-Client-Konfiguration in die Zwischenablage kopiert',
+
+  // Feature Modules / Extras section
+  heading_feature_modules: 'Funktionsmodule',
+  heading_extras: 'Extras',
+  message_no_modules:
+    'Keine Module registriert. Klicke auf „Module neu laden", um die Erkennung erneut auszuführen.',
+  button_refresh_modules: 'Module neu laden',
+
+  // Plugin lifecycle notices
+  notice_server_started: 'MCP-Server auf Port {port} gestartet',
+  notice_server_start_failed: 'MCP-Server konnte nicht gestartet werden: {message}',
+
+  // Command palette entries
+  command_start_server: 'MCP-Server starten',
+  command_stop_server: 'MCP-Server stoppen',
+  command_restart_server: 'MCP-Server neu starten',
+  command_copy_access_key: 'Zugriffsschlüssel kopieren',
+
+  // Ribbon icon
+  ribbon_mcp_server: 'MCP-Server',
+  ribbon_tooltip_running: 'MCP-Server (läuft auf :{port})',
+  ribbon_tooltip_stopped: 'MCP-Server (gestoppt)',
+};
+
+export default de;

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -1,0 +1,82 @@
+// English is the source of truth. Every translation key MUST exist here;
+// other locales are `Partial<typeof en>` and fall back to English for
+// missing keys. Keep keys in snake_case and scoped by surface.
+
+const en = {
+  // Settings — Server Status section
+  heading_server_status: 'Server Status',
+  setting_status_name: 'Status',
+  status_stopped: 'Stopped',
+  status_running_one: 'Running on {url} (1 connection)',
+  status_running_many: 'Running on {url} ({count} connections)',
+  tooltip_start_server: 'Start MCP server',
+  tooltip_stop_server: 'Stop MCP server',
+  tooltip_restart_server: 'Restart server',
+
+  // Settings — Server Settings section
+  heading_server_settings: 'Server Settings',
+  setting_server_address_name: 'Server Address',
+  setting_server_address_desc:
+    'IP address the server binds to (default: 127.0.0.1). Requires restart.',
+  warning_non_localhost:
+    'Warning: Non-localhost address exposes the server to the network. Ensure an access key is set.',
+  error_invalid_ipv4: 'Invalid IPv4 address. Expected format: 127.0.0.1',
+  setting_port_name: 'Port',
+  setting_port_desc: 'HTTP port for the MCP server (default: 28741)',
+  error_invalid_port: 'Invalid port. Enter a whole number between 1 and 65535.',
+  setting_server_url_name: 'Server URL',
+  tooltip_copy_server_url: 'Copy server URL',
+  notice_server_url_copied: 'MCP server URL copied to clipboard',
+  setting_access_key_name: 'Access Key',
+  setting_access_key_desc: 'Bearer token for authenticating MCP clients',
+  placeholder_access_key: 'Enter access key',
+  tooltip_copy_access_key: 'Copy access key',
+  notice_access_key_copied: 'Access key copied to clipboard',
+  tooltip_generate: 'Generate',
+  setting_https_name: 'HTTPS',
+  setting_https_desc:
+    'Serve MCP over HTTPS with a locally generated self-signed certificate. Clients must trust the certificate (or disable certificate verification). Requires restart.',
+  setting_tls_cert_name: 'TLS Certificate',
+  setting_tls_cert_desc_present:
+    'A self-signed certificate is cached. Regenerate to replace it (e.g. after changing the server address).',
+  setting_tls_cert_desc_absent:
+    'No certificate cached yet — one will be generated on the next server start.',
+  tooltip_regenerate_cert: 'Regenerate certificate',
+  notice_tls_regenerated: 'TLS certificate regenerated. Restart the server to apply.',
+  setting_autostart_name: 'Auto-start on launch',
+  setting_autostart_desc: 'Start MCP server automatically when Obsidian launches',
+  setting_debug_name: 'Debug Mode',
+  setting_debug_desc: 'Enable verbose logging of MCP requests and responses',
+
+  // Settings — MCP Client Configuration section
+  heading_mcp_client_config: 'MCP Client Configuration',
+  setting_client_config_name: 'Client configuration',
+  setting_client_config_desc:
+    'Copy the JSON snippet for your MCP client and paste it into the mcpServers section of its config (Claude Desktop, Claude Code, …).',
+  tooltip_copy_config: 'Copy configuration',
+  notice_config_copied: 'MCP client configuration copied to clipboard',
+
+  // Settings — Feature Modules / Extras section
+  heading_feature_modules: 'Feature Modules',
+  heading_extras: 'Extras',
+  message_no_modules:
+    'No modules registered. Click "Refresh Modules" to re-run discovery.',
+  button_refresh_modules: 'Refresh Modules',
+
+  // Plugin lifecycle notices (main.ts)
+  notice_server_started: 'MCP server started on port {port}',
+  notice_server_start_failed: 'Failed to start MCP server: {message}',
+
+  // Command palette entries
+  command_start_server: 'Start MCP Server',
+  command_stop_server: 'Stop MCP Server',
+  command_restart_server: 'Restart MCP Server',
+  command_copy_access_key: 'Copy Access Key',
+
+  // Ribbon icon
+  ribbon_mcp_server: 'MCP Server',
+  ribbon_tooltip_running: 'MCP Server (running on :{port})',
+  ribbon_tooltip_stopped: 'MCP Server (stopped)',
+} as const;
+
+export default en;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { generateSelfSignedCert } from './server/tls';
 import { RealObsidianAdapter, ObsidianAdapter } from './obsidian/adapter';
 import { discoverModules } from './tools';
 import { McpSettingsTab, migrateSettings } from './settings';
+import { t } from './lang/helpers';
 
 const ICON_MCP = 'plug';
 const ICON_MCP_RUNNING = 'plug-zap';
@@ -40,7 +41,7 @@ export default class McpPlugin extends Plugin {
     // Add ribbon icon
     this.ribbonIconEl = this.addRibbonIcon(
       ICON_MCP,
-      'MCP Server',
+      t('ribbon_mcp_server'),
       () => {
         if (this.httpServer?.isRunning) {
           void this.stopServer();
@@ -56,7 +57,7 @@ export default class McpPlugin extends Plugin {
     // Register commands
     this.addCommand({
       id: 'start-server',
-      name: 'Start MCP Server',
+      name: t('command_start_server'),
       callback: () => {
         void this.startServer();
       },
@@ -64,7 +65,7 @@ export default class McpPlugin extends Plugin {
 
     this.addCommand({
       id: 'stop-server',
-      name: 'Stop MCP Server',
+      name: t('command_stop_server'),
       callback: () => {
         void this.stopServer();
       },
@@ -72,7 +73,7 @@ export default class McpPlugin extends Plugin {
 
     this.addCommand({
       id: 'restart-server',
-      name: 'Restart MCP Server',
+      name: t('command_restart_server'),
       callback: () => {
         void this.restartServer();
       },
@@ -80,10 +81,10 @@ export default class McpPlugin extends Plugin {
 
     this.addCommand({
       id: 'copy-access-key',
-      name: 'Copy Access Key',
+      name: t('command_copy_access_key'),
       callback: () => {
         void navigator.clipboard.writeText(this.settings.accessKey).then(() => {
-          new Notice('Access key copied to clipboard');
+          new Notice(t('notice_access_key_copied'));
         });
       },
     });
@@ -123,11 +124,11 @@ export default class McpPlugin extends Plugin {
       );
       await this.httpServer.start();
       this.updateStatusDisplay();
-      new Notice(`MCP server started on port ${String(this.settings.port)}`);
+      new Notice(t('notice_server_started', { port: this.settings.port }));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to start MCP server: ${message}`);
-      new Notice(`Failed to start MCP server: ${message}`);
+      new Notice(t('notice_server_start_failed', { message }));
     }
   }
 
@@ -189,8 +190,8 @@ export default class McpPlugin extends Plugin {
     if (this.ribbonIconEl) {
       setIcon(this.ribbonIconEl, isRunning ? ICON_MCP_RUNNING : ICON_MCP);
       this.ribbonIconEl.ariaLabel = isRunning
-        ? `MCP Server (running on :${String(this.settings.port)})`
-        : 'MCP Server (stopped)';
+        ? t('ribbon_tooltip_running', { port: this.settings.port })
+        : t('ribbon_tooltip_stopped');
     }
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
 import { randomBytes } from 'crypto';
 import type McpPlugin from './main';
 import type { ModuleRegistration } from './registry/types';
+import { t } from './lang/helpers';
 
 export class McpSettingsTab extends PluginSettingTab {
   plugin: McpPlugin;
@@ -26,24 +27,27 @@ export class McpSettingsTab extends PluginSettingTab {
   }
 
   private renderServerStatus(containerEl: HTMLElement): void {
-    containerEl.createEl('h2', { text: 'Server Status' });
+    containerEl.createEl('h2', { text: t('heading_server_status') });
 
     const isRunning = this.plugin.httpServer?.isRunning ?? false;
     const port = this.plugin.settings.port;
     const clients = this.plugin.httpServer?.connectedClients ?? 0;
 
     const address = this.plugin.settings.serverAddress;
+    const url = `${this.scheme()}://${address}:${String(port)}`;
     const statusText = isRunning
-      ? `Running on ${this.scheme()}://${address}:${String(port)} (${String(clients)} connection${clients !== 1 ? 's' : ''})`
-      : 'Stopped';
+      ? clients === 1
+        ? t('status_running_one', { url })
+        : t('status_running_many', { url, count: clients })
+      : t('status_stopped');
 
     const setting = new Setting(containerEl)
-      .setName('Status')
+      .setName(t('setting_status_name'))
       .setDesc(statusText)
       .addToggle((toggle) =>
         toggle
           .setValue(isRunning)
-          .setTooltip(isRunning ? 'Stop MCP server' : 'Start MCP server')
+          .setTooltip(isRunning ? t('tooltip_stop_server') : t('tooltip_start_server'))
           .onChange((value) => {
             const action = value
               ? this.plugin.startServer()
@@ -58,7 +62,7 @@ export class McpSettingsTab extends PluginSettingTab {
       setting.addExtraButton((btn) =>
         btn
           .setIcon('refresh-cw')
-          .setTooltip('Restart server')
+          .setTooltip(t('tooltip_restart_server'))
           .onClick(() => {
             void this.plugin.restartServer().then(() => {
               this.display();
@@ -69,11 +73,11 @@ export class McpSettingsTab extends PluginSettingTab {
   }
 
   private renderServerSettings(containerEl: HTMLElement): void {
-    containerEl.createEl('h2', { text: 'Server Settings' });
+    containerEl.createEl('h2', { text: t('heading_server_settings') });
 
     const addressSetting = new Setting(containerEl)
-      .setName('Server Address')
-      .setDesc('IP address the server binds to (default: 127.0.0.1). Requires restart.');
+      .setName(t('setting_server_address_name'))
+      .setDesc(t('setting_server_address_desc'));
     const addressError = createValidationError(addressSetting);
     addressSetting.addText((text) =>
       text
@@ -85,7 +89,7 @@ export class McpSettingsTab extends PluginSettingTab {
             this.plugin.settings.serverAddress = value;
             await this.plugin.saveSettings();
           } else {
-            addressError.show('Invalid IPv4 address. Expected format: 127.0.0.1');
+            addressError.show(t('error_invalid_ipv4'));
           }
         }),
     );
@@ -93,13 +97,13 @@ export class McpSettingsTab extends PluginSettingTab {
     if (this.plugin.settings.serverAddress !== '127.0.0.1') {
       addressSetting.descEl.createEl('br');
       addressSetting.descEl.createEl('strong', {
-        text: 'Warning: Non-localhost address exposes the server to the network. Ensure an access key is set.',
+        text: t('warning_non_localhost'),
       });
     }
 
     const portSetting = new Setting(containerEl)
-      .setName('Port')
-      .setDesc('HTTP port for the MCP server (default: 28741)');
+      .setName(t('setting_port_name'))
+      .setDesc(t('setting_port_desc'));
     const portError = createValidationError(portSetting);
     portSetting.addText((text) =>
       text
@@ -112,32 +116,32 @@ export class McpSettingsTab extends PluginSettingTab {
             this.plugin.settings.port = port;
             await this.plugin.saveSettings();
           } else {
-            portError.show('Invalid port. Enter a whole number between 1 and 65535.');
+            portError.show(t('error_invalid_port'));
           }
         }),
     );
 
     const serverUrl = `${this.scheme()}://${this.plugin.settings.serverAddress}:${String(this.plugin.settings.port)}/mcp`;
     new Setting(containerEl)
-      .setName('Server URL')
+      .setName(t('setting_server_url_name'))
       .setDesc(serverUrl)
       .addExtraButton((btn) =>
         btn
           .setIcon('copy')
-          .setTooltip('Copy server URL')
+          .setTooltip(t('tooltip_copy_server_url'))
           .onClick(() => {
             void navigator.clipboard.writeText(serverUrl).then(() => {
-              new Notice('MCP server URL copied to clipboard');
+              new Notice(t('notice_server_url_copied'));
             });
           }),
       );
 
     new Setting(containerEl)
-      .setName('Access Key')
-      .setDesc('Bearer token for authenticating MCP clients')
+      .setName(t('setting_access_key_name'))
+      .setDesc(t('setting_access_key_desc'))
       .addText((text) =>
         text
-          .setPlaceholder('Enter access key')
+          .setPlaceholder(t('placeholder_access_key'))
           .setValue(this.plugin.settings.accessKey)
           .onChange(async (value) => {
             this.plugin.settings.accessKey = value;
@@ -147,19 +151,19 @@ export class McpSettingsTab extends PluginSettingTab {
       .addExtraButton((btn) =>
         btn
           .setIcon('copy')
-          .setTooltip('Copy access key')
+          .setTooltip(t('tooltip_copy_access_key'))
           .onClick(() => {
             void navigator.clipboard
               .writeText(this.plugin.settings.accessKey)
               .then(() => {
-                new Notice('Access key copied to clipboard');
+                new Notice(t('notice_access_key_copied'));
               });
           }),
       )
       .addExtraButton((btn) =>
         btn
           .setIcon('refresh-cw')
-          .setTooltip('Generate')
+          .setTooltip(t('tooltip_generate'))
           .onClick(() => {
             this.plugin.settings.accessKey = generateAccessKey();
             void this.plugin.saveSettings().then(() => {
@@ -169,10 +173,8 @@ export class McpSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName('HTTPS')
-      .setDesc(
-        'Serve MCP over HTTPS with a locally generated self-signed certificate. Clients must trust the certificate (or disable certificate verification). Requires restart.',
-      )
+      .setName(t('setting_https_name'))
+      .setDesc(t('setting_https_desc'))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.httpsEnabled)
@@ -186,19 +188,19 @@ export class McpSettingsTab extends PluginSettingTab {
     if (this.plugin.settings.httpsEnabled) {
       const hasCert = this.plugin.settings.tlsCertificate !== null;
       new Setting(containerEl)
-        .setName('TLS Certificate')
+        .setName(t('setting_tls_cert_name'))
         .setDesc(
           hasCert
-            ? 'A self-signed certificate is cached. Regenerate to replace it (e.g. after changing the server address).'
-            : 'No certificate cached yet — one will be generated on the next server start.',
+            ? t('setting_tls_cert_desc_present')
+            : t('setting_tls_cert_desc_absent'),
         )
         .addExtraButton((btn) =>
           btn
             .setIcon('refresh-cw')
-            .setTooltip('Regenerate certificate')
+            .setTooltip(t('tooltip_regenerate_cert'))
             .onClick(() => {
               void this.plugin.regenerateTlsCertificate().then(() => {
-                new Notice('TLS certificate regenerated. Restart the server to apply.');
+                new Notice(t('notice_tls_regenerated'));
                 this.display();
               });
             }),
@@ -206,8 +208,8 @@ export class McpSettingsTab extends PluginSettingTab {
     }
 
     new Setting(containerEl)
-      .setName('Auto-start on launch')
-      .setDesc('Start MCP server automatically when Obsidian launches')
+      .setName(t('setting_autostart_name'))
+      .setDesc(t('setting_autostart_desc'))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.autoStart)
@@ -218,8 +220,8 @@ export class McpSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName('Debug Mode')
-      .setDesc('Enable verbose logging of MCP requests and responses')
+      .setName(t('setting_debug_name'))
+      .setDesc(t('setting_debug_desc'))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.debugMode)
@@ -232,22 +234,20 @@ export class McpSettingsTab extends PluginSettingTab {
   }
 
   private renderMcpConfig(containerEl: HTMLElement): void {
-    containerEl.createEl('h2', { text: 'MCP Client Configuration' });
+    containerEl.createEl('h2', { text: t('heading_mcp_client_config') });
 
     new Setting(containerEl)
-      .setName('Client configuration')
-      .setDesc(
-        'Copy the JSON snippet for your MCP client and paste it into the mcpServers section of its config (Claude Desktop, Claude Code, …).',
-      )
+      .setName(t('setting_client_config_name'))
+      .setDesc(t('setting_client_config_desc'))
       .addExtraButton((btn) =>
         btn
           .setIcon('copy')
-          .setTooltip('Copy configuration')
+          .setTooltip(t('tooltip_copy_config'))
           .onClick(() => {
             void navigator.clipboard
               .writeText(this.buildMcpConfigJson())
               .then(() => {
-                new Notice('MCP client configuration copied to clipboard');
+                new Notice(t('notice_config_copied'));
               });
           }),
       );
@@ -282,11 +282,11 @@ export class McpSettingsTab extends PluginSettingTab {
       (r) => r.module.metadata.group === 'extras',
     );
 
-    containerEl.createEl('h2', { text: 'Feature Modules' });
+    containerEl.createEl('h2', { text: t('heading_feature_modules') });
 
     if (modules.length === 0) {
       containerEl.createEl('p', {
-        text: 'No modules registered. Click "Refresh Modules" to re-run discovery.',
+        text: t('message_no_modules'),
         cls: 'setting-item-description',
       });
     }
@@ -296,14 +296,14 @@ export class McpSettingsTab extends PluginSettingTab {
     }
 
     if (extrasModules.length > 0) {
-      containerEl.createEl('h2', { text: 'Extras' });
+      containerEl.createEl('h2', { text: t('heading_extras') });
       for (const registration of extrasModules) {
         this.renderExtrasToolRows(containerEl, registration);
       }
     }
 
     new Setting(containerEl).addButton((btn) =>
-      btn.setButtonText('Refresh Modules').onClick(() => {
+      btn.setButtonText(t('button_refresh_modules')).onClick(() => {
         this.plugin.refreshModules();
         this.display();
       }),

--- a/tests/lang/helpers.test.ts
+++ b/tests/lang/helpers.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { t } from '../../src/lang/helpers';
+import en from '../../src/lang/locale/en';
+import de from '../../src/lang/locale/de';
+
+interface WindowWithStorage {
+  localStorage: { getItem: (key: string) => string | null };
+}
+
+function setLanguage(lang: string | null): void {
+  const win: WindowWithStorage = {
+    localStorage: {
+      getItem: (key: string): string | null =>
+        key === 'language' ? lang : null,
+    },
+  };
+  Object.defineProperty(globalThis, 'window', {
+    value: win,
+    configurable: true,
+  });
+}
+
+function clearWindow(): void {
+  delete (globalThis as unknown as { window?: unknown }).window;
+}
+
+describe('t()', () => {
+  const consoleErrorSpy = vi
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    clearWindow();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('locale detection', () => {
+    it('returns the English string when language is "en"', () => {
+      setLanguage('en');
+      expect(t('setting_status_name')).toBe(en.setting_status_name);
+    });
+
+    it('returns the German string when language is "de"', () => {
+      setLanguage('de');
+      expect(t('setting_status_name')).toBe(de.setting_status_name);
+    });
+
+    it('falls back to English when window is undefined (SSR / tests)', () => {
+      clearWindow();
+      expect(t('setting_port_name')).toBe(en.setting_port_name);
+    });
+
+    it('falls back to English when language is not set', () => {
+      setLanguage(null);
+      expect(t('setting_port_name')).toBe(en.setting_port_name);
+    });
+
+    it('does not log an error when using a registered locale', () => {
+      setLanguage('de');
+      t('setting_status_name');
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fallback behaviour', () => {
+    it('falls back to English when the German translation is missing for a key', () => {
+      setLanguage('de');
+      const germanMap = de as Partial<Record<string, string>>;
+      // Sanity check: the key exists in English but we simulate a gap in German
+      const key = 'setting_status_name';
+      const original = germanMap[key];
+      delete germanMap[key];
+      try {
+        expect(t('setting_status_name')).toBe(en.setting_status_name);
+      } finally {
+        if (original !== undefined) germanMap[key] = original;
+      }
+    });
+
+    it('falls back to English for an unknown locale and logs an error', () => {
+      setLanguage('fr');
+      const result = t('setting_port_name');
+      expect(result).toBe(en.setting_port_name);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fr'),
+      );
+    });
+  });
+
+  describe('interpolation', () => {
+    it('substitutes a single placeholder', () => {
+      setLanguage('en');
+      expect(t('notice_server_started', { port: 28741 })).toBe(
+        'MCP server started on port 28741',
+      );
+    });
+
+    it('substitutes multiple placeholders', () => {
+      setLanguage('en');
+      expect(
+        t('status_running_many', {
+          url: 'http://127.0.0.1:28741',
+          count: 3,
+        }),
+      ).toBe('Running on http://127.0.0.1:28741 (3 connections)');
+    });
+
+    it('leaves unknown placeholders untouched when params are missing', () => {
+      setLanguage('en');
+      expect(t('notice_server_started')).toBe('MCP server started on port {port}');
+    });
+
+    it('applies interpolation to the German string when locale is "de"', () => {
+      setLanguage('de');
+      expect(t('notice_server_started', { port: 28741 })).toBe(
+        'MCP-Server auf Port 28741 gestartet',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Introduces a tiny in-house i18n helper modelled on the obsidian-kanban
pattern: zero runtime dependencies, all translations compiled into the
plugin bundle. English is the source of truth; other locales are
Partial<Record<keyof typeof en, string>> maps and fall back to English
for missing keys. The active locale is auto-detected via
window.localStorage.getItem('language') — the same key Obsidian writes
for its own UI — so the plugin follows Obsidian's language setting
without a separate override.

All user-facing strings in the settings tab, ribbon tooltip, lifecycle
notices, and command palette entries now route through t(). MCP tool
names, descriptions, schemas, error payloads, and log output remain
English-only by design (LLM-facing, interop stability). PRD adds a new
Internationalization section with requirements I1-I4.

Closes #114