### PR TITLE
feat(diagnostics): add debug info bundle and persistent log file

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -137,6 +137,11 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 
 - **CR21** — Settings UI contains an "MCP Client Configuration" section with a clipboard-copy extra button that copies a ready-to-paste JSON snippet for the `mcpServers` entry of Claude Desktop / Claude Code config files. The snippet is derived live from the current `serverAddress`, `port`, and `accessKey`: it always includes the MCP endpoint URL (`http://<address>:<port>/mcp`) and, when the access key is non-empty, a `headers` object with `Authorization: Bearer <key>`. The copy action shows a confirmation Notice.
 
+### Diagnostics
+
+- **CR22** — Settings UI exposes a "Diagnostics" section rendered after the Feature Modules / Extras sections. It contains three rows: a Log File row whose description shows the relative path to the persistent debug log (see CR23); a "Copy debug info" row with an extra button that opens a modal preview of the debug bundle (read-only textarea with Copy and Close buttons); and a "Clear log" row with an extra button that empties the log file and shows a confirmation Notice.
+- **CR23** — The plugin persists structured log output to `<vault>/.obsidian/plugins/<plugin-id>/debug.log` via Obsidian's vault adapter (`app.vault.adapter`), not Node `fs`. Level gating mirrors console output: `info` and above always written, `debug` only when Debug Mode (CR4) is on. Writes are serialized through a single in-flight Promise chain so concurrent log calls do not interleave. Single-file rotation: when the file exceeds 1 MiB, the next write trims it to the most recent 512 KiB and prepends a `--- rotated ---` marker on its own line. No multi-file backups (`.1`, `.2`, …) are kept. Errors writing to the log are swallowed so logging never throws.
+
 ### Settings Persistence
 
 - **CR13** — All settings persisted in Obsidian's plugin data.json
@@ -162,6 +167,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 - **NFR9** — Self-signed HTTPS certificate generated locally, never transmitted
 - **NFR10** — Access key never appears in logs even in debug mode. The `Logger` enforces this by substituting the configured access key with the literal placeholder `[REDACTED]` in every formatted message string and every string reached recursively inside structured log data before the entry is emitted. `updateOptions` keeps the redaction key in sync with the current settings.
 - **NFR32** — The HTTP transport caps individual request bodies at 4 MiB. Requests whose body exceeds `MAX_BODY_BYTES` are rejected with a JSON-RPC `-32700` ("Parse error: Request body too large") response and the underlying socket is destroyed mid-upload to avoid buffering unbounded input. Implemented in `src/server/http-server.ts` (`readJsonBody`).
+- **NFR33** — The "Copy debug info" bundle (CR22) is plain text and never includes secret material. The access key is rendered as the literal placeholder `<set>` or `<empty>` (never the configured value), and the cached TLS certificate is rendered as `<present>` or `<absent>` (never the PEM contents). The recent-log tail included in the bundle is read straight from `debug.log` (CR23), which is already redacted at write time by the `Logger` per NFR10, so no additional scrubbing is performed on the tail.
 
 ### Reliability
 
@@ -227,6 +233,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 - **TR14** — Settings tab class extends PluginSettingTab
 - **TR15** — Ribbon icon showing server status (running/stopped)
 - **TR16** — Command palette commands: start server, stop server, restart server, copy access key
+- **TR26** — Adds a "Copy Debug Info" command palette entry alongside the four listed in TR16. Invoking it opens the same diagnostics modal as the "Copy debug info" button in the settings UI (CR22).
 
 ### Testing
 

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -71,11 +71,29 @@ const de: Partial<Record<keyof typeof en, string>> = {
   notice_server_started: 'MCP-Server auf Port {port} gestartet',
   notice_server_start_failed: 'MCP-Server konnte nicht gestartet werden: {message}',
 
+  // Diagnostics section
+  heading_diagnostics: 'Diagnose',
+  setting_log_file_name: 'Protokolldatei',
+  setting_copy_debug_info_name: 'Debug-Infos kopieren',
+  setting_copy_debug_info_desc:
+    'Öffnet eine Vorschau des Debug-Pakets (Einstellungen, Module, Serverstatus, aktuelles Protokoll) und kopiert es in die Zwischenablage.',
+  tooltip_copy_debug_info: 'Debug-Vorschau öffnen',
+  setting_clear_log_name: 'Protokoll leeren',
+  setting_clear_log_desc: 'Leert die persistente Debug-Protokolldatei.',
+  tooltip_clear_log: 'Protokolldatei leeren',
+  notice_log_cleared: 'Debug-Protokoll geleert',
+  notice_debug_info_copied: 'Debug-Infos in die Zwischenablage kopiert',
+  modal_debug_info_title: 'Debug-Infos',
+  modal_debug_info_loading: 'Wird zusammengestellt …',
+  button_copy: 'Kopieren',
+  button_close: 'Schließen',
+
   // Command palette entries
   command_start_server: 'MCP-Server starten',
   command_stop_server: 'MCP-Server stoppen',
   command_restart_server: 'MCP-Server neu starten',
   command_copy_access_key: 'Zugriffsschlüssel kopieren',
+  command_copy_debug_info: 'Debug-Infos kopieren',
 
   // Ribbon icon
   ribbon_mcp_server: 'MCP-Server',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -67,11 +67,29 @@ const en = {
   notice_server_started: 'MCP server started on port {port}',
   notice_server_start_failed: 'Failed to start MCP server: {message}',
 
+  // Settings — Diagnostics section
+  heading_diagnostics: 'Diagnostics',
+  setting_log_file_name: 'Log file',
+  setting_copy_debug_info_name: 'Copy debug info',
+  setting_copy_debug_info_desc:
+    'Open a preview of the debug info bundle (settings, modules, server status, recent log) and copy it to the clipboard.',
+  tooltip_copy_debug_info: 'Open debug info preview',
+  setting_clear_log_name: 'Clear log',
+  setting_clear_log_desc: 'Empty the persistent debug log file.',
+  tooltip_clear_log: 'Clear log file',
+  notice_log_cleared: 'Debug log cleared',
+  notice_debug_info_copied: 'Debug info copied to clipboard',
+  modal_debug_info_title: 'Debug info',
+  modal_debug_info_loading: 'Collecting…',
+  button_copy: 'Copy',
+  button_close: 'Close',
+
   // Command palette entries
   command_start_server: 'Start MCP Server',
   command_stop_server: 'Stop MCP Server',
   command_restart_server: 'Restart MCP Server',
   command_copy_access_key: 'Copy Access Key',
+  command_copy_debug_info: 'Copy Debug Info',
 
   // Ribbon icon
   ribbon_mcp_server: 'MCP Server',

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ import { RealObsidianAdapter, ObsidianAdapter } from './obsidian/adapter';
 import { discoverModules } from './tools';
 import { McpSettingsTab, migrateSettings } from './settings';
 import { t } from './lang/helpers';
+import { createLogFileSink } from './utils/log-file';
+import { DebugInfoModal } from './ui/debug-info-modal';
 
 const ICON_MCP = 'plug';
 const ICON_MCP_RUNNING = 'plug-zap';
@@ -28,6 +30,7 @@ export default class McpPlugin extends Plugin {
     this.logger = createLogger('mcp-plugin', {
       debugMode: this.settings.debugMode,
       accessKey: this.settings.accessKey,
+      sink: createLogFileSink(this),
     });
 
     this.adapter = new RealObsidianAdapter(this.app);
@@ -86,6 +89,14 @@ export default class McpPlugin extends Plugin {
         void navigator.clipboard.writeText(this.settings.accessKey).then(() => {
           new Notice(t('notice_access_key_copied'));
         });
+      },
+    });
+
+    this.addCommand({
+      id: 'copy-debug-info',
+      name: t('command_copy_debug_info'),
+      callback: () => {
+        new DebugInfoModal(this.app, this).open();
       },
     });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,8 @@ import { randomBytes } from 'crypto';
 import type McpPlugin from './main';
 import type { ModuleRegistration } from './registry/types';
 import { t } from './lang/helpers';
+import { clearLogFile, getLogFilePath } from './utils/log-file';
+import { DebugInfoModal } from './ui/debug-info-modal';
 
 export class McpSettingsTab extends PluginSettingTab {
   plugin: McpPlugin;
@@ -20,6 +22,7 @@ export class McpSettingsTab extends PluginSettingTab {
     this.renderServerSettings(containerEl);
     this.renderMcpConfig(containerEl);
     this.renderModuleToggles(containerEl);
+    this.renderDiagnostics(containerEl);
   }
 
   private scheme(): 'http' | 'https' {
@@ -273,6 +276,40 @@ export class McpSettingsTab extends PluginSettingTab {
       .slice(1, -1)
       .map((line) => line.slice(2))
       .join('\n');
+  }
+
+  private renderDiagnostics(containerEl: HTMLElement): void {
+    containerEl.createEl('h2', { text: t('heading_diagnostics') });
+
+    new Setting(containerEl)
+      .setName(t('setting_log_file_name'))
+      .setDesc(getLogFilePath(this.plugin));
+
+    new Setting(containerEl)
+      .setName(t('setting_copy_debug_info_name'))
+      .setDesc(t('setting_copy_debug_info_desc'))
+      .addExtraButton((btn) =>
+        btn
+          .setIcon('copy')
+          .setTooltip(t('tooltip_copy_debug_info'))
+          .onClick(() => {
+            new DebugInfoModal(this.plugin.app, this.plugin).open();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName(t('setting_clear_log_name'))
+      .setDesc(t('setting_clear_log_desc'))
+      .addExtraButton((btn) =>
+        btn
+          .setIcon('trash')
+          .setTooltip(t('tooltip_clear_log'))
+          .onClick(() => {
+            void clearLogFile(this.plugin).then(() => {
+              new Notice(t('notice_log_cleared'));
+            });
+          }),
+      );
   }
 
   private renderModuleToggles(containerEl: HTMLElement): void {

--- a/src/ui/debug-info-modal.ts
+++ b/src/ui/debug-info-modal.ts
@@ -1,0 +1,59 @@
+import { App, Modal, Notice } from 'obsidian';
+import type McpPlugin from '../main';
+import { collectDebugInfo } from '../utils/debug-info';
+import { t } from '../lang/helpers';
+
+/**
+ * Modal that previews the debug bundle in a read-only textarea and
+ * copies it to the clipboard on demand. Implements CR22.
+ */
+export class DebugInfoModal extends Modal {
+  private plugin: McpPlugin;
+
+  constructor(app: App, plugin: McpPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl('h2', { text: t('modal_debug_info_title') });
+
+    const textarea = contentEl.createEl('textarea', {
+      cls: 'mcp-debug-info-textarea',
+      attr: { readonly: 'true', rows: '20' },
+    });
+    textarea.value = t('modal_debug_info_loading');
+
+    const buttonRow = contentEl.createDiv({
+      cls: 'modal-button-container mcp-debug-info-buttons',
+    });
+    const copyBtn = buttonRow.createEl('button', {
+      text: t('button_copy'),
+      cls: 'mod-cta',
+    });
+    const closeBtn = buttonRow.createEl('button', { text: t('button_close') });
+
+    copyBtn.disabled = true;
+
+    copyBtn.addEventListener('click', () => {
+      void navigator.clipboard.writeText(textarea.value).then(() => {
+        new Notice(t('notice_debug_info_copied'));
+      });
+    });
+
+    closeBtn.addEventListener('click', () => {
+      this.close();
+    });
+
+    void collectDebugInfo(this.plugin).then((bundle) => {
+      textarea.value = bundle;
+      copyBtn.disabled = false;
+    });
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/utils/debug-info.ts
+++ b/src/utils/debug-info.ts
@@ -1,0 +1,128 @@
+import type { App } from 'obsidian';
+import type { McpPluginSettings } from '../types';
+import type { ModuleRegistration } from '../registry/types';
+import { readLogFile } from './log-file';
+
+/**
+ * Builds the plain-text "Copy debug info" bundle (CR22 / NFR33).
+ *
+ * Sections: Environment, Server, Settings (redacted), Modules,
+ * Recent log. The bundle never contains the access key or TLS PEM.
+ */
+
+const RECENT_LOG_LINES = 200;
+
+interface ServerSnapshot {
+  isRunning: boolean;
+  scheme: 'http' | 'https';
+  connectedClients: number;
+  activeSessions: number;
+  port: number;
+}
+
+export interface DebugInfoPluginRef {
+  app: App & { appVersion?: string };
+  manifest: { id: string; version: string };
+  settings: McpPluginSettings;
+  httpServer: ServerSnapshot | null;
+  registry: { getModules: () => ModuleRegistration[] };
+}
+
+export async function collectDebugInfo(
+  plugin: DebugInfoPluginRef,
+): Promise<string> {
+  const sections: string[] = [
+    section('Environment', renderEnvironment(plugin)),
+    section('Server', renderServer(plugin)),
+    section('Settings (redacted)', renderSettings(plugin.settings)),
+    section('Modules', renderModules(plugin.registry.getModules())),
+    section(
+      `Recent log (last ${String(RECENT_LOG_LINES)} lines)`,
+      await renderRecentLog(plugin),
+    ),
+  ];
+  return sections.join('\n\n') + '\n';
+}
+
+function section(title: string, body: string): string {
+  return `=== ${title} ===\n${body}`;
+}
+
+function renderEnvironment(plugin: DebugInfoPluginRef): string {
+  const obsidianVersion = plugin.app.appVersion ?? 'unknown';
+  const lines = [
+    `Plugin: ${plugin.manifest.id} ${plugin.manifest.version}`,
+    `Obsidian: ${obsidianVersion}`,
+    `Platform: ${process.platform} ${process.arch}`,
+    `Node: ${process.version}`,
+  ];
+  return lines.join('\n');
+}
+
+function renderServer(plugin: DebugInfoPluginRef): string {
+  const server = plugin.httpServer;
+  if (!server) {
+    return 'Status: stopped';
+  }
+  const lines = [
+    `Status: ${server.isRunning ? 'running' : 'stopped'}`,
+    `Scheme: ${server.scheme}`,
+    `Address: ${plugin.settings.serverAddress}`,
+    `Port: ${String(server.port)}`,
+    `Connected clients: ${String(server.connectedClients)}`,
+    `Active sessions: ${String(server.activeSessions)}`,
+  ];
+  return lines.join('\n');
+}
+
+function renderSettings(settings: McpPluginSettings): string {
+  const lines = [
+    `schemaVersion: ${String(settings.schemaVersion)}`,
+    `serverAddress: ${settings.serverAddress}`,
+    `port: ${String(settings.port)}`,
+    `accessKey: ${settings.accessKey.length > 0 ? '<set>' : '<empty>'}`,
+    `httpsEnabled: ${String(settings.httpsEnabled)}`,
+    `tlsCertificate: ${settings.tlsCertificate ? '<present>' : '<absent>'}`,
+    `debugMode: ${String(settings.debugMode)}`,
+    `autoStart: ${String(settings.autoStart)}`,
+  ];
+  return lines.join('\n');
+}
+
+function renderModules(modules: ModuleRegistration[]): string {
+  if (modules.length === 0) {
+    return '(none registered)';
+  }
+  const lines: string[] = [];
+  for (const reg of modules) {
+    const { id, group } = reg.module.metadata;
+    if (group === 'extras') {
+      lines.push(`- ${id} (extras)`);
+      const tools = reg.module.tools();
+      if (tools.length === 0) {
+        lines.push('    (no tools)');
+        continue;
+      }
+      for (const tool of tools) {
+        const enabled = reg.toolStates[tool.name] ?? false;
+        lines.push(`    - ${tool.name} (${enabled ? 'enabled' : 'disabled'})`);
+      }
+    } else {
+      lines.push(`- ${id} (${reg.enabled ? 'enabled' : 'disabled'})`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function renderRecentLog(plugin: DebugInfoPluginRef): Promise<string> {
+  const contents = await readLogFile(plugin);
+  if (contents.length === 0) {
+    return '(log is empty)';
+  }
+  const lines = contents.split('\n');
+  // split on '\n' for a trailing newline produces an empty final element; drop it.
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines.slice(-RECENT_LOG_LINES).join('\n');
+}

--- a/src/utils/log-file.ts
+++ b/src/utils/log-file.ts
@@ -1,0 +1,92 @@
+/**
+ * Persistent log-file sink for the Diagnostics surface (CR23).
+ *
+ * Writes to `<vault>/.obsidian/plugins/<plugin-id>/debug.log` via the
+ * Obsidian DataAdapter (no Node `fs`). All writes are serialized through
+ * a per-instance promise chain so concurrent log calls do not interleave,
+ * and the file is rotated in place when it grows past 1 MiB.
+ */
+
+export const LOG_FILE_NAME = 'debug.log';
+export const ROTATE_THRESHOLD_BYTES = 1024 * 1024;
+export const ROTATE_KEEP_BYTES = 512 * 1024;
+export const ROTATE_MARKER = '--- rotated ---\n';
+
+interface AdapterLike {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, data: string): Promise<void>;
+  append(path: string, data: string): Promise<void>;
+  stat(path: string): Promise<{ size: number } | null>;
+}
+
+export interface LogFilePluginRef {
+  app: { vault: { configDir: string; adapter: AdapterLike } };
+  manifest: { id: string };
+}
+
+export function getLogFilePath(plugin: LogFilePluginRef): string {
+  const configDir = plugin.app.vault.configDir;
+  return `${configDir}/plugins/${plugin.manifest.id}/${LOG_FILE_NAME}`;
+}
+
+export function createLogFileSink(
+  plugin: LogFilePluginRef,
+): (line: string) => void {
+  const adapter = plugin.app.vault.adapter;
+  const path = getLogFilePath(plugin);
+  let chain: Promise<void> = Promise.resolve();
+
+  return (line: string): void => {
+    chain = chain
+      .then(() => writeOneLine(adapter, path, line))
+      .catch(() => {
+        // Logging must never throw — swallow disk errors.
+      });
+  };
+}
+
+export async function readLogFile(plugin: LogFilePluginRef): Promise<string> {
+  const adapter = plugin.app.vault.adapter;
+  const path = getLogFilePath(plugin);
+  if (!(await adapter.exists(path))) {
+    return '';
+  }
+  return adapter.read(path);
+}
+
+export async function clearLogFile(plugin: LogFilePluginRef): Promise<void> {
+  const adapter = plugin.app.vault.adapter;
+  const path = getLogFilePath(plugin);
+  await adapter.write(path, '');
+}
+
+async function writeOneLine(
+  adapter: AdapterLike,
+  path: string,
+  line: string,
+): Promise<void> {
+  await rotateIfNeeded(adapter, path);
+  const payload = `${line}\n`;
+  if (await adapter.exists(path)) {
+    await adapter.append(path, payload);
+  } else {
+    await adapter.write(path, payload);
+  }
+}
+
+async function rotateIfNeeded(
+  adapter: AdapterLike,
+  path: string,
+): Promise<void> {
+  const stats = await adapter.stat(path);
+  if (!stats || stats.size <= ROTATE_THRESHOLD_BYTES) {
+    return;
+  }
+  const existing = await adapter.read(path);
+  const tail = existing.slice(-ROTATE_KEEP_BYTES);
+  // Drop the leading partial line so the rotated file starts cleanly.
+  const firstNewline = tail.indexOf('\n');
+  const aligned = firstNewline === -1 ? tail : tail.slice(firstNewline + 1);
+  await adapter.write(path, ROTATE_MARKER + aligned);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,6 +11,12 @@ export interface LogEntry {
 export interface LoggerOptions {
   debugMode: boolean;
   accessKey: string;
+  /**
+   * Optional plain-text sink invoked once per emitted log line, after
+   * level gating and access-key redaction. Used to persist log output
+   * to `debug.log` for the Diagnostics surface (CR23).
+   */
+  sink?: (line: string) => void;
 }
 
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
@@ -63,20 +69,30 @@ export class Logger {
       ...(data !== undefined && { data: this.redactUnknown(data) }),
     };
 
+    const json = JSON.stringify(entry);
+
     switch (level) {
       case 'debug':
       case 'info':
         // eslint-disable-next-line no-console
-        console.log(JSON.stringify(entry));
+        console.log(json);
         break;
       case 'warn':
         // eslint-disable-next-line no-console
-        console.warn(JSON.stringify(entry));
+        console.warn(json);
         break;
       case 'error':
         // eslint-disable-next-line no-console
-        console.error(JSON.stringify(entry));
+        console.error(json);
         break;
+    }
+
+    if (this.options.sink) {
+      try {
+        this.options.sink(formatPlainTextLine(entry));
+      } catch {
+        // Logging must never throw — swallow sink failures.
+      }
     }
   }
 
@@ -107,4 +123,19 @@ export class Logger {
 
 export function createLogger(module: string, options: LoggerOptions): Logger {
   return new Logger(module, options);
+}
+
+function formatPlainTextLine(entry: LogEntry): string {
+  const level = entry.level.toUpperCase().padEnd(5, ' ');
+  const base = `${entry.timestamp}  ${level}  [${entry.module}] ${entry.message}`;
+  if (entry.data === undefined) {
+    return base;
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(entry.data);
+  } catch {
+    serialized = '[unserializable]';
+  }
+  return `${base} ${serialized}`;
 }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -2,7 +2,7 @@
 
 export class Plugin {
   app: any;
-  manifest: any;
+  manifest: any = { id: 'obsidian-mcp', version: '0.0.0' };
   async loadData(): Promise<any> {
     return null;
   }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -8,13 +8,24 @@ interface TestPlugin extends McpPlugin {
 
 function createPlugin(persisted: Record<string, unknown> | null): TestPlugin {
   const app = {
-    vault: { adapter: { basePath: '/tmp/vault' } },
+    vault: {
+      configDir: '.obsidian',
+      adapter: {
+        basePath: '/tmp/vault',
+        exists: (): Promise<boolean> => Promise.resolve(false),
+        read: (): Promise<string> => Promise.resolve(''),
+        write: (): Promise<void> => Promise.resolve(),
+        append: (): Promise<void> => Promise.resolve(),
+        stat: (): Promise<null> => Promise.resolve(null),
+      },
+    },
     workspace: {},
     metadataCache: {},
   };
   /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-  const plugin = new McpPlugin(app as any, {} as any) as unknown as TestPlugin;
+  const plugin = new McpPlugin(app as any, { id: 'obsidian-mcp', version: '0.0.0' } as any) as unknown as TestPlugin;
   (plugin as any).app = app;
+  (plugin as any).manifest = { id: 'obsidian-mcp', version: '0.0.0' };
   /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
   plugin.loadData = vi.fn().mockResolvedValue(persisted);
   plugin.saveData = vi.fn().mockResolvedValue(undefined);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -333,6 +333,8 @@ describe('McpSettingsTab MCP config display', () => {
     registry: { getModules: () => [] };
     logger: { updateOptions: () => void };
     saveSettings: ReturnType<typeof vi.fn>;
+    app: { vault: { configDir: string } };
+    manifest: { id: string; version: string };
   } {
     return {
       settings: {
@@ -344,6 +346,8 @@ describe('McpSettingsTab MCP config display', () => {
       registry: { getModules: () => [] },
       logger: { updateOptions: (): void => {} },
       saveSettings: vi.fn().mockResolvedValue(undefined),
+      app: { vault: { configDir: '.obsidian' } },
+      manifest: { id: 'obsidian-mcp', version: '0.0.0' },
     };
   }
 
@@ -438,6 +442,8 @@ describe('McpSettingsTab server controls', () => {
       stopServer: vi.fn().mockResolvedValue(undefined),
       restartServer: vi.fn().mockResolvedValue(undefined),
       saveSettings: vi.fn().mockResolvedValue(undefined),
+      app: { vault: { configDir: '.obsidian' } },
+      manifest: { id: 'obsidian-mcp', version: '0.0.0' },
     };
   }
 
@@ -677,6 +683,8 @@ describe('McpSettingsTab module rows rendering', () => {
       registry,
       saveSettings: vi.fn().mockResolvedValue(undefined),
       logger: { updateOptions: (): void => {} },
+      app: { vault: { configDir: '.obsidian' } },
+      manifest: { id: 'obsidian-mcp', version: '0.0.0' },
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
     const tab = new McpSettingsTab({} as any, plugin as any);
@@ -863,6 +871,8 @@ describe('McpSettingsTab server settings validation', () => {
     registry: { getModules: () => [] };
     logger: { updateOptions: () => void };
     saveSettings: ReturnType<typeof vi.fn>;
+    app: { vault: { configDir: string } };
+    manifest: { id: string; version: string };
   } {
     return {
       settings: { ...DEFAULT_SETTINGS, accessKey: 'k' },
@@ -870,6 +880,8 @@ describe('McpSettingsTab server settings validation', () => {
       registry: { getModules: () => [] },
       logger: { updateOptions: (): void => {} },
       saveSettings: vi.fn().mockResolvedValue(undefined),
+      app: { vault: { configDir: '.obsidian' } },
+      manifest: { id: 'obsidian-mcp', version: '0.0.0' },
     };
   }
 

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { collectDebugInfo, type DebugInfoPluginRef } from '../../src/utils/debug-info';
+import type { McpPluginSettings } from '../../src/types';
+import type { ModuleRegistration, ToolModule } from '../../src/registry/types';
+
+const SECRET = 'super-secret-access-key';
+const FAKE_PEM = '-----BEGIN CERTIFICATE-----\nABCDEF\n-----END CERTIFICATE-----';
+
+interface FakeAdapter {
+  files: Map<string, string>;
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, data: string): Promise<void>;
+  append(path: string, data: string): Promise<void>;
+  stat(path: string): Promise<{ size: number } | null>;
+}
+
+function adapter(files: Record<string, string> = {}): FakeAdapter {
+  const map = new Map(Object.entries(files));
+  return {
+    files: map,
+    exists: (p: string): Promise<boolean> => Promise.resolve(map.has(p)),
+    read: (p: string): Promise<string> => {
+      const v = map.get(p);
+      if (v === undefined) return Promise.reject(new Error('ENOENT'));
+      return Promise.resolve(v);
+    },
+    write: (p: string, d: string): Promise<void> => {
+      map.set(p, d);
+      return Promise.resolve();
+    },
+    append: (p: string, d: string): Promise<void> => {
+      map.set(p, (map.get(p) ?? '') + d);
+      return Promise.resolve();
+    },
+    stat: (p: string): Promise<{ size: number } | null> => {
+      const v = map.get(p);
+      return Promise.resolve(v === undefined ? null : { size: v.length });
+    },
+  };
+}
+
+function makeModule(
+  id: string,
+  group: 'extras' | undefined,
+  toolNames: string[] = [],
+): ToolModule {
+  return {
+    metadata: {
+      id,
+      name: id,
+      description: '',
+      ...(group ? { group } : {}),
+    },
+    tools(): ReturnType<ToolModule['tools']> {
+      return toolNames.map((name) => ({
+        name,
+        description: '',
+        schema: {},
+        handler: () => Promise.resolve({ content: [] }),
+        isReadOnly: true,
+      }));
+    },
+  };
+}
+
+const baseSettings: McpPluginSettings = {
+  schemaVersion: 5,
+  serverAddress: '127.0.0.1',
+  port: 28741,
+  accessKey: SECRET,
+  httpsEnabled: false,
+  tlsCertificate: { cert: FAKE_PEM, key: FAKE_PEM },
+  debugMode: true,
+  autoStart: false,
+  moduleStates: {},
+};
+
+function makePlugin(opts: {
+  settings?: Partial<McpPluginSettings>;
+  files?: Record<string, string>;
+  httpServer?: DebugInfoPluginRef['httpServer'];
+  modules?: ModuleRegistration[];
+} = {}): DebugInfoPluginRef {
+  const a = adapter(opts.files);
+  return {
+    app: {
+      vault: { adapter: a, configDir: '.obsidian' },
+      appVersion: '1.8.9',
+      // unused fields cast away
+    } as unknown as DebugInfoPluginRef['app'],
+    manifest: { id: 'obsidian-mcp', version: '2.2.0' },
+    settings: { ...baseSettings, ...(opts.settings ?? {}) },
+    httpServer: opts.httpServer ?? null,
+    registry: { getModules: () => opts.modules ?? [] },
+  };
+}
+
+describe('collectDebugInfo', () => {
+  let bundle: string;
+
+  describe('with running server, set access key, cached TLS, modules', () => {
+    beforeEach(async () => {
+      const vaultMod: ModuleRegistration = {
+        module: makeModule('vault', undefined),
+        enabled: true,
+        toolStates: {},
+      };
+      const editorMod: ModuleRegistration = {
+        module: makeModule('editor', undefined),
+        enabled: false,
+        toolStates: {},
+      };
+      const extrasMod: ModuleRegistration = {
+        module: makeModule('extras', 'extras', ['get_date', 'other_tool']),
+        enabled: true,
+        toolStates: { get_date: true, other_tool: false },
+      };
+      bundle = await collectDebugInfo(
+        makePlugin({
+          httpServer: {
+            isRunning: true,
+            scheme: 'https',
+            connectedClients: 2,
+            activeSessions: 3,
+            port: 28741,
+          },
+          modules: [vaultMod, editorMod, extrasMod],
+          files: {
+            '.obsidian/plugins/obsidian-mcp/debug.log':
+              'line-1\nline-2\nline-3\n',
+          },
+        }),
+      );
+    });
+
+    it('contains all five section headers', () => {
+      expect(bundle).toContain('=== Environment ===');
+      expect(bundle).toContain('=== Server ===');
+      expect(bundle).toContain('=== Settings (redacted) ===');
+      expect(bundle).toContain('=== Modules ===');
+      expect(bundle).toContain('=== Recent log');
+    });
+
+    it('renders environment fields', () => {
+      expect(bundle).toContain('Plugin: obsidian-mcp 2.2.0');
+      expect(bundle).toContain('Obsidian: 1.8.9');
+      expect(bundle).toContain('Platform:');
+      expect(bundle).toContain('Node:');
+    });
+
+    it('renders server snapshot fields', () => {
+      expect(bundle).toContain('Status: running');
+      expect(bundle).toContain('Scheme: https');
+      expect(bundle).toContain('Address: 127.0.0.1');
+      expect(bundle).toContain('Port: 28741');
+      expect(bundle).toContain('Connected clients: 2');
+      expect(bundle).toContain('Active sessions: 3');
+    });
+
+    it('redacts the access key as <set>, never the literal value', () => {
+      expect(bundle).toContain('accessKey: <set>');
+      expect(bundle).not.toContain(SECRET);
+    });
+
+    it('redacts the TLS certificate as <present>, never the PEM', () => {
+      expect(bundle).toContain('tlsCertificate: <present>');
+      expect(bundle).not.toContain('BEGIN CERTIFICATE');
+      expect(bundle).not.toContain(FAKE_PEM);
+    });
+
+    it('lists core modules with enabled state', () => {
+      expect(bundle).toContain('- vault (enabled)');
+      expect(bundle).toContain('- editor (disabled)');
+    });
+
+    it('lists extras module with per-tool state', () => {
+      expect(bundle).toContain('- extras (extras)');
+      expect(bundle).toContain('    - get_date (enabled)');
+      expect(bundle).toContain('    - other_tool (disabled)');
+    });
+
+    it('includes the recent log tail', () => {
+      expect(bundle).toContain('line-1');
+      expect(bundle).toContain('line-3');
+    });
+  });
+
+  describe('with empty access key and absent TLS', () => {
+    it('shows <empty> for access key and <absent> for TLS', async () => {
+      bundle = await collectDebugInfo(
+        makePlugin({
+          settings: { accessKey: '', tlsCertificate: null },
+        }),
+      );
+      expect(bundle).toContain('accessKey: <empty>');
+      expect(bundle).toContain('tlsCertificate: <absent>');
+    });
+  });
+
+  describe('with no server running', () => {
+    it('renders Status: stopped without other server fields', async () => {
+      bundle = await collectDebugInfo(makePlugin({ httpServer: null }));
+      expect(bundle).toContain('Status: stopped');
+      expect(bundle).not.toContain('Connected clients:');
+    });
+  });
+
+  describe('with no log file present', () => {
+    it('shows "(log is empty)"', async () => {
+      bundle = await collectDebugInfo(makePlugin());
+      expect(bundle).toContain('(log is empty)');
+    });
+  });
+
+  describe('with no modules registered', () => {
+    it('shows "(none registered)"', async () => {
+      bundle = await collectDebugInfo(makePlugin({ modules: [] }));
+      expect(bundle).toContain('(none registered)');
+    });
+  });
+
+  describe('recent log tail size', () => {
+    it('limits the included tail to the most recent ~200 lines', async () => {
+      const lines = Array.from({ length: 500 }, (_, i) => `entry-${String(i)}`);
+      bundle = await collectDebugInfo(
+        makePlugin({
+          files: {
+            '.obsidian/plugins/obsidian-mcp/debug.log': lines.join('\n') + '\n',
+          },
+        }),
+      );
+      expect(bundle).toContain('entry-499');
+      expect(bundle).toContain('entry-300');
+      expect(bundle).not.toContain('entry-100');
+    });
+  });
+});

--- a/tests/utils/log-file.test.ts
+++ b/tests/utils/log-file.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clearLogFile,
+  createLogFileSink,
+  getLogFilePath,
+  readLogFile,
+  ROTATE_KEEP_BYTES,
+  ROTATE_MARKER,
+  ROTATE_THRESHOLD_BYTES,
+} from '../../src/utils/log-file';
+
+interface FakeAdapter {
+  files: Map<string, string>;
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, data: string): Promise<void>;
+  append(path: string, data: string): Promise<void>;
+  stat(path: string): Promise<{ size: number } | null>;
+}
+
+function createFakeAdapter(): FakeAdapter {
+  const files = new Map<string, string>();
+  return {
+    files,
+    exists: (path: string): Promise<boolean> => Promise.resolve(files.has(path)),
+    read: (path: string): Promise<string> => {
+      const v = files.get(path);
+      if (v === undefined) return Promise.reject(new Error(`ENOENT: ${path}`));
+      return Promise.resolve(v);
+    },
+    write: (path: string, data: string): Promise<void> => {
+      files.set(path, data);
+      return Promise.resolve();
+    },
+    append: (path: string, data: string): Promise<void> => {
+      files.set(path, (files.get(path) ?? '') + data);
+      return Promise.resolve();
+    },
+    stat: (path: string): Promise<{ size: number } | null> => {
+      const v = files.get(path);
+      if (v === undefined) return Promise.resolve(null);
+      return Promise.resolve({ size: Buffer.byteLength(v, 'utf8') });
+    },
+  };
+}
+
+function makePlugin(adapter: FakeAdapter): {
+  app: { vault: { adapter: FakeAdapter; configDir: string } };
+  manifest: { id: string };
+} {
+  return {
+    app: { vault: { adapter, configDir: '.obsidian' } },
+    manifest: { id: 'obsidian-mcp' },
+  };
+}
+
+const expectedPath = '.obsidian/plugins/obsidian-mcp/debug.log';
+
+async function flush(): Promise<void> {
+  // The sink serializes writes through a Promise chain whose individual
+  // links each await several microtasks (exists / stat / write or
+  // append). Drain a generous number of microtasks so the chain settles
+  // even for batches of ~50 calls.
+  for (let i = 0; i < 500; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('log-file', () => {
+  let adapter: FakeAdapter;
+  let plugin: ReturnType<typeof makePlugin>;
+
+  beforeEach(() => {
+    adapter = createFakeAdapter();
+    plugin = makePlugin(adapter);
+  });
+
+  describe('getLogFilePath', () => {
+    it('returns <configDir>/plugins/<id>/debug.log', () => {
+      expect(getLogFilePath(plugin)).toBe(expectedPath);
+    });
+  });
+
+  describe('readLogFile', () => {
+    it('returns "" when the file does not exist', async () => {
+      expect(await readLogFile(plugin)).toBe('');
+    });
+
+    it('returns the file contents when it exists', async () => {
+      adapter.files.set(expectedPath, 'hello\n');
+      expect(await readLogFile(plugin)).toBe('hello\n');
+    });
+  });
+
+  describe('clearLogFile', () => {
+    it('writes an empty string to the file', async () => {
+      adapter.files.set(expectedPath, 'old data\n');
+      await clearLogFile(plugin);
+      expect(adapter.files.get(expectedPath)).toBe('');
+    });
+  });
+
+  describe('createLogFileSink', () => {
+    it('creates the file on first write and appends a newline', async () => {
+      const sink = createLogFileSink(plugin);
+      sink('first');
+      await flush();
+      expect(adapter.files.get(expectedPath)).toBe('first\n');
+    });
+
+    it('appends subsequent lines instead of overwriting', async () => {
+      const sink = createLogFileSink(plugin);
+      sink('one');
+      sink('two');
+      sink('three');
+      await flush();
+      expect(adapter.files.get(expectedPath)).toBe('one\ntwo\nthree\n');
+    });
+
+    it('serializes concurrent writes (no interleaving)', async () => {
+      const sink = createLogFileSink(plugin);
+      const lines = Array.from({ length: 50 }, (_, i) => `line-${String(i)}`);
+      for (const l of lines) sink(l);
+      await flush();
+      const expected = lines.map((l) => `${l}\n`).join('');
+      expect(adapter.files.get(expectedPath)).toBe(expected);
+    });
+
+    it('rotates when the file exceeds the threshold', async () => {
+      // Pre-seed a file comfortably over the threshold. Lines are
+      // 9 bytes (`n-NNNNNN\n`) so we need at least
+      // ceil(threshold / 9) + buffer entries.
+      const lineCount = Math.ceil(ROTATE_THRESHOLD_BYTES / 9) + 1000;
+      const seeded =
+        Array.from(
+          { length: lineCount },
+          (_, i) => `n-${String(i).padStart(6, '0')}`,
+        ).join('\n') + '\n';
+      adapter.files.set(expectedPath, seeded);
+      expect(Buffer.byteLength(seeded, 'utf8')).toBeGreaterThan(
+        ROTATE_THRESHOLD_BYTES,
+      );
+
+      const sink = createLogFileSink(plugin);
+      sink('after-rotate');
+      await flush();
+
+      const result = adapter.files.get(expectedPath) ?? '';
+      expect(result.startsWith(ROTATE_MARKER)).toBe(true);
+      expect(result.endsWith('after-rotate\n')).toBe(true);
+      // Rotated payload is bounded by ROTATE_KEEP_BYTES + marker + new line.
+      expect(Buffer.byteLength(result, 'utf8')).toBeLessThan(
+        ROTATE_KEEP_BYTES + ROTATE_MARKER.length + 50,
+      );
+    });
+
+    it('does not rotate when the file is under the threshold', async () => {
+      adapter.files.set(expectedPath, 'small\n');
+      const sink = createLogFileSink(plugin);
+      sink('next');
+      await flush();
+      expect(adapter.files.get(expectedPath)).toBe('small\nnext\n');
+    });
+
+    it('swallows adapter errors so the sink never throws', async () => {
+      const failing: FakeAdapter = {
+        files: new Map(),
+        exists: (): Promise<boolean> => Promise.reject(new Error('boom')),
+        read: (): Promise<string> => Promise.reject(new Error('boom')),
+        write: (): Promise<void> => Promise.reject(new Error('boom')),
+        append: (): Promise<void> => Promise.reject(new Error('boom')),
+        stat: (): Promise<{ size: number } | null> =>
+          Promise.reject(new Error('boom')),
+      };
+      const sink = createLogFileSink(makePlugin(failing));
+      expect(() => sink('x')).not.toThrow();
+      await flush();
+    });
+  });
+});

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -169,4 +169,71 @@ describe('Logger', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('sink', () => {
+    it('invokes the sink once per emitted line at info level', () => {
+      const sink = vi.fn();
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const l = createLogger('m', { debugMode: false, accessKey: '', sink });
+      l.info('first');
+      l.info('second');
+      expect(sink).toHaveBeenCalledTimes(2);
+    });
+
+    it('invokes the sink for warn and error too', () => {
+      const sink = vi.fn();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const l = createLogger('m', { debugMode: false, accessKey: '', sink });
+      l.warn('w');
+      l.error('e');
+      expect(sink).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not invoke the sink for messages filtered by level', () => {
+      const sink = vi.fn();
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const l = createLogger('m', { debugMode: false, accessKey: '', sink });
+      l.debug('suppressed');
+      expect(sink).not.toHaveBeenCalled();
+    });
+
+    it('formats sink lines as human-readable plain text', () => {
+      const sink = vi.fn();
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const l = createLogger('http-server', {
+        debugMode: false,
+        accessKey: '',
+        sink,
+      });
+      l.info('listening', { port: 28741 });
+      const line = sink.mock.calls[0][0] as string;
+      expect(line).toMatch(
+        /^\d{4}-\d{2}-\d{2}T[^\s]+Z\s+INFO\s+\[http-server\] listening \{"port":28741\}$/,
+      );
+    });
+
+    it('redacts the access key in sink output', () => {
+      const sink = vi.fn();
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const l = createLogger('m', {
+        debugMode: false,
+        accessKey: 'sekrit',
+        sink,
+      });
+      l.info('Bearer sekrit');
+      const line = sink.mock.calls[0][0] as string;
+      expect(line).not.toContain('sekrit');
+      expect(line).toContain('[REDACTED]');
+    });
+
+    it('swallows sink errors so logging never throws', () => {
+      const sink = vi.fn(() => {
+        throw new Error('disk full');
+      });
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const l = createLogger('m', { debugMode: false, accessKey: '', sink });
+      expect(() => l.info('x')).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a **Diagnostics** section to the settings tab and a **Copy Debug Info** command palette entry. Both open a preview modal showing a plain-text bundle (environment, server status, redacted settings, modules, recent log) that the user can copy in one click.
- Mirrors all logger output to `<vault>/.obsidian/plugins/obsidian-mcp/debug.log` via the Obsidian vault adapter, with single-file rotation at 1 MiB → 512 KiB. The existing access-key redaction in `Logger` applies to the file too.
- Bundle redaction (NFR33): access key rendered as `<set>` / `<empty>`, TLS certificate rendered as `<present>` / `<absent>` — never the literal value or PEM contents.
- Adds new PRD requirements **CR22, CR23, NFR33, TR26** per the repo's ID-governance rules (no IDs deleted or reused).

Closes #143

## Test plan

- [x] `npm test` — 356/356 passing (29 new across logger sink, log-file rotation/serialization, and debug-info redaction)
- [x] `npm run lint` — 0 errors (only the 2 pre-existing settings.test.ts warnings)
- [x] `npm run typecheck` — clean
- [x] Visual check via the Xvfb + CDP screenshot pipeline: Diagnostics section renders below Feature Modules; modal opens via both the settings button and the `Copy Debug Info` command; Copy button writes the bundle to clipboard
- [x] Confirmed redacted bundle never contains the access key or TLS PEM
- [ ] Reviewer to verify on a real vault: log file is created on first emitted line, `Clear log` empties it, rotation marker appears once the file grows past 1 MiB
