### PR TITLE
feat: add toggle to require Bearer authentication (off by default)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -110,12 +110,13 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 ### Server Settings
 
 - **CR1** — Configurable HTTP port with default value 28741
-- **CR2** — Access key field for authentication (user-provided, with a "Generate" button for convenience). The Generate button produces a new access key by calling Node's `crypto.randomBytes(32)` and rendering the 32 random bytes as a 64-character lowercase hex string, then overwrites the stored access key and re-renders the settings tab.
+- **CR2** — Access key field for authentication (user-provided, with a "Generate" button for convenience). The Generate button produces a new access key by calling Node's `crypto.randomBytes(32)` and rendering the 32 random bytes as a 64-character lowercase hex string, then overwrites the stored access key and re-renders the settings tab. The Access Key row only renders when **CR24** ("Require Bearer authentication") is on; with auth disabled the row is hidden because the key has no effect.
 - **CR3** — Toggle between HTTP and HTTPS (self-signed certificate), HTTP by default
 - **CR4** — Debug mode toggle that enables verbose logging
 - **CR17** — Configurable server IP address (default `127.0.0.1`). Must validate IPv4 format. Settings UI shows a security warning when bound to a non-localhost address. Requires server restart to take effect.
-- **CR19** — Auto-start on launch toggle. Defaults to off. When on, the plugin's `onload` starts the MCP server automatically during plugin load only if the stored access key is non-empty; if `autoStart` is true but no access key is configured, the server is left stopped and the plugin logs an `info` entry explaining why. Users must explicitly opt in per install.
+- **CR19** — Auto-start on launch toggle. Defaults to off. When on, the plugin's `onload` starts the MCP server automatically during plugin load. The auto-start gate respects **CR24**: if Bearer auth is enabled but no access key is configured, the server is left stopped and the plugin logs an `info` entry explaining why; if Bearer auth is disabled, no access key is required for auto-start. Users must explicitly opt in per install.
 - **CR20** — Server URL row displays the current `http://<address>:<port>/mcp` URL in its description and exposes a clipboard-copy extra button ("Copy server URL") that writes that URL to the clipboard and shows a confirmation Notice.
+- **CR24** — "Require Bearer authentication" toggle in Server Settings. Defaults to **off** so a fresh install can be used without first generating an access key. When off, `authenticateRequest` short-circuits and the server accepts every request regardless of the `Authorization` header; the Access Key row (CR2) is hidden, and the MCP client configuration snippet (CR21) omits the `headers`/`Authorization` entry. When on, the existing CR2 access key field is rendered and **NFR5** Bearer enforcement applies. Persisted as `authEnabled` in the v6 settings schema (see Appendix A).
 
 ### Feature Access Control
 
@@ -135,7 +136,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 
 ### MCP Client Configuration
 
-- **CR21** — Settings UI contains an "MCP Client Configuration" section with a clipboard-copy extra button that copies a ready-to-paste JSON snippet for the `mcpServers` entry of Claude Desktop / Claude Code config files. The snippet is derived live from the current `serverAddress`, `port`, and `accessKey`: it always includes the MCP endpoint URL (`http://<address>:<port>/mcp`) and, when the access key is non-empty, a `headers` object with `Authorization: Bearer <key>`. The copy action shows a confirmation Notice.
+- **CR21** — Settings UI contains an "MCP Client Configuration" section with a clipboard-copy extra button that copies a ready-to-paste JSON snippet for the `mcpServers` entry of Claude Desktop / Claude Code config files. The snippet is derived live from the current `serverAddress`, `port`, `authEnabled`, and `accessKey`: it always includes the MCP endpoint URL (`http://<address>:<port>/mcp`) and, only when Bearer auth is enabled (CR24) **and** the access key is non-empty, a `headers` object with `Authorization: Bearer <key>`. The copy action shows a confirmation Notice.
 
 ### Diagnostics
 
@@ -159,7 +160,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 
 ### Security
 
-- **NFR5** — All MCP requests require a valid access key (Bearer token). Bearer authentication is enforced by `authenticateRequest` before any request-routing logic, including the MCP `initialize` handshake and any subsequent `mcp-session-id`-keyed calls. CORS preflight (`OPTIONS`) requests are handled earlier and are the only HTTP traffic that does not require the Bearer token. If the server has no configured access key, every request is rejected with an authentication error.
+- **NFR5** — Bearer-token authentication is opt-in and controlled by **CR24** (`authEnabled`, default off). When enabled, every MCP request must carry a valid `Authorization: Bearer <key>` header; enforcement happens in `authenticateRequest` before any request-routing logic, including the MCP `initialize` handshake and any subsequent `mcp-session-id`-keyed calls. With auth enabled and no access key configured, every request is rejected with an authentication error. When `authEnabled` is off, `authenticateRequest` short-circuits and accepts every request — operators must rely on network controls (localhost-only binding, firewall) instead. CORS preflight (`OPTIONS`) requests are handled earlier and never reach the auth check in either mode.
 - **NFR6** — CORS headers configurable and restrictive by default
 - ~~NFR7~~ — ~~Disabled feature categories reject requests with 403, not just hide tools~~
 - **NFR30** — Disabled feature modules (and, for Extras, individually disabled tools) are filtered out of the MCP tool list advertised to clients. A client that invokes a tool from a disabled module receives the standard MCP unknown-tool error from the SDK; the plugin does not emit an HTTP 403 for feature-gating. Replaces ~~NFR7~~ because the implemented contract is "hide disabled tools at `tools/list` time", not "reject with HTTP 403".
@@ -274,5 +275,7 @@ This appendix grounds CR14 in the concrete migration steps implemented in `migra
 - **v2** — Adds `serverAddress`, defaulting to `127.0.0.1` (see CR17).
 - **v3** — Adds `autoStart`, defaulting to `false` for existing installs so the server never starts unexpectedly after an upgrade (see CR19).
 - **v4** — Removes the per-module `readOnly` flag from every `moduleStates` entry (the feature was dropped), and converts the Extras group from a single module-level toggle to per-tool toggles (`toolStates`). Preserves behaviour: if the Extras module was previously enabled, the known `get_date` tool stays enabled; otherwise its `toolStates` map is initialized empty.
+- **v5** — Adds `tlsCertificate`, defaulting to `null` so the self-signed certificate is generated on the next server start with HTTPS enabled.
+- **v6** — Adds `authEnabled`, defaulting to `false` (see CR24 / NFR5). Existing installs that previously relied on always-on Bearer auth will need to flip the toggle back on after upgrading; the access key itself is preserved so re-enabling auth restores the prior behaviour without regenerating the key.
 
 Future schema versions must be appended here with the same format (version number, behaviour summary, rationale, and links to the CRs/NFRs they serve).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,10 @@
 # Security Best Practices
 
+## Bearer Authentication
+
+- **Off by default**: Bearer authentication is opt-in via the **Require Bearer authentication** toggle in Server Settings. With it off the server accepts every request without an `Authorization` header — only safe on a trusted, localhost-only setup.
+- **Turn it on for any non-local exposure**: If you bind the server to anything other than `127.0.0.1`, or share the host with anyone you don't trust, enable the toggle and configure an access key.
+
 ## Access Key Management
 
 - **Generate a strong key**: Use the "Generate" button to create a random 64-character hex key

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -30,6 +30,9 @@ const de: Partial<Record<keyof typeof en, string>> = {
   setting_server_url_name: 'Server-URL',
   tooltip_copy_server_url: 'Server-URL kopieren',
   notice_server_url_copied: 'MCP-Server-URL in die Zwischenablage kopiert',
+  setting_auth_enabled_name: 'Bearer-Authentifizierung erforderlich',
+  setting_auth_enabled_desc:
+    'Wenn aktiviert, verlangt der Server bei jeder MCP-Anfrage einen gültigen Bearer-Zugriffsschlüssel. Wenn deaktiviert, werden Anfragen ohne Authentifizierung akzeptiert — nur in einer vertrauenswürdigen, ausschließlich lokal erreichbaren Umgebung sicher.',
   setting_access_key_name: 'Zugriffsschlüssel',
   setting_access_key_desc: 'Bearer-Token zur Authentifizierung von MCP-Clients',
   placeholder_access_key: 'Zugriffsschlüssel eingeben',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -27,6 +27,9 @@ const en = {
   setting_server_url_name: 'Server URL',
   tooltip_copy_server_url: 'Copy server URL',
   notice_server_url_copied: 'MCP server URL copied to clipboard',
+  setting_auth_enabled_name: 'Require Bearer authentication',
+  setting_auth_enabled_desc:
+    'When on, the server requires a valid Bearer access key on every MCP request. When off, requests are accepted without authentication — only safe on a trusted, localhost-only setup.',
   setting_access_key_name: 'Access Key',
   setting_access_key_desc: 'Bearer token for authenticating MCP clients',
   placeholder_access_key: 'Enter access key',

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,14 +100,20 @@ export default class McpPlugin extends Plugin {
       },
     });
 
-    // Start server only when explicitly opted in and an access key is set
-    if (this.settings.autoStart && this.settings.accessKey) {
+    // Start server only when explicitly opted in. If auth is enabled, require
+    // a configured access key — otherwise every request would be rejected.
+    const canAutoStart =
+      this.settings.autoStart &&
+      (!this.settings.authEnabled || this.settings.accessKey.length > 0);
+    if (canAutoStart) {
       await this.startServer();
     } else {
-      if (!this.settings.accessKey) {
-        this.logger.info('MCP server not started: no access key configured');
-      } else {
+      if (!this.settings.autoStart) {
         this.logger.info('MCP server not started: auto-start is disabled');
+      } else {
+        this.logger.info(
+          'MCP server not started: Bearer auth is on but no access key is configured',
+        );
       }
       this.updateStatusDisplay();
     }
@@ -129,6 +135,7 @@ export default class McpPlugin extends Plugin {
         {
           host: this.settings.serverAddress,
           port: this.settings.port,
+          authEnabled: this.settings.authEnabled,
           accessKey: this.settings.accessKey,
           tls,
         },

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -8,7 +8,12 @@ export interface AuthResult {
 export function authenticateRequest(
   req: IncomingMessage,
   accessKey: string,
+  authEnabled: boolean,
 ): AuthResult {
+  if (!authEnabled) {
+    return { authenticated: true };
+  }
+
   if (!accessKey || accessKey.length === 0) {
     return { authenticated: false, error: 'Server access key is not configured' };
   }

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -11,6 +11,8 @@ import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } 
 export interface HttpServerOptions {
   host: string;
   port: number;
+  /** When false, the server skips Bearer token validation entirely. */
+  authEnabled: boolean;
   accessKey: string;
   corsOptions?: CorsOptions;
   /** When provided, the server uses HTTPS with these PEM-encoded credentials. */
@@ -116,7 +118,11 @@ export class HttpMcpServer {
 
     applyCorsHeaders(res, corsOptions);
 
-    const authResult = authenticateRequest(req, this.options.accessKey);
+    const authResult = authenticateRequest(
+      req,
+      this.options.accessKey,
+      this.options.authEnabled,
+    );
     if (!authResult.authenticated) {
       this.logger.warn('Authentication failed', { error: authResult.error });
       sendAuthError(res, authResult.error ?? 'Authentication failed');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,40 +140,55 @@ export class McpSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName(t('setting_access_key_name'))
-      .setDesc(t('setting_access_key_desc'))
-      .addText((text) =>
-        text
-          .setPlaceholder(t('placeholder_access_key'))
-          .setValue(this.plugin.settings.accessKey)
+      .setName(t('setting_auth_enabled_name'))
+      .setDesc(t('setting_auth_enabled_desc'))
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.authEnabled)
           .onChange(async (value) => {
-            this.plugin.settings.accessKey = value;
+            this.plugin.settings.authEnabled = value;
             await this.plugin.saveSettings();
-          }),
-      )
-      .addExtraButton((btn) =>
-        btn
-          .setIcon('copy')
-          .setTooltip(t('tooltip_copy_access_key'))
-          .onClick(() => {
-            void navigator.clipboard
-              .writeText(this.plugin.settings.accessKey)
-              .then(() => {
-                new Notice(t('notice_access_key_copied'));
-              });
-          }),
-      )
-      .addExtraButton((btn) =>
-        btn
-          .setIcon('refresh-cw')
-          .setTooltip(t('tooltip_generate'))
-          .onClick(() => {
-            this.plugin.settings.accessKey = generateAccessKey();
-            void this.plugin.saveSettings().then(() => {
-              this.display();
-            });
+            this.display();
           }),
       );
+
+    if (this.plugin.settings.authEnabled) {
+      new Setting(containerEl)
+        .setName(t('setting_access_key_name'))
+        .setDesc(t('setting_access_key_desc'))
+        .addText((text) =>
+          text
+            .setPlaceholder(t('placeholder_access_key'))
+            .setValue(this.plugin.settings.accessKey)
+            .onChange(async (value) => {
+              this.plugin.settings.accessKey = value;
+              await this.plugin.saveSettings();
+            }),
+        )
+        .addExtraButton((btn) =>
+          btn
+            .setIcon('copy')
+            .setTooltip(t('tooltip_copy_access_key'))
+            .onClick(() => {
+              void navigator.clipboard
+                .writeText(this.plugin.settings.accessKey)
+                .then(() => {
+                  new Notice(t('notice_access_key_copied'));
+                });
+            }),
+        )
+        .addExtraButton((btn) =>
+          btn
+            .setIcon('refresh-cw')
+            .setTooltip(t('tooltip_generate'))
+            .onClick(() => {
+              this.plugin.settings.accessKey = generateAccessKey();
+              void this.plugin.saveSettings().then(() => {
+                this.display();
+              });
+            }),
+        );
+    }
 
     new Setting(containerEl)
       .setName(t('setting_https_name'))
@@ -260,11 +275,12 @@ export class McpSettingsTab extends PluginSettingTab {
     const address = this.plugin.settings.serverAddress;
     const port = this.plugin.settings.port;
     const accessKey = this.plugin.settings.accessKey;
+    const authEnabled = this.plugin.settings.authEnabled;
     const url = `${this.scheme()}://${address}:${String(port)}/mcp`;
 
     const config: Record<string, unknown> = { url };
 
-    if (accessKey) {
+    if (authEnabled && accessKey) {
       config.headers = {
         Authorization: `Bearer ${accessKey}`,
       };
@@ -491,6 +507,14 @@ export function migrateSettings(
     data.schemaVersion = 5;
     // V4 -> V5: introduce cached self-signed TLS certificate.
     if (data.tlsCertificate === undefined) data.tlsCertificate = null;
+  }
+
+  if ((data.schemaVersion as number) < 6) {
+    data.schemaVersion = 6;
+    // V5 -> V6: introduce optional Bearer authentication. Default to off so
+    // existing installs match new-install behaviour; users who want auth can
+    // toggle it back on in Server Settings.
+    if (data.authEnabled === undefined) data.authEnabled = false;
   }
 
   return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export interface McpPluginSettings {
   serverAddress: string;
   /** HTTP port for the MCP server */
   port: number;
+  /** When true, the server requires a Bearer access key on every request. */
+  authEnabled: boolean;
   /** Access key for bearer token authentication */
   accessKey: string;
   /** Enable HTTPS with self-signed certificate */
@@ -31,9 +33,10 @@ export interface ModuleState {
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 5,
+  schemaVersion: 6,
   serverAddress: '127.0.0.1',
   port: 28741,
+  authEnabled: false,
   accessKey: '',
   httpsEnabled: false,
   tlsCertificate: null,

--- a/tests/integration/https-server.test.ts
+++ b/tests/integration/https-server.test.ts
@@ -67,6 +67,7 @@ describe('Integration: HTTPS server', () => {
       {
         host: '127.0.0.1',
         port: TEST_PORT,
+        authEnabled: true,
         accessKey: ACCESS_KEY,
         tls,
       },

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -87,6 +87,7 @@ describe('Integration: HTTP Server Authentication', () => {
       {
         host: '127.0.0.1',
         port: TEST_PORT,
+        authEnabled: true,
         accessKey: ACCESS_KEY,
       },
     );

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -73,15 +73,17 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(startSpy).toHaveBeenCalled();
   });
 
-  it('does not start the server when autoStart is true but no access key is set', async () => {
+  it('does not start the server when autoStart is true, auth is required, but no access key is set', async () => {
     const plugin = createPlugin({
-      schemaVersion: 3,
+      schemaVersion: 6,
       serverAddress: '127.0.0.1',
       port: 28741,
       accessKey: '',
       httpsEnabled: false,
+      tlsCertificate: null,
       debugMode: false,
       autoStart: true,
+      authEnabled: true,
       moduleStates: {},
     });
     const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
@@ -89,6 +91,26 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     await plugin.onload();
 
     expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it('starts the server when autoStart is true and Bearer auth is disabled, even without an access key', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 6,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: true,
+      authEnabled: false,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(startSpy).toHaveBeenCalled();
   });
 
   it('swaps the ribbon icon glyph when the server transitions between stopped and running', async () => {

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -9,44 +9,74 @@ function createMockRequest(headers: Record<string, string> = {}): IncomingMessag
 describe('authenticateRequest', () => {
   const accessKey = 'test-key-12345';
 
-  it('should authenticate with a valid bearer token', () => {
-    const req = createMockRequest({ authorization: `Bearer ${accessKey}` });
-    const result = authenticateRequest(req, accessKey);
-    expect(result.authenticated).toBe(true);
-    expect(result.error).toBeUndefined();
+  describe('with auth enabled', () => {
+    it('should authenticate with a valid bearer token', () => {
+      const req = createMockRequest({ authorization: `Bearer ${accessKey}` });
+      const result = authenticateRequest(req, accessKey, true);
+      expect(result.authenticated).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should reject when no Authorization header is present', () => {
+      const req = createMockRequest({});
+      const result = authenticateRequest(req, accessKey, true);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Missing Authorization');
+    });
+
+    it('should reject when Authorization header format is invalid', () => {
+      const req = createMockRequest({ authorization: 'Basic abc123' });
+      const result = authenticateRequest(req, accessKey, true);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Invalid Authorization');
+    });
+
+    it('should reject when the token does not match', () => {
+      const req = createMockRequest({ authorization: 'Bearer wrong-key' });
+      const result = authenticateRequest(req, accessKey, true);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Invalid access key');
+    });
+
+    it('should reject when access key is empty', () => {
+      const req = createMockRequest({ authorization: 'Bearer something' });
+      const result = authenticateRequest(req, '', true);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('not configured');
+    });
+
+    it('should reject token with extra spaces', () => {
+      const req = createMockRequest({ authorization: `Bearer  ${accessKey}` });
+      const result = authenticateRequest(req, accessKey, true);
+      expect(result.authenticated).toBe(false);
+    });
   });
 
-  it('should reject when no Authorization header is present', () => {
-    const req = createMockRequest({});
-    const result = authenticateRequest(req, accessKey);
-    expect(result.authenticated).toBe(false);
-    expect(result.error).toContain('Missing Authorization');
-  });
+  describe('with auth disabled', () => {
+    it('authenticates a request with no Authorization header', () => {
+      const req = createMockRequest({});
+      const result = authenticateRequest(req, accessKey, false);
+      expect(result.authenticated).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
 
-  it('should reject when Authorization header format is invalid', () => {
-    const req = createMockRequest({ authorization: 'Basic abc123' });
-    const result = authenticateRequest(req, accessKey);
-    expect(result.authenticated).toBe(false);
-    expect(result.error).toContain('Invalid Authorization');
-  });
+    it('authenticates even when the access key is empty', () => {
+      const req = createMockRequest({});
+      const result = authenticateRequest(req, '', false);
+      expect(result.authenticated).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
 
-  it('should reject when the token does not match', () => {
-    const req = createMockRequest({ authorization: 'Bearer wrong-key' });
-    const result = authenticateRequest(req, accessKey);
-    expect(result.authenticated).toBe(false);
-    expect(result.error).toContain('Invalid access key');
-  });
+    it('authenticates regardless of an invalid Bearer token', () => {
+      const req = createMockRequest({ authorization: 'Bearer wrong-key' });
+      const result = authenticateRequest(req, accessKey, false);
+      expect(result.authenticated).toBe(true);
+    });
 
-  it('should reject when access key is empty', () => {
-    const req = createMockRequest({ authorization: 'Bearer something' });
-    const result = authenticateRequest(req, '');
-    expect(result.authenticated).toBe(false);
-    expect(result.error).toContain('not configured');
-  });
-
-  it('should reject token with extra spaces', () => {
-    const req = createMockRequest({ authorization: `Bearer  ${accessKey}` });
-    const result = authenticateRequest(req, accessKey);
-    expect(result.authenticated).toBe(false);
+    it('authenticates regardless of a malformed Authorization header', () => {
+      const req = createMockRequest({ authorization: 'Basic nope' });
+      const result = authenticateRequest(req, accessKey, false);
+      expect(result.authenticated).toBe(true);
+    });
   });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4,10 +4,10 @@ import { migrateSettings, generateAccessKey, isValidIPv4, McpSettingsTab } from 
 import { DEFAULT_SETTINGS } from '../src/types';
 
 describe('migrateSettings', () => {
-  it('should migrate v0 (no schemaVersion) to v4', () => {
+  it('should migrate v0 (no schemaVersion) to current schema', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -15,6 +15,7 @@ describe('migrateSettings', () => {
     expect(result.moduleStates).toEqual({});
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
+    expect(result.authEnabled).toBe(false);
   });
 
   it('should preserve existing values during migration', () => {
@@ -24,7 +25,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -32,7 +33,7 @@ describe('migrateSettings', () => {
     expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v1 data to v4 by adding serverAddress and autoStart', () => {
+  it('should migrate v1 data by adding serverAddress and autoStart', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 1,
       port: 28741,
@@ -42,12 +43,12 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v2 data to v4 by adding autoStart=false', () => {
+  it('should migrate v2 data by adding autoStart=false', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 2,
       serverAddress: '192.168.1.100',
@@ -58,11 +59,11 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.autoStart).toBe(false);
   });
 
-  it('should migrate v3 data to v4 by stripping per-module readOnly flags', () => {
+  it('should migrate v3 data by stripping per-module readOnly flags', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 3,
       serverAddress: '127.0.0.1',
@@ -77,7 +78,7 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
@@ -96,13 +97,51 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.tlsCertificate).toBeNull();
   });
 
-  it('should not modify data already at v5', () => {
+  it('should migrate v5 data to v6 by adding authEnabled=false', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 5,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: 'test',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: false,
+      moduleStates: {},
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(6);
+    expect(result.authEnabled).toBe(false);
+  });
+
+  it('v5->v6 migration sets authEnabled=false even when an access key is configured', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 5,
+      accessKey: 'pre-existing-key',
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(6);
+    expect(result.authEnabled).toBe(false);
+    expect(result.accessKey).toBe('pre-existing-key');
+  });
+
+  it('v5->v6 preserves an explicitly set authEnabled=true value', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 5,
+      authEnabled: true,
+    };
+    const result = migrateSettings(data);
+    expect(result.schemaVersion).toBe(6);
+    expect(result.authEnabled).toBe(true);
+  });
+
+  it('should not modify data already at v6', () => {
+    const data: Record<string, unknown> = {
+      schemaVersion: 6,
       serverAddress: '192.168.1.100',
       port: 28741,
       accessKey: 'test',
@@ -110,6 +149,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'C', key: 'K' },
       debugMode: false,
       autoStart: true,
+      authEnabled: true,
       moduleStates: {},
     };
     const result = migrateSettings(data);
@@ -122,7 +162,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.tlsCertificate).toEqual({
       cert: 'EXISTING_CERT',
       key: 'EXISTING_KEY',
@@ -134,12 +174,13 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
+    expect(result.authEnabled).toBe(false);
   });
 
   it('should migrate v3 extras state to per-tool states (enabled -> get_date on)', () => {
@@ -154,7 +195,7 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(5);
+    expect(result.schemaVersion).toBe(6);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
@@ -201,6 +242,14 @@ describe('migrateSettings', () => {
 describe('DEFAULT_SETTINGS', () => {
   it('should default autoStart to false', () => {
     expect(DEFAULT_SETTINGS.autoStart).toBe(false);
+  });
+
+  it('should default authEnabled to false', () => {
+    expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
+  });
+
+  it('declares schemaVersion 6', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(6);
   });
 });
 
@@ -327,8 +376,8 @@ describe('McpSettingsTab MCP config display', () => {
     (Setting as unknown as { instances: unknown[] }).instances = [];
   });
 
-  function createConfigMockPlugin(overrides?: Partial<{ port: number; accessKey: string }>): {
-    settings: { serverAddress: string; port: number; accessKey: string; httpsEnabled: boolean; debugMode: boolean; moduleStates: Record<string, unknown>; schemaVersion: number };
+  function createConfigMockPlugin(overrides?: Partial<{ port: number; accessKey: string; authEnabled: boolean }>): {
+    settings: { serverAddress: string; port: number; accessKey: string; authEnabled: boolean; httpsEnabled: boolean; debugMode: boolean; moduleStates: Record<string, unknown>; schemaVersion: number };
     httpServer: null;
     registry: { getModules: () => [] };
     logger: { updateOptions: () => void };
@@ -340,6 +389,7 @@ describe('McpSettingsTab MCP config display', () => {
       settings: {
         ...DEFAULT_SETTINGS,
         accessKey: 'test-key-abc',
+        authEnabled: true,
         ...overrides,
       },
       httpServer: null,
@@ -352,7 +402,7 @@ describe('McpSettingsTab MCP config display', () => {
   }
 
   function renderTab(
-    overrides?: Partial<{ port: number; accessKey: string }>,
+    overrides?: Partial<{ port: number; accessKey: string; authEnabled: boolean }>,
   ): { container: TrackingEl } {
     const plugin = createConfigMockPlugin(overrides);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
@@ -425,6 +475,23 @@ describe('McpSettingsTab MCP config display', () => {
     expect(copied).not.toContain('Authorization');
     expect(copied).not.toContain('headers');
   });
+
+  it('copied JSON omits the Authorization header when Bearer auth is disabled', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+    renderTab({ authEnabled: false });
+    getClientConfigSetting().extraButtons[0].callback!();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalled();
+    });
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('"url"');
+    expect(copied).not.toContain('Authorization');
+    expect(copied).not.toContain('headers');
+  });
 });
 
 describe('McpSettingsTab server controls', () => {
@@ -433,7 +500,7 @@ describe('McpSettingsTab server controls', () => {
 
   function createMockPlugin(isRunning: boolean, clients = 0) {
     return {
-      settings: { ...DEFAULT_SETTINGS, accessKey: 'test-key' },
+      settings: { ...DEFAULT_SETTINGS, accessKey: 'test-key', authEnabled: true },
       httpServer: isRunning
         ? { isRunning: true, connectedClients: clients }
         : null,
@@ -442,6 +509,7 @@ describe('McpSettingsTab server controls', () => {
       stopServer: vi.fn().mockResolvedValue(undefined),
       restartServer: vi.fn().mockResolvedValue(undefined),
       saveSettings: vi.fn().mockResolvedValue(undefined),
+      logger: { updateOptions: (): void => {} },
       app: { vault: { configDir: '.obsidian' } },
       manifest: { id: 'obsidian-mcp', version: '0.0.0' },
     };
@@ -622,6 +690,84 @@ describe('McpSettingsTab server controls', () => {
     restart.callback!();
     await vi.waitFor(() => {
       expect(mockPlugin.restartServer).toHaveBeenCalled();
+    });
+  });
+
+  describe('Require Bearer authentication toggle', () => {
+    function getAuthEnabledSetting(): SettingInstance | undefined {
+      return (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+        (s) => s.settingName === 'Require Bearer authentication',
+      );
+    }
+
+    function createAuthMockPlugin(authEnabled: boolean): Record<string, unknown> {
+      return {
+        settings: { ...DEFAULT_SETTINGS, accessKey: 'test-key', authEnabled },
+        httpServer: null,
+        registry: { getModules: () => [] },
+        startServer: vi.fn().mockResolvedValue(undefined),
+        stopServer: vi.fn().mockResolvedValue(undefined),
+        restartServer: vi.fn().mockResolvedValue(undefined),
+        saveSettings: vi.fn().mockResolvedValue(undefined),
+        logger: { updateOptions: (): void => {} },
+        app: { vault: { configDir: '.obsidian' } },
+        manifest: { id: 'obsidian-mcp', version: '0.0.0' },
+      };
+    }
+
+    function renderAuthTab(authEnabled: boolean): Record<string, unknown> {
+      const plugin = createAuthMockPlugin(authEnabled);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      const tab = new McpSettingsTab({} as any, plugin as any);
+      tab.display();
+      return plugin;
+    }
+
+    it('renders the toggle with the stored value', () => {
+      renderAuthTab(true);
+      const setting = getAuthEnabledSetting();
+      expect(setting).toBeDefined();
+      expect(setting!.toggles).toHaveLength(1);
+      expect(setting!.toggles[0].value).toBe(true);
+    });
+
+    it('reflects authEnabled=false in the toggle value', () => {
+      renderAuthTab(false);
+      expect(getAuthEnabledSetting()!.toggles[0].value).toBe(false);
+    });
+
+    it('hides the Access Key row when auth is disabled', () => {
+      renderAuthTab(false);
+      const accessKey = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+        (s) => s.settingName === 'Access Key',
+      );
+      expect(accessKey).toBeUndefined();
+    });
+
+    it('shows the Access Key row when auth is enabled', () => {
+      renderAuthTab(true);
+      const accessKey = (Setting as unknown as { instances: SettingInstance[] }).instances.find(
+        (s) => s.settingName === 'Access Key',
+      );
+      expect(accessKey).toBeDefined();
+    });
+
+    it('toggling on persists authEnabled=true via saveSettings', async () => {
+      const plugin = renderAuthTab(false);
+      getAuthEnabledSetting()!.toggles[0].callback!(true);
+      await vi.waitFor(() => {
+        expect((plugin.saveSettings as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+      });
+      expect((plugin.settings as { authEnabled: boolean }).authEnabled).toBe(true);
+    });
+
+    it('toggling off persists authEnabled=false via saveSettings', async () => {
+      const plugin = renderAuthTab(true);
+      getAuthEnabledSetting()!.toggles[0].callback!(false);
+      await vi.waitFor(() => {
+        expect((plugin.saveSettings as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+      });
+      expect((plugin.settings as { authEnabled: boolean }).authEnabled).toBe(false);
     });
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,12 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 5', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(5);
+  it('should have schema version 6', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(6);
+  });
+
+  it('should have Bearer authentication disabled by default', () => {
+    expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
   });
 
   it('should have a null TLS certificate by default', () => {

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -65,9 +65,10 @@ function makeModule(
 }
 
 const baseSettings: McpPluginSettings = {
-  schemaVersion: 5,
+  schemaVersion: 6,
   serverAddress: '127.0.0.1',
   port: 28741,
+  authEnabled: true,
   accessKey: SECRET,
   httpsEnabled: false,
   tlsCertificate: { cert: FAKE_PEM, key: FAKE_PEM },


### PR DESCRIPTION
## Summary

- New **Require Bearer authentication** toggle in Server Settings, defaulting to **off** so a fresh install is usable without first generating an access key.
- When off: `authenticateRequest` short-circuits, every request is accepted, the Access Key row is hidden, and the copied MCP client config omits the `Authorization` header. When on: existing always-enforced behaviour applies.
- Settings schema bumps to **v6**: `authEnabled` is added (defaults to `false`) and existing v5 installs migrate to off (per the planning discussion). PRD updated — NFR5 reframed as opt-in, new **CR22** documents the toggle, and Appendix A gains v5/v6 entries. `docs/security.md` notes the toggle and recommends turning it on for any non-local exposure.
- Auto-start gate in `main.ts` no longer requires an access key when auth is off; only requires one when auth is on.

## Test plan

- [x] `npm test` — 345/345 pass (24 new auth/migration/UI tests added)
- [x] `npm run lint` — 0 errors, only the 2 pre-existing warnings in `tests/settings.test.ts`
- [x] `npm run typecheck` — clean
- [x] Visual: before/after screenshots captured via the host Xvfb + CDP pipeline (toggle off hides Access Key, toggle on reveals it). Screenshots are not committed per CLAUDE.md rule 4 — see PR comments below for inline images.

Closes #144