### PR TITLE
refactor(settings): align status toggle with other toggles on right

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,20 +46,7 @@ export class McpSettingsTab extends PluginSettingTab {
 
     const setting = new Setting(containerEl)
       .setName(t('setting_status_name'))
-      .setDesc(statusText)
-      .addToggle((toggle) =>
-        toggle
-          .setValue(isRunning)
-          .setTooltip(isRunning ? t('tooltip_stop_server') : t('tooltip_start_server'))
-          .onChange((value) => {
-            const action = value
-              ? this.plugin.startServer()
-              : this.plugin.stopServer();
-            void action.then(() => {
-              this.display();
-            });
-          }),
-      );
+      .setDesc(statusText);
 
     if (isRunning) {
       setting.addExtraButton((btn) =>
@@ -73,6 +60,20 @@ export class McpSettingsTab extends PluginSettingTab {
           }),
       );
     }
+
+    setting.addToggle((toggle) =>
+      toggle
+        .setValue(isRunning)
+        .setTooltip(isRunning ? t('tooltip_stop_server') : t('tooltip_start_server'))
+        .onChange((value) => {
+          const action = value
+            ? this.plugin.startServer()
+            : this.plugin.stopServer();
+          void action.then(() => {
+            this.display();
+          });
+        }),
+    );
   }
 
   private renderServerSettings(containerEl: HTMLElement): void {


### PR DESCRIPTION
## Summary

The Status row on the settings screen rendered the start/stop toggle **before** the restart icon, so when the server was running the toggle sat inside the row (`[toggle] [↻ restart]`) rather than flush-right. Every other toggle on the settings screen (HTTPS, Auto-start, Debug mode, Require Bearer authentication, module toggles) is the rightmost control on its row.

Swap the order so the restart icon is added first and the toggle last, producing `[↻ restart] [toggle]`. The Status toggle now aligns with the rest of the toggle column down the right edge of the screen.

Pure reorder — no behaviour, copy, translation, or CSS changes. Restart icon still only appears while the server is running.

## Visual check

Before/after screenshots (stopped + running states) were captured via the host Xvfb + CDP pipeline and reviewed. The stopped-state layout is unchanged; the running state now has the restart icon on the left and the toggle flush-right, vertically aligned with HTTPS / Auto-start / Require Bearer toggles.

## Test plan

- [x] `npm test` — 374 tests pass
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in `tests/settings.test.ts` only)
- [x] `npm run typecheck` — clean
- [x] Manual visual check: Status toggle aligns with the other right-edge toggles in both stopped and running states
- [x] Restart icon still appears only while the server is running, and still refreshes the tab after click

Closes #149