### PR TITLE
fix(ci): make extracted Obsidian AppImage executable for runner user

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -53,13 +53,19 @@ jobs:
 
       - name: Download Obsidian AppImage
         run: |
+          set -x
           sudo mkdir -p /opt
           sudo wget -q \
             "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.8.9/Obsidian-1.8.9.AppImage" \
             -O /opt/Obsidian.AppImage
           sudo chmod +x /opt/Obsidian.AppImage
           (cd /opt && sudo ./Obsidian.AppImage --appimage-extract >/dev/null)
-          sudo ln -sf /opt/squashfs-root/obsidian /usr/local/bin/obsidian
+          sudo chown -R "$USER":"$USER" /opt/squashfs-root
+          sudo chmod -R a+rX /opt/squashfs-root
+          sudo chmod a+x /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
+          sudo ln -sf /opt/squashfs-root/AppRun /usr/local/bin/obsidian
+          ls -la /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
+          /usr/local/bin/obsidian --version || true
 
       - name: Capture release screenshots
         run: |


### PR DESCRIPTION
## Summary

- The `Release Screenshots` workflow failed on the `ubuntu-24.04` runner image (`20260413.86.1`) with `nohup: failed to run command 'obsidian': Permission denied` — `--appimage-extract` was run via `sudo`, leaving `/opt/squashfs-root` owned by root with permissions the runner user could not traverse/exec.
- `chown` the extracted tree to the runner user, `chmod a+rX`, and explicitly `+x` `AppRun` / `obsidian`.
- Symlink `AppRun` (the canonical AppImage entry point) instead of the inner `obsidian` binary.
- Add `set -x` and a `--version` sanity check so the next failure mode is visible immediately in the step log.

Failing run for reference: `actions/runs/24601246469/job/71940193081` (tag `v2.3.0`).

## Test plan

- [ ] Re-run `Release Screenshots` via `workflow_dispatch` against tag `v2.3.0` and confirm the step reaches `CDP ready after Ns`.
- [ ] Confirm `release-main.png`, `release-plugin-settings.png`, `release-server-running.png` are uploaded to the `v2.3.0` release.
- [ ] CI green on this PR.

Closes #152
