### PR TITLE
ci: auto-file issue when a workflow fails

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,65 @@
+name: Notify workflow failure
+
+on:
+  workflow_run:
+    workflows: [CI, Release, Release Screenshots]
+    types: [completed]
+
+permissions:
+  issues: write
+
+jobs:
+  file-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or comment on failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          set -euo pipefail
+
+          TITLE="Workflow failure: ${WORKFLOW_NAME}"
+          LABEL="workflow-failure"
+
+          gh label create "$LABEL" \
+            --repo "$REPO" \
+            --color B60205 \
+            --description "Auto-filed when a workflow fails on main" \
+            >/dev/null 2>&1 || true
+
+          cat > /tmp/body.md <<EOF
+          The **${WORKFLOW_NAME}** workflow failed.
+
+          - Run: ${RUN_URL}
+          - Branch: \`${HEAD_BRANCH}\`
+          - Commit: \`${HEAD_SHA}\`
+          - Trigger: \`${EVENT}\`
+
+          Auto-filed by \`.github/workflows/notify-failure.yml\`. Repeat failures comment on this issue instead of opening new ones. Close once resolved.
+          EOF
+
+          EXISTING=$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --label "$LABEL" \
+            --search "\"${TITLE}\" in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+            | head -n 1)
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file /tmp/body.md
+            echo "Commented on existing issue #${EXISTING}"
+          else
+            gh issue create --repo "$REPO" \
+              --title "$TITLE" \
+              --label "$LABEL" \
+              --body-file /tmp/body.md
+          fi

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -250,6 +250,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 - **TR23** — GitHub Actions workflow: build-and-test (lint, type-check, test, build) on every PR and push to main
 - **TR24** — GitHub Actions workflow: please-release for release management (tag-based, produces main.js, manifest.json, styles.css as release assets)
 - **TR25** — Dependabot for dependency updates
+- **TR27** — GitHub Actions workflow `notify-failure.yml` listens for `workflow_run` completions of `CI`, `Release`, and `Release Screenshots` and, when `conclusion == 'failure'`, auto-files a tracking issue. A single open issue per workflow is kept (matched by the `workflow-failure` label and a title of the form `Workflow failure: <workflow-name>`); repeat failures append a comment to that issue instead of opening duplicates, and once the issue is closed the next failure opens a fresh one. The workflow requires only `issues: write` permission and runs from the `main` definition, so fork PRs cannot inject into the notifier.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- New `.github/workflows/notify-failure.yml` listens for `workflow_run: completed` on `CI`, `Release`, and `Release Screenshots` and, on `conclusion == 'failure'`, opens a tracking issue.
- Deduped by the `workflow-failure` label plus exact title (`Workflow failure: <workflow-name>`): repeat failures comment on the existing open issue instead of spawning duplicates. Close the issue once resolved; the next failure opens a fresh one.
- Documented as **TR27** in `docs/PRD.md`.

## Why this design

- `workflow_run` runs the workflow definition from `main`, so fork PRs can't inject into the notifier.
- Only `issues: write` permission is required — no `contents`, no `pull-requests`.
- The label is auto-created on first run via `gh label create ... || true`, so no manual repo setup.

## Test plan

- [ ] Merge this PR and intentionally break `main` in a throwaway follow-up commit to verify the notifier fires and opens one issue.
- [ ] Push a second failing commit to verify the second failure appends a comment rather than opening a duplicate issue.
- [ ] Close the issue, push a third failure, and verify a new issue is opened.
- [x] `npm run lint`, `npm run typecheck`, `npm test` all green locally.

Closes #155