### PR TITLE
fix(ci): invoke Obsidian AppRun by absolute path in release screenshots

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -63,9 +63,8 @@ jobs:
           sudo chown -R "$USER":"$USER" /opt/squashfs-root
           sudo chmod -R a+rX /opt/squashfs-root
           sudo chmod a+x /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
-          sudo ln -sf /opt/squashfs-root/AppRun /usr/local/bin/obsidian
           ls -la /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
-          /usr/local/bin/obsidian --version || true
+          /opt/squashfs-root/AppRun --version || true
 
       - name: Capture release screenshots
         run: |
@@ -83,7 +82,7 @@ jobs:
           echo '{"vaults":{"v1":{"path":"/tmp/vault","ts":1,"open":true}}}' \
             > "$HOME/.config/obsidian/obsidian.json"
 
-          nohup obsidian --no-sandbox --disable-gpu \
+          nohup /opt/squashfs-root/AppRun --no-sandbox --disable-gpu \
             --disable-software-rasterizer \
             --remote-debugging-port=9222 --remote-allow-origins='*' \
             "obsidian://open?path=/tmp/vault" \


### PR DESCRIPTION
## Summary

- The Release Screenshots workflow was failing end-to-end because `ln -sf /opt/squashfs-root/AppRun /usr/local/bin/obsidian` makes AppRun's internal path resolution produce an empty `$HERE`, so AppRun exec's the literal path `/obsidian` and bails with `/usr/local/bin/obsidian: line 45: /obsidian: No such file or directory` — causing the 60s CDP wait loop to time out.
- Drop the symlink, run AppRun by its absolute extracted path (`/opt/squashfs-root/AppRun`) for both the `--version` smoke test and the `nohup` launch. `$HERE` then resolves to `/opt/squashfs-root` and AppRun exec's `/opt/squashfs-root/obsidian` correctly.
- No Python/code changes — the failure is purely in how the workflow spawns Obsidian. See [#159 comment](https://github.com/KingOfKalk/obisdian-plugin-mcp/issues/159#issuecomment-4273363173) for the full log trace.

Closes #159

## Test plan

- [x] CI passes on this PR
- [ ] After merge, manually dispatch **Release Screenshots** from the Actions tab with `tag=v2.3.0` (same input that failed on run [24601558880](https://github.com/KingOfKalk/obisdian-plugin-mcp/actions/runs/24601558880))
- [ ] `Download Obsidian AppImage` step prints a real version string from `AppRun --version` (no `line 45: /obsidian: No such file or directory`)
- [ ] `Capture release screenshots` step prints `CDP ready after Ns` and produces three PNGs in `/tmp/shots/`
- [ ] `Upload screenshot release assets` attaches `release-main.png`, `release-plugin-settings.png`, `release-server-running.png` to the `v2.3.0` release
- [ ] `Append Screenshots section to release notes` updates the release body with the three image links