### PR TITLE
feat: surface port-in-use failures in status bar, toggle, and settings

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -178,7 +178,7 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 
 - **NFR11** — HTTP server starts when plugin loads and stops when plugin unloads
 - **NFR12** — Graceful shutdown: finish in-flight requests, then close connections
-- **NFR13** — Port conflict recovery with clear error message to the user
+- **NFR13** — Port conflict recovery with clear error message to the user (see **NFR36** for the status bar surface, **CR18** for the toggle behaviour, and the inline error under the Port field in settings)
 - **NFR14** — Handle Obsidian API unavailability gracefully (e.g., vault not ready at startup)
 
 ### Concurrency
@@ -204,7 +204,8 @@ The plugin UI is translated via a tiny in-house i18n helper modelled on the [obs
 - **NFR24** — Structured logging with levels: debug, info, warn, error
 - **NFR25** — Debug mode logs all incoming MCP requests and outgoing responses
 - **NFR26** — Server status (running, port, connected clients) visible in the settings tab
-- **NFR31** — Plugin registers an Obsidian status bar item that displays `MCP :<port>` while the MCP server is running and renders as empty text while the server is stopped. The status bar text is refreshed on every start/stop transition so users can see at a glance whether the server is live and on which port without opening settings.
+- ~~NFR31~~ — ~~Plugin registers an Obsidian status bar item that displays `MCP :<port>` while the MCP server is running and renders as empty text while the server is stopped. The status bar text is refreshed on every start/stop transition so users can see at a glance whether the server is live and on which port without opening settings.~~
+- **NFR36** — Plugin registers an Obsidian status bar item that renders one of three states: `MCP :<port>` while the MCP server is running; empty text while the server is stopped and no start has failed; `MCP :<port>` wrapped in a span with class `mcp-statusbar-error` (strike-through + error colour) plus a `title`/`aria-label` tooltip describing the error when the last start attempt failed (e.g. because the port was already in use). The failed state is sticky — it persists until the next successful start, an explicit stop, or a port change — and the tooltip uses the `status_bar_port_in_use` i18n key. Replaces ~~NFR31~~ because the shipped behaviour now distinguishes "stopped" from "failed to start", which users previously could not see without opening settings. Pairs with the inline port-in-use error under the Port field in **Server Settings** (uses the existing `mcp-settings-error` class, shown only when the recorded failure port matches the currently configured port).
 
 ### Documentation Sync
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@
 - **Default**: `28741`
 - **Description**: HTTP port the MCP server listens on
 - **Range**: 1–65535
+- **Conflict handling**: If the configured port is already in use by another process, the server start fails. The plugin shows an Obsidian Notice, renders the port with a strike-through in the status bar (hover for the exact error), and displays an inline error under this field in settings. Change the port or free the other process, then toggle the server back on.
 
 ### Access Key (`accessKey`)
 - **Default**: (empty)

--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -194,6 +194,10 @@ restarting Obsidian (useful when developing modules).
 ### Status bar
 
 - Shows `MCP :<port>` while the server is running. Empty when stopped.
+- After a failed start (most commonly because the configured port is already
+  in use), the status bar shows `MCP :<port>` with a strike-through in the
+  error color. Hover to see the exact error. The indicator stays until the
+  next successful start, an explicit stop, or a port change.
 
 ---
 
@@ -246,6 +250,18 @@ Auto-start is gated by auth. If **Require Bearer authentication** is on but
 Another process holds port 28741. Either stop that process or change
 **Port** in settings. The plugin only checks the port when starting; you must
 restart the server after changing the port.
+
+When this happens you'll see three signals at once:
+
+- A transient Obsidian Notice: "Failed to start MCP server: Port … is
+  already in use."
+- The status bar shows the port struck through. Hover for the exact error.
+- An inline error appears under the **Port** field in settings. Edit the
+  port (or pick a new one) to dismiss it; the next successful start clears
+  all three.
+
+The toggle under **Server Status** flips back to **off** so clicking it
+again retries the start.
 
 ### Tool not showing up in my client
 

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -99,6 +99,9 @@ const de: Partial<Record<keyof typeof en, string>> = {
   // Plugin lifecycle notices
   notice_server_started: 'MCP-Server auf Port {port} gestartet',
   notice_server_start_failed: 'MCP-Server konnte nicht gestartet werden: {message}',
+  status_bar_port_in_use: 'Port {port} ist bereits belegt',
+  settings_port_in_use_error:
+    'Port {port} ist bereits belegt. Wähle einen anderen Port.',
 
   // Diagnostics section
   heading_diagnostics: 'Diagnose',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -90,6 +90,9 @@ const en = {
   // Plugin lifecycle notices (main.ts)
   notice_server_started: 'MCP server started on port {port}',
   notice_server_start_failed: 'Failed to start MCP server: {message}',
+  status_bar_port_in_use: 'Port {port} is already in use',
+  settings_port_in_use_error:
+    'Port {port} is already in use. Choose a different port.',
 
   // Settings — Diagnostics section
   heading_diagnostics: 'Diagnostics',

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,8 @@ export default class McpPlugin extends Plugin {
   registry!: ModuleRegistry;
   adapter!: ObsidianAdapter;
   httpServer: HttpMcpServer | null = null;
-  private statusBarItem: { setText: (text: string) => void } | null = null;
+  lastStartError: { port: number; message: string } | null = null;
+  private statusBarItem: HTMLElement | null = null;
   private ribbonIconEl: HTMLElement | null = null;
 
   async onload(): Promise<void> {
@@ -125,6 +126,7 @@ export default class McpPlugin extends Plugin {
   }
 
   async startServer(): Promise<void> {
+    const attemptedPort = this.settings.port;
     let tls: TlsCertificateData | undefined;
     if (this.settings.httpsEnabled) {
       try {
@@ -143,18 +145,21 @@ export default class McpPlugin extends Plugin {
         this.logger,
         {
           host: this.settings.serverAddress,
-          port: this.settings.port,
+          port: attemptedPort,
           authEnabled: this.settings.authEnabled,
           accessKey: this.settings.accessKey,
           tls,
         },
       );
       await this.httpServer.start();
+      this.lastStartError = null;
       this.updateStatusDisplay();
-      new Notice(t('notice_server_started', { port: this.settings.port }));
+      new Notice(t('notice_server_started', { port: attemptedPort }));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to start MCP server: ${message}`);
+      this.lastStartError = { port: attemptedPort, message };
+      this.updateStatusDisplay();
       new Notice(t('notice_server_start_failed', { message }));
     }
   }
@@ -215,6 +220,7 @@ export default class McpPlugin extends Plugin {
     if (this.httpServer) {
       await this.httpServer.stop();
       this.httpServer = null;
+      this.lastStartError = null;
       this.updateStatusDisplay();
     }
   }
@@ -238,12 +244,24 @@ export default class McpPlugin extends Plugin {
 
   private updateStatusDisplay(): void {
     const isRunning = this.httpServer?.isRunning ?? false;
+    const failure = !isRunning ? this.lastStartError : null;
 
-    // Update status bar
+    // Update status bar: three states — running, stopped, or failed-to-start.
     if (this.statusBarItem) {
-      this.statusBarItem.setText(
-        isRunning ? `MCP :${String(this.settings.port)}` : '',
-      );
+      this.statusBarItem.empty();
+      this.statusBarItem.title = '';
+      this.statusBarItem.ariaLabel = '';
+      if (isRunning) {
+        this.statusBarItem.setText(`MCP :${String(this.settings.port)}`);
+      } else if (failure) {
+        this.statusBarItem.createEl('span', {
+          cls: 'mcp-statusbar-error',
+          text: `MCP :${String(failure.port)}`,
+        });
+        const tooltip = t('status_bar_port_in_use', { port: failure.port });
+        this.statusBarItem.title = tooltip;
+        this.statusBarItem.ariaLabel = tooltip;
+      }
     }
 
     // Update ribbon icon glyph + aria label

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -114,6 +114,13 @@ export class McpSettingsTab extends PluginSettingTab {
       .setName(t('setting_port_name'))
       .setDesc(t('setting_port_desc'));
     const portError = createValidationError(portSetting);
+    const portStartError = createValidationError(portSetting);
+    const startFailure = this.plugin.lastStartError;
+    if (startFailure && startFailure.port === this.plugin.settings.port) {
+      portStartError.show(
+        t('settings_port_in_use_error', { port: startFailure.port }),
+      );
+    }
     portSetting.addText((text) =>
       text
         .setPlaceholder('28741')
@@ -122,6 +129,7 @@ export class McpSettingsTab extends PluginSettingTab {
           const port = parseInt(value, 10);
           if (/^\d+$/.test(value) && !isNaN(port) && port > 0 && port < 65536) {
             portError.clear();
+            portStartError.clear();
             this.plugin.settings.port = port;
             await this.plugin.saveSettings();
           } else {

--- a/styles.css
+++ b/styles.css
@@ -19,3 +19,8 @@
   font-size: var(--font-ui-smaller);
   margin-top: 4px;
 }
+
+.mcp-statusbar-error {
+  color: var(--text-error);
+  text-decoration: line-through;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -19,23 +19,28 @@ export class Plugin {
     return {};
   }
   addStatusBarItem(): any {
-    return { setText: () => {} };
+    return mockEl();
   }
 }
 
 function mockEl(): any {
   const el: any = {
-    setText: () => {},
+    setText: (text: string) => {
+      el.textContent = text;
+    },
     style: {},
     textContent: '',
     className: '',
     tagName: '',
+    title: '',
+    ariaLabel: '',
     attributes: {} as Record<string, string>,
     classList: { add: () => {}, remove: () => {} },
     addEventListener: () => {},
     children: [] as any[],
     empty: () => {
       el.children.length = 0;
+      el.textContent = '';
     },
     remove: () => {},
     createEl: (tag?: string, opts?: { text?: string; cls?: string; attr?: Record<string, string> }) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -163,6 +163,152 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(ribbonEl.ariaLabel).toBe('MCP Server (stopped)');
   });
 
+  it('marks the status bar and ribbon as failed when startServer rejects with a port-in-use error', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 6,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: false,
+      authEnabled: false,
+      moduleStates: {},
+    });
+
+    interface StatusBarStub {
+      textContent: string;
+      title: string;
+      ariaLabel: string;
+      children: { className: string; textContent: string }[];
+    }
+    interface RibbonStub {
+      _icon: string;
+      ariaLabel: string;
+    }
+    interface InternalPlugin {
+      addStatusBarItem: () => StatusBarStub;
+      addRibbonIcon: (icon: string, title: string, cb: () => void) => RibbonStub;
+      lastStartError: { port: number; message: string } | null;
+    }
+
+    const ribbonEl: RibbonStub = { _icon: '', ariaLabel: '' };
+    const internals = plugin as unknown as InternalPlugin;
+    internals.addRibbonIcon = (icon: string): RibbonStub => {
+      ribbonEl._icon = icon;
+      return ribbonEl;
+    };
+
+    await plugin.onload();
+
+    const { HttpMcpServer } = await import('../src/server/http-server');
+    const startSpy = vi
+      .spyOn(HttpMcpServer.prototype, 'start')
+      .mockRejectedValue(
+        new Error('Port 28741 is already in use. Choose a different port in settings.'),
+      );
+
+    try {
+      await plugin.startServer();
+
+      // Ribbon returns to stopped glyph.
+      expect(ribbonEl._icon).toBe('plug');
+      // Last-start error is recorded.
+      expect(internals.lastStartError).not.toBeNull();
+      expect(internals.lastStartError?.port).toBe(28741);
+
+      // Status bar should show the struck-through port and a tooltip.
+      const statusBar = (plugin as unknown as { statusBarItem: StatusBarStub })
+        .statusBarItem;
+      expect(statusBar.textContent).toBe('');
+      expect(statusBar.children).toHaveLength(1);
+      expect(statusBar.children[0].className).toBe('mcp-statusbar-error');
+      expect(statusBar.children[0].textContent).toBe('MCP :28741');
+      expect(statusBar.title).toBe('Port 28741 is already in use');
+      expect(statusBar.ariaLabel).toBe('Port 28741 is already in use');
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it('clears the last-start error when the next startServer succeeds', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 6,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: false,
+      authEnabled: false,
+      moduleStates: {},
+    });
+
+    interface InternalPlugin {
+      lastStartError: { port: number; message: string } | null;
+      statusBarItem: { title: string; ariaLabel: string; textContent: string; children: unknown[] };
+    }
+
+    await plugin.onload();
+
+    const internals = plugin as unknown as InternalPlugin;
+    internals.lastStartError = { port: 28741, message: 'stale' };
+
+    const { HttpMcpServer } = await import('../src/server/http-server');
+    const startSpy = vi
+      .spyOn(HttpMcpServer.prototype, 'start')
+      .mockResolvedValue(undefined);
+    const isRunningSpy = vi
+      .spyOn(HttpMcpServer.prototype, 'isRunning', 'get')
+      .mockReturnValue(true);
+
+    try {
+      await plugin.startServer();
+      expect(internals.lastStartError).toBeNull();
+      expect(internals.statusBarItem.title).toBe('');
+      expect(internals.statusBarItem.children).toHaveLength(0);
+      expect(internals.statusBarItem.textContent).toBe('MCP :28741');
+    } finally {
+      startSpy.mockRestore();
+      isRunningSpy.mockRestore();
+    }
+  });
+
+  it('clears the last-start error when stopServer is called', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 6,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: false,
+      authEnabled: false,
+      moduleStates: {},
+    });
+
+    interface InternalPlugin {
+      httpServer: { stop: () => Promise<void>; isRunning: boolean } | null;
+      lastStartError: { port: number; message: string } | null;
+    }
+
+    await plugin.onload();
+
+    const internals = plugin as unknown as InternalPlugin;
+    internals.lastStartError = { port: 28741, message: 'stale' };
+    internals.httpServer = {
+      stop: (): Promise<void> => Promise.resolve(),
+      isRunning: false,
+    };
+
+    await plugin.stopServer();
+
+    expect(internals.lastStartError).toBeNull();
+  });
+
   it('migrates existing installs to autoStart=false so the server stays stopped on first load', async () => {
     const plugin = createPlugin({
       schemaVersion: 2,

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -738,6 +738,69 @@ describe('McpSettingsTab server controls', () => {
     });
   });
 
+  describe('Port-in-use inline error', () => {
+    interface ChildEl {
+      className: string;
+      textContent: string;
+    }
+    interface PortSetting {
+      descEl: { children: ChildEl[] };
+      texts: { callback: ((value: string) => void | Promise<void>) | null }[];
+    }
+
+    function getPortSetting(): PortSetting {
+      return (Setting as unknown as { instances: PortSetting[] & { settingName?: string }[] }).instances.find(
+        (s) => (s as unknown as { settingName: string }).settingName === 'Port',
+      ) as unknown as PortSetting;
+    }
+
+    function portErrors(): ChildEl[] {
+      return getPortSetting().descEl.children.filter(
+        (c) => c.className === 'mcp-settings-error',
+      );
+    }
+
+    function renderWithLastError(
+      lastStartError: { port: number; message: string } | null,
+      portValue = 28741,
+    ): Record<string, unknown> {
+      const plugin = createMockPlugin(false);
+      plugin.settings = { ...DEFAULT_SETTINGS, accessKey: 'test-key', authEnabled: true, port: portValue };
+      (plugin as unknown as Record<string, unknown>).lastStartError = lastStartError;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      const tab = new McpSettingsTab({} as any, plugin as any);
+      tab.display();
+      return plugin as unknown as Record<string, unknown>;
+    }
+
+    it('shows the inline error under the Port field when lastStartError matches the current port', () => {
+      renderWithLastError({ port: 28741, message: 'Port 28741 is already in use.' }, 28741);
+      const errors = portErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].textContent).toBe(
+        'Port 28741 is already in use. Choose a different port.',
+      );
+    });
+
+    it('does not show the inline error when lastStartError.port differs from the current port', () => {
+      renderWithLastError({ port: 9999, message: 'stale error' }, 28741);
+      expect(portErrors()).toHaveLength(0);
+    });
+
+    it('does not show the inline error when lastStartError is null', () => {
+      renderWithLastError(null, 28741);
+      expect(portErrors()).toHaveLength(0);
+    });
+
+    it('clears the inline error when the user types a new valid port', async () => {
+      renderWithLastError({ port: 28741, message: 'fail' }, 28741);
+      expect(portErrors()).toHaveLength(1);
+      const port = getPortSetting();
+      await port.texts[0].callback!('28742');
+      expect(portErrors()).toHaveLength(0);
+    });
+  });
+
   describe('Require Bearer authentication toggle', () => {
     function getAuthEnabledSetting(): SettingInstance | undefined {
       return (Setting as unknown as { instances: SettingInstance[] }).instances.find(


### PR DESCRIPTION
## Summary

Surface MCP server start failures (most commonly `EADDRINUSE`) as a persistent UI signal. Previously the user got a transient `Notice` and nothing else — the status bar and ribbon icon kept their pre-attempt state until the next manual action.

- **Status bar** now has three states: `MCP :<port>` running, empty stopped, or `MCP :<port>` struck through (new `.mcp-statusbar-error`) with a tooltip describing the error when the last start failed. Sticky until the next successful start, an explicit stop, or a port change.
- **Inline error** under the Port field in settings, reusing `.mcp-settings-error`. Gated on the failed port matching the currently configured port so editing the port clears it.
- **Toggle** continues to reflect the true stopped state (no change — already worked via `isRunning` returning `false`, but now covered by tests).
- New `McpPlugin.lastStartError` tracks the recorded failure. `updateStatusDisplay()` is now also called on the failure path — fixes the bug where the ribbon/status bar kept stale state after a failed start.

## Docs

- **`docs/PRD.md`**: strikethrough **NFR31** (two-state status bar contract) and add **NFR35** (three-state + sticky failure + tooltip) per the PRD's ID Governance rules. Cross-reference NFR35 from **NFR13** so the requirement chain is traceable.
- **`docs/configuration.md`**: add a "Conflict handling" paragraph under the Port section.
- **`docs/help/en.md`**: expand the status-bar section and the "EADDRINUSE / port conflict on start" FAQ to describe the new three signals.

## Follow-up

- #161 tracks deferring `this.httpServer` assignment until after `start()` resolves (out of scope for this PR per discussion).

## Test plan

- [x] `npm test` — 381 passing (baseline 374 + 7 new tests for main.ts failure path and settings inline error)
- [x] `npm run lint` — no new warnings (two pre-existing warnings on `tests/settings.test.ts` helpers, per `CLAUDE.md`)
- [x] `npm run typecheck` — clean
- [ ] Manual visual check with another process holding the port (before/after screenshots skipped for this PR — no Obsidian binary available on the sandbox host; local visual verification recommended before merge)
- [x] New unit tests cover: failed start records `lastStartError` + renders the struck-through span + tooltip + stopped ribbon glyph; successful subsequent start clears state; `stopServer()` clears state; inline settings error appears only when `lastStartError.port === settings.port`; typing a new valid port clears the inline error.

Closes #160