### PR TITLE
fix(ci): launch Obsidian binary directly in release screenshots

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -62,9 +62,9 @@ jobs:
           (cd /opt && sudo ./Obsidian.AppImage --appimage-extract >/dev/null)
           sudo chown -R "$USER":"$USER" /opt/squashfs-root
           sudo chmod -R a+rX /opt/squashfs-root
-          sudo chmod a+x /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
-          ls -la /opt/squashfs-root/AppRun /opt/squashfs-root/obsidian
-          /opt/squashfs-root/AppRun --version || true
+          sudo chmod a+x /opt/squashfs-root/obsidian
+          ls -la /opt/squashfs-root/obsidian
+          /opt/squashfs-root/obsidian --version || true
 
       - name: Capture release screenshots
         run: |
@@ -82,7 +82,7 @@ jobs:
           echo '{"vaults":{"v1":{"path":"/tmp/vault","ts":1,"open":true}}}' \
             > "$HOME/.config/obsidian/obsidian.json"
 
-          nohup /opt/squashfs-root/AppRun --no-sandbox --disable-gpu \
+          nohup /opt/squashfs-root/obsidian --no-sandbox --disable-gpu \
             --disable-software-rasterizer \
             --remote-debugging-port=9222 --remote-allow-origins='*' \
             "obsidian://open?path=/tmp/vault" \


### PR DESCRIPTION
## Summary

- PR #164 switched AppRun to an absolute path but the Release Screenshots workflow kept failing the same way on run [24602143010](https://github.com/KingOfKalk/obisdian-plugin-mcp/actions/runs/24602143010):

  ```
  /opt/squashfs-root/AppRun: line 45: /obsidian: No such file or directory
  ```

- Root cause: AppRun's line 45 is `exec "$APPDIR/obsidian"`. `$APPDIR` is set by the AppImage runtime loader, not by `--appimage-extract`, so invoking AppRun directly after extraction leaves it empty — the path collapses to `/obsidian`. This is independent of whether AppRun is called via symlink or absolute path.
- Fix: skip AppRun entirely and invoke `/opt/squashfs-root/obsidian` (the Electron binary) directly, matching the already-working pattern in `docs-screenshots.yml`.

## Related

- Closes #166
- Follow-up #167 tracks the `|| true` on the `--version` smoke test that masked the previous broken fix.

## Test plan

- [ ] After merge, manually dispatch **Release Screenshots** from the Actions tab with `tag=v2.3.0`
- [ ] `Download Obsidian AppImage` step prints a real version string (no `line 45: /obsidian` error)
- [ ] `Capture release screenshots` step prints `CDP ready after Ns` and produces three PNGs in `/tmp/shots/`
- [ ] `Upload screenshot release assets` attaches `release-main.png`, `release-plugin-settings.png`, `release-server-running.png` to the `v2.3.0` release
- [ ] `Append Screenshots section to release notes` updates the release body with the three image links