### PR TITLE
fix(ci): assert Obsidian smoke test output instead of swallowing errors

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -64,7 +64,9 @@ jobs:
           sudo chmod -R a+rX /opt/squashfs-root
           sudo chmod a+x /opt/squashfs-root/obsidian
           ls -la /opt/squashfs-root/obsidian
-          /opt/squashfs-root/obsidian --version || true
+          version_output=$(/opt/squashfs-root/obsidian --version 2>&1)
+          echo "obsidian --version: ${version_output}"
+          echo "${version_output}" | grep -Eq '[0-9]+\.[0-9]+\.[0-9]+'
 
       - name: Capture release screenshots
         run: |


### PR DESCRIPTION
## Summary

- The `|| true` on the `--version` smoke test let PR #164 ship with a still-broken AppRun invocation — the step happily went green while Obsidian couldn't actually launch. See #166 for the downstream failure.
- Capture `--version` output, echo it for diagnostics, and require a dotted version string (`[0-9]+\.[0-9]+\.[0-9]+`). If Obsidian can't print a version, the workflow now fails at the smoke test step instead of 60s later during the CDP wait loop.

## Related

- Closes #167
- Stacked on top of #168 (which fixes #166). Target branch is `fix/issue-166-release-screenshots-apprun` — retarget to `main` once #168 merges.

## Test plan

- [ ] Merge #168 first, then rebase this PR onto `main`
- [ ] Manually dispatch **Release Screenshots** with `tag=v2.3.0`
- [ ] The `Download Obsidian AppImage` step logs a line like `obsidian --version: 1.8.9` (or an Electron version string)
- [ ] Regression check: if we break the AppImage invocation again, the smoke test fails immediately rather than letting the workflow continue