### PR TITLE
refactor(server): migrate from deprecated `server.tool()` to `registerTool()`

### DIFF
--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -31,10 +31,12 @@ function registerTools(
   const tools = registry.getActiveTools();
   for (const tool of tools) {
     logger.debug(`Registering tool: ${tool.name}`);
-    server.tool(
+    server.registerTool(
       tool.name,
-      tool.description,
-      tool.schema,
+      {
+        description: tool.description,
+        inputSchema: tool.schema,
+      },
       async (params) => {
         try {
           return await tool.handler(params as Record<string, unknown>);


### PR DESCRIPTION
## Summary

Migrates `src/server/mcp-server.ts` from the deprecated `server.tool(name, description, schema, cb)` API to `server.registerTool(name, config, cb)`. Pure API migration — no behaviour change.

## Why

`server.tool()` is marked `@deprecated Use registerTool instead` in `@modelcontextprotocol/sdk@1.12`. The new API takes a config object (`{ description, inputSchema, title?, outputSchema?, annotations?, _meta? }`) which is the seam for the follow-up issues:

- #173 — per-tool `annotations` (readOnly/destructive/idempotent/openWorld)
- #174 — runtime `schema.parse()` at dispatch
- #176 — `response_format` + `structuredContent`

Landing this first keeps each follow-up PR focused.

## Test plan

- [x] `npm run lint` — only the two pre-existing warnings in `tests/settings.test.ts` (see `CLAUDE.md` "Linting & Code Quality")
- [x] `npm run typecheck` — clean
- [x] `npm test` — 398/398 pass
- [ ] Manual: start the plugin, confirm tools still list via MCP Inspector (optional for reviewer — behaviour is unchanged and covered by the integration suite)

Closes #172