### PR TITLE
refactor(main): defer this.httpServer assignment until start() resolves

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -139,19 +139,21 @@ export default class McpPlugin extends Plugin {
       }
     }
 
+    const server = new HttpMcpServer(
+      () => createMcpServer(this.registry, this.logger),
+      this.logger,
+      {
+        host: this.settings.serverAddress,
+        port: attemptedPort,
+        authEnabled: this.settings.authEnabled,
+        accessKey: this.settings.accessKey,
+        tls,
+      },
+    );
+
     try {
-      this.httpServer = new HttpMcpServer(
-        () => createMcpServer(this.registry, this.logger),
-        this.logger,
-        {
-          host: this.settings.serverAddress,
-          port: attemptedPort,
-          authEnabled: this.settings.authEnabled,
-          accessKey: this.settings.accessKey,
-          tls,
-        },
-      );
-      await this.httpServer.start();
+      await server.start();
+      this.httpServer = server;
       this.lastStartError = null;
       this.updateStatusDisplay();
       new Notice(t('notice_server_started', { port: attemptedPort }));

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -232,6 +232,59 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     }
   });
 
+  it('leaves plugin.httpServer null when startServer fails, and wires a fresh instance on the next successful start', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 6,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: false,
+      authEnabled: false,
+      moduleStates: {},
+    });
+
+    interface InternalPlugin {
+      httpServer: unknown;
+    }
+
+    await plugin.onload();
+
+    const internals = plugin as unknown as InternalPlugin;
+    expect(internals.httpServer).toBeNull();
+
+    const { HttpMcpServer } = await import('../src/server/http-server');
+    const failingStart = vi
+      .spyOn(HttpMcpServer.prototype, 'start')
+      .mockRejectedValueOnce(new Error('EADDRINUSE'));
+
+    try {
+      await plugin.startServer();
+      // After a failed start, httpServer must remain null — no half-constructed
+      // reference hanging around.
+      expect(internals.httpServer).toBeNull();
+    } finally {
+      failingStart.mockRestore();
+    }
+
+    // A subsequent successful start must assign a fresh instance.
+    const okStart = vi
+      .spyOn(HttpMcpServer.prototype, 'start')
+      .mockResolvedValue(undefined);
+    const isRunningSpy = vi
+      .spyOn(HttpMcpServer.prototype, 'isRunning', 'get')
+      .mockReturnValue(true);
+    try {
+      await plugin.startServer();
+      expect(internals.httpServer).not.toBeNull();
+    } finally {
+      okStart.mockRestore();
+      isRunningSpy.mockRestore();
+    }
+  });
+
   it('clears the last-start error when the next startServer succeeds', async () => {
     const plugin = createPlugin({
       schemaVersion: 6,


### PR DESCRIPTION
## Summary

Construct the `HttpMcpServer` into a local, await `start()`, and only assign to `this.httpServer` on success. Makes the invariant explicit: `this.httpServer !== null` ⇒ a server that successfully started.

## Changes

- `src/main.ts` — `startServer()` assigns `this.httpServer` only after `start()` resolves.
- `tests/main.test.ts` — new test asserts that after a failed `start()`, `plugin.httpServer` remains `null`, and a subsequent successful start wires a fresh instance.

## Test plan

- [x] `npm test` — 399 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #161