### PR TITLE
fix(vault): harden vault_rename — reject separators in newName, stop echoing paths on error

### DIFF
--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -33,6 +33,18 @@ function errorResult(message: string): CallToolResult {
   return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
 }
 
+const RENAME_TARGET_PATTERN = /^[^/\\\x00]+$/;
+
+function isValidRenameTarget(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 255 &&
+    value.trim().length > 0 &&
+    RENAME_TARGET_PATTERN.test(value)
+  );
+}
+
 export function createHandlers(
   adapter: ObsidianAdapter,
   mutex: WriteMutex,
@@ -142,11 +154,19 @@ export function createHandlers(
     async renameFile(params): Promise<CallToolResult> {
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
-        const newName = params.newName as string;
+        const rawNewName = params.newName;
+        if (!isValidRenameTarget(rawNewName)) {
+          return errorResult('Invalid rename target');
+        }
+        const newName = rawNewName;
         const parts = path.split('/');
         parts[parts.length - 1] = newName;
         const newPath = parts.join('/');
-        validateVaultPath(newPath, vaultPath);
+        try {
+          validateVaultPath(newPath, vaultPath);
+        } catch {
+          return errorResult('Invalid rename target');
+        }
         return await mutex.acquire(path, async () => {
           await adapter.renameFile(path, newPath);
           return textResult(`Renamed file: ${path} → ${newPath}`);

--- a/src/tools/vault/schemas.ts
+++ b/src/tools/vault/schemas.ts
@@ -29,7 +29,15 @@ export const getMetadataSchema = {
 
 export const renameFileSchema = {
   path: z.string().min(1).describe('Current file path'),
-  newName: z.string().min(1).describe('New file name (within the same folder)'),
+  newName: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(
+      /^[^/\\\x00]+$/,
+      'newName must not contain path separators or null bytes',
+    )
+    .describe('New file name (within the same folder)'),
 };
 
 export const moveFileSchema = {

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -134,6 +134,80 @@ describe('vault handlers', () => {
       const result = await handlers.renameFile({ path: '../test.md', newName: 'new.md' });
       expect(result.isError).toBe(true);
     });
+
+    it('should reject newName containing forward slashes', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: 'sub/dir',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+      // File untouched — still at original path.
+      expect(await adapter.readFile('notes/old.md')).toBe('content');
+    });
+
+    it('should reject newName attempting directory traversal', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: '../escape',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+      expect(await adapter.readFile('notes/old.md')).toBe('content');
+    });
+
+    it('should reject empty newName', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: '',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+    });
+
+    it('should reject whitespace-only newName', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: '   ',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+    });
+
+    it('should reject newName with Windows-style backslashes', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: 'foo\\bar',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+    });
+
+    it('should reject newName containing null bytes', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: 'foo\0bar',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe('Error: Invalid rename target');
+    });
+
+    it('should not echo the user-supplied newName in the error', async () => {
+      adapter.addFile('notes/old.md', 'content');
+      const result = await handlers.renameFile({
+        path: 'notes/old.md',
+        newName: '../../etc/passwd',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).not.toContain('etc/passwd');
+      expect(getText(result)).not.toContain('..');
+    });
   });
 
   describe('moveFile', () => {


### PR DESCRIPTION
## Summary

- Reject `newName` values containing path separators (`/`, `\`), null bytes, or that are empty / whitespace-only — `vault_rename` now returns a generic `Invalid rename target` error for all of these.
- Keep `validateVaultPath()` on the constructed path as defence in depth; map any failure there to the same generic error so we never echo the user-supplied fragment.
- Tighten `renameFileSchema.newName` with a `min(1).max(255)` + separator-rejecting regex for clients that enforce schemas on their end.

## Changes

- `src/tools/vault/handlers.ts` — new `isValidRenameTarget()` guard + generic error mapping.
- `src/tools/vault/schemas.ts` — tightened regex on `newName`.
- `tests/tools/vault/handlers.test.ts` — cases for `../escape`, `sub/dir`, `""`, `"   "`, Windows backslash, null bytes, and a no-echo assertion.

## Test plan

- [x] `npm test` — 405 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #183