### PR TITLE
fix(ci): single light-mode settings screenshot in releases

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Capture release screenshots
         run: |
           export DISPLAY=:99
-          Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset \
+          # 1920x1400 gives the settings tab enough vertical room on Xvfb even
+          # before we fall back to captureBeyondViewport in the capture script.
+          Xvfb :99 -screen 0 1920x1400x24 -ac +extension GLX +render -noreset \
             >/tmp/xvfb.log 2>&1 &
           eval "$(dbus-launch --sh-syntax)"
           sleep 1
@@ -109,14 +111,12 @@ jobs:
           python3 docker/scripts/release_screenshots.py \
             --out-dir /tmp/shots --port 9222
 
-      - name: Upload screenshot release assets
+      - name: Upload screenshot release asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "$TAG" \
-            /tmp/shots/release-main.png \
-            /tmp/shots/release-plugin-settings.png \
-            /tmp/shots/release-server-running.png \
+            /tmp/shots/release-settings.png \
             --clobber
 
       - name: Append Screenshots section to release notes
@@ -131,10 +131,6 @@ jobs:
             echo
             echo "## Screenshots"
             echo
-            echo "![Main view](${BASE}/release-main.png)"
-            echo
-            echo "![Plugin settings](${BASE}/release-plugin-settings.png)"
-            echo
-            echo "![Server running](${BASE}/release-server-running.png)"
+            echo "![Plugin settings](${BASE}/release-settings.png)"
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ PNGs. Use this whenever you need to verify a UI change visually.
 
 Read the PNG files with the `Read` tool — they render inline. Screenshots
 published to users land on the GitHub release page: `release.yml` captures
-`release-main.png`, `release-plugin-settings.png`, and `release-server-running.png`
-via `docker/scripts/release_screenshots.py` and attaches them as release assets.
+`release-settings.png` via `docker/scripts/release_screenshots.py` and
+attaches it as a release asset.
 
 ### Mandatory before/after screenshots for UI work
 

--- a/docker/scripts/obsidian_cdp.py
+++ b/docker/scripts/obsidian_cdp.py
@@ -213,21 +213,53 @@ class ObsidianCDP:
             self.eval(f"app.commands.executeCommandById({json.dumps(command_id)})")
         )
 
-    def screenshot(self, output_path: str, fmt: str = "png") -> str:
+    def screenshot(
+        self,
+        output_path: str,
+        fmt: str = "png",
+        capture_beyond_viewport: bool = False,
+    ) -> str:
         """Capture the renderer surface to a PNG. Returns the absolute path written.
 
         Uses CDP `Page.captureScreenshot`, the same call obsidian-cli's
         `dev:screenshot` uses internally. No external screenshot tool needed.
+
+        Set `capture_beyond_viewport=True` to render the full document when a
+        modal or settings tab overflows the viewport — useful for capturing the
+        full Obsidian MCP settings tab in a single uncropped image.
         """
         result = self._send(
             "Page.captureScreenshot",
-            {"format": fmt, "captureBeyondViewport": False},
+            {"format": fmt, "captureBeyondViewport": capture_beyond_viewport},
         )
         data = base64.b64decode(result["data"])
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
         with open(output_path, "wb") as f:
             f.write(data)
         return os.path.abspath(output_path)
+
+    def set_color_scheme(self, scheme: str) -> None:
+        """Flip Obsidian's base color scheme at runtime.
+
+        `scheme` must be either `"moonstone"` (light) or `"obsidian"` (dark).
+        Uses the same JS sequence as the official `obsidian-system-dark-mode`
+        plugin: flip the in-memory theme, persist it, and trigger `css-change`
+        so all CSS variables re-evaluate.
+        """
+        if scheme not in ("moonstone", "obsidian"):
+            raise ValueError(
+                f"Unknown color scheme {scheme!r}; expected 'moonstone' or 'obsidian'"
+            )
+        self.eval(
+            f"""
+            (() => {{
+                const scheme = {json.dumps(scheme)};
+                app.setTheme(scheme);
+                app.vault.setConfig('theme', scheme);
+                app.workspace.trigger('css-change');
+            }})()
+            """
+        )
 
     def open_file(self, path: str) -> None:
         """Open a markdown file in the active leaf."""

--- a/docker/scripts/release_screenshots.py
+++ b/docker/scripts/release_screenshots.py
@@ -1,12 +1,14 @@
-"""release_screenshots.py — Capture the 3 curated shots shown in each GitHub release.
+"""release_screenshots.py — Capture the single shot shown in each GitHub release.
 
 Assumes Obsidian is already running with CDP on port 9222 and the plugin is
 bootstrapped (see docs/screenshots-on-host.md and .github/workflows/release.yml).
 
 Outputs to --out-dir:
-    release-main.png              Welcome.md open, plugin enabled, server stopped.
-    release-plugin-settings.png   Settings dialog on the obsidian-mcp tab, server stopped.
-    release-server-running.png    Same tab after starting the server (shows "Running on ...").
+    release-settings.png   Obsidian MCP settings tab, MCP server running,
+                           Obsidian default theme in light (moonstone) color
+                           scheme. Uncropped — captured with
+                           `captureBeyondViewport=True` so the full tab is
+                           visible even when it overflows the Xvfb viewport.
 """
 
 from __future__ import annotations
@@ -23,7 +25,6 @@ from obsidian_cdp import ObsidianCDP  # noqa: E402
 
 PLUGIN_ID = "obsidian-mcp"
 IS_RUNNING_JS = f"app.plugins.plugins[{PLUGIN_ID!r}]?.httpServer?.isRunning === true"
-IS_STOPPED_JS = f"app.plugins.plugins[{PLUGIN_ID!r}]?.httpServer?.isRunning !== true"
 
 
 def _close_modals(cdp: ObsidianCDP) -> None:
@@ -36,25 +37,32 @@ def capture(out_dir: Path, port: int) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     with ObsidianCDP(port=port) as cdp:
         _close_modals(cdp)
-        cdp.open_file("Welcome.md")
-        cdp.wait_for(
-            "document.querySelector('.workspace-leaf-content[data-type=\"markdown\"]')"
-        )
-        time.sleep(0.5)
-        cdp.screenshot(str(out_dir / "release-main.png"))
 
-        cdp.open_settings(tab_id=PLUGIN_ID)
-        cdp.wait_for("document.querySelector('.modal.mod-settings')")
-        cdp.wait_for(IS_STOPPED_JS)
+        # Flip to Obsidian's default theme in light (moonstone) color scheme.
+        cdp.set_color_scheme("moonstone")
         time.sleep(0.5)
-        cdp.screenshot(str(out_dir / "release-plugin-settings.png"))
 
+        # Start the MCP server before opening settings so the tab renders the
+        # "Running on …" URL.
         cdp.execute_command(f"{PLUGIN_ID}:start-server")
         if not cdp.wait_for(IS_RUNNING_JS, timeout=15.0):
             raise SystemExit("MCP server did not start within 15s")
+
         cdp.open_settings(tab_id=PLUGIN_ID)
+        cdp.wait_for("document.querySelector('.modal.mod-settings')")
+
+        # Confirm the settings tab renders the running-server URL before we snap.
+        cdp.wait_for(
+            "Array.from(document.querySelectorAll('.modal.mod-settings *'))"
+            ".some(el => /Running on/i.test(el.textContent || ''))",
+            timeout=5.0,
+        )
         time.sleep(0.5)
-        cdp.screenshot(str(out_dir / "release-server-running.png"))
+
+        cdp.screenshot(
+            str(out_dir / "release-settings.png"),
+            capture_beyond_viewport=True,
+        )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- Collapse the three dark-mode release screenshots into a single `release-settings.png` showing the Obsidian MCP settings tab with the MCP server running.
- Capture the screenshot against Obsidian's default theme in the `moonstone` (light) base color scheme — no community theme change.
- Render uncropped: `captureBeyondViewport=True` in the CDP call plus a 1920×1400 Xvfb screen as belt-and-braces so the full settings tab is visible.

## Changes

- `docker/scripts/obsidian_cdp.py` — add `set_color_scheme('moonstone'|'obsidian')` and an opt-in `capture_beyond_viewport: bool = False` kwarg on `screenshot()`.
- `docker/scripts/release_screenshots.py` — single capture flow: flip to light, start MCP, open settings, wait for "Running on …", snapshot with full-document capture.
- `.github/workflows/release-screenshots.yml` — Xvfb bumped to `1920×1400`; upload & release-notes step each reference only `release-settings.png`.
- `CLAUDE.md` — doc string updated to match the single asset.

## Test plan

- [x] `npm test` — 406 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] Python scripts parse cleanly (`python3 -c "import ast; ast.parse(...)"`)
- [ ] End-to-end verification lives in the `Release Screenshots` workflow, which runs on release publication.

Closes #171