### PR TITLE
ci(release): surface all conventional commit types in CHANGELOG

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,19 @@
 {
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Styles" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "test", "section": "Tests" },
+    { "type": "build", "section": "Build System" },
+    { "type": "ci", "section": "Continuous Integration" },
+    { "type": "chore", "section": "Miscellaneous Chores" }
+  ],
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Register explicit `changelog-sections` in `release-please-config.json` so release-please emits a section for every Conventional Commit type we accept — `feat`, `fix`, `perf`, `revert`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`. The changelog now doubles as a full audit log of the project's history; `docs:`, `refactor:`, `ci:`, `chore:` commits are no longer silently dropped.

## Test plan

- [x] JSON validates (`python3 -c "import json; json.load(open('release-please-config.json'))"`)
- [ ] Verify on the next release PR that queued commits show up under their respective sections (runs automatically when release-please opens the next release PR).

Closes #198