### PR TITLE
test(mocks): replace `any`-typed Obsidian mock with typed factories

### DIFF
--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,31 +1,36 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/require-await, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unsafe-call */
+/**
+ * Typed stubs for the subset of the Obsidian API that this plugin's tests
+ * exercise. Kept deliberately structural: the goal is "matches what the
+ * production code pulls off these objects", not "is literally the Obsidian
+ * runtime type". That's why we don't `implements Obsidian.Plugin`; the real
+ * surface is enormous and we only mock what we use.
+ */
 
-export class Plugin {
-  app: any;
-  manifest: any = { id: 'obsidian-mcp', version: '0.0.0' };
-  async loadData(): Promise<any> {
-    return null;
-  }
-  async saveData(_data: any): Promise<void> {
-    // no-op
-  }
-  addSettingTab(_tab: any): void {
-    // no-op
-  }
-  addRibbonIcon(_icon: string, _title: string, _callback: () => void): any {
-    return { remove: () => {} };
-  }
-  addCommand(_command: any): any {
-    return {};
-  }
-  addStatusBarItem(): any {
-    return mockEl();
-  }
+export interface MockElement {
+  setText: (text: string) => void;
+  style: Record<string, unknown>;
+  textContent: string;
+  className: string;
+  tagName: string;
+  title: string;
+  ariaLabel: string;
+  attributes: Record<string, string>;
+  classList: { add: (cls: string) => void; remove: (cls: string) => void };
+  addEventListener: (event: string, handler: unknown) => void;
+  children: MockElement[];
+  empty: () => void;
+  remove: () => void;
+  _icon?: string;
+  createEl: (
+    tag?: string,
+    opts?: { text?: string; cls?: string; attr?: Record<string, string> },
+  ) => MockElement;
+  createDiv: (opts?: { cls?: string }) => MockElement;
 }
 
-function mockEl(): any {
-  const el: any = {
-    setText: (text: string) => {
+function mockEl(): MockElement {
+  const el: MockElement = {
+    setText: (text: string): void => {
       el.textContent = text;
     },
     style: {},
@@ -34,34 +39,37 @@ function mockEl(): any {
     tagName: '',
     title: '',
     ariaLabel: '',
-    attributes: {} as Record<string, string>,
-    classList: { add: () => {}, remove: () => {} },
-    addEventListener: () => {},
-    children: [] as any[],
-    empty: () => {
+    attributes: {},
+    classList: {
+      add: (): void => {},
+      remove: (): void => {},
+    },
+    addEventListener: (): void => {},
+    children: [],
+    empty: (): void => {
       el.children.length = 0;
       el.textContent = '';
     },
-    remove: () => {},
-    createEl: (tag?: string, opts?: { text?: string; cls?: string; attr?: Record<string, string> }) => {
+    remove: (): void => {},
+    createEl: (tag, opts): MockElement => {
       const child = mockEl();
       if (tag) child.tagName = tag;
       if (opts?.text) child.textContent = opts.text;
       if (opts?.cls) child.className = opts.cls;
       if (opts?.attr) Object.assign(child.attributes, opts.attr);
       el.children.push(child);
-      child.remove = () => {
+      child.remove = (): void => {
         const idx = el.children.indexOf(child);
         if (idx >= 0) el.children.splice(idx, 1);
       };
       return child;
     },
-    createDiv: (opts?: { cls?: string }) => {
+    createDiv: (opts): MockElement => {
       const child = mockEl();
       child.tagName = 'div';
       if (opts?.cls) child.className = opts.cls;
       el.children.push(child);
-      child.remove = () => {
+      child.remove = (): void => {
         const idx = el.children.indexOf(child);
         if (idx >= 0) el.children.splice(idx, 1);
       };
@@ -71,22 +79,130 @@ function mockEl(): any {
   return el;
 }
 
-export class PluginSettingTab {
-  app: any;
-  containerEl: any = {
-    empty: () => {},
-    createEl: () => mockEl(),
-    createDiv: (_opts?: any) => mockEl(),
-  };
-  constructor(_app: any, _plugin: any) {
-    this.app = _app;
+export interface MockManifest {
+  id: string;
+  version: string;
+}
+
+export interface MockRibbonIcon {
+  remove: () => void;
+}
+
+export type MockStatusBarItem = MockElement;
+
+export interface MockCommand {
+  id?: string;
+  name?: string;
+  callback?: () => void;
+}
+
+export class Plugin {
+  app: unknown;
+  manifest: MockManifest = { id: 'obsidian-mcp', version: '0.0.0' };
+
+  loadData(): Promise<unknown> {
+    return Promise.resolve(null);
   }
+
+  saveData(_data: unknown): Promise<void> {
+    return Promise.resolve();
+  }
+
+  addSettingTab(_tab: unknown): void {
+    // no-op
+  }
+
+  addRibbonIcon(
+    _icon: string,
+    _title: string,
+    _callback: () => void,
+  ): MockRibbonIcon {
+    return { remove: (): void => {} };
+  }
+
+  addCommand(_command: MockCommand): Record<string, never> {
+    return {};
+  }
+
+  addStatusBarItem(): MockStatusBarItem {
+    return mockEl();
+  }
+}
+
+export interface MockContainerEl {
+  empty: () => void;
+  createEl: () => MockElement;
+  createDiv: (opts?: { cls?: string }) => MockElement;
+}
+
+export class PluginSettingTab {
+  app: unknown;
+  containerEl: MockContainerEl = {
+    empty: (): void => {},
+    createEl: (): MockElement => mockEl(),
+    createDiv: (): MockElement => mockEl(),
+  };
+
+  constructor(app: unknown, _plugin: unknown) {
+    this.app = app;
+  }
+
   display(): void {
     // no-op
   }
+
   hide(): void {
     // no-op
   }
+}
+
+interface SettingTextRecord {
+  placeholder: string;
+  value: string;
+  callback: ((value: string) => void | Promise<void>) | null;
+}
+
+interface SettingToggleRecord {
+  value: boolean;
+  tooltip: string;
+  callback: ((value: boolean) => void) | null;
+}
+
+interface SettingButtonRecord {
+  text: string;
+  disabled: boolean;
+  callback: (() => void) | null;
+}
+
+interface SettingExtraButtonRecord {
+  icon: string;
+  tooltip: string;
+  callback: (() => void) | null;
+}
+
+interface SettingTextHandle {
+  setPlaceholder: (p: string) => SettingTextHandle;
+  setValue: (v: string) => SettingTextHandle;
+  onChange: (fn: (value: string) => void | Promise<void>) => SettingTextHandle;
+}
+
+interface SettingToggleHandle {
+  setValue: (v: boolean) => SettingToggleHandle;
+  setTooltip: (t: string) => SettingToggleHandle;
+  onChange: (fn: (value: boolean) => void) => SettingToggleHandle;
+}
+
+interface SettingButtonHandle {
+  buttonEl: { disabled: boolean };
+  setButtonText: (t: string) => SettingButtonHandle;
+  setCta: () => SettingButtonHandle;
+  onClick: (fn: () => void) => SettingButtonHandle;
+}
+
+interface SettingExtraButtonHandle {
+  setIcon: (icon: string) => SettingExtraButtonHandle;
+  setTooltip: (t: string) => SettingExtraButtonHandle;
+  onClick: (fn: () => void) => SettingExtraButtonHandle;
 }
 
 export class Setting {
@@ -94,87 +210,139 @@ export class Setting {
   settingName = '';
   settingDesc = '';
   settingClass = '';
-  container: any;
-  descEl: any;
-  buttons: Array<{ text: string; disabled: boolean; callback: (() => void) | null }> = [];
-  extraButtons: Array<{ icon: string; tooltip: string; callback: (() => void) | null }> = [];
-  toggles: Array<{ value: boolean; tooltip: string; callback: ((value: boolean) => void) | null }> = [];
-  texts: Array<{
-    placeholder: string;
-    value: string;
-    callback: ((value: string) => void | Promise<void>) | null;
-  }> = [];
+  container: unknown;
+  descEl: MockElement;
+  buttons: SettingButtonRecord[] = [];
+  extraButtons: SettingExtraButtonRecord[] = [];
+  toggles: SettingToggleRecord[] = [];
+  texts: SettingTextRecord[] = [];
   settingEl: { classList: { add: (cls: string) => void } };
 
-  constructor(containerEl: any) {
+  constructor(containerEl: unknown) {
     Setting.instances.push(this);
     this.container = containerEl;
     this.descEl = mockEl();
     this.settingEl = {
       classList: {
         add: (cls: string): void => {
-          this.settingClass = this.settingClass ? `${this.settingClass} ${cls}` : cls;
+          this.settingClass = this.settingClass
+            ? `${this.settingClass} ${cls}`
+            : cls;
         },
       },
     };
   }
+
   setName(name: string): this {
     this.settingName = name;
     return this;
   }
-  setDesc(desc: any): this {
+
+  setDesc(desc: unknown): this {
     if (typeof desc === 'string') this.settingDesc = desc;
     return this;
   }
+
   setClass(cls: string): this {
     this.settingClass = this.settingClass ? `${this.settingClass} ${cls}` : cls;
     return this;
   }
-  addText(cb: (text: any) => void): this {
-    const record = {
+
+  addText(cb: (text: SettingTextHandle) => void): this {
+    const record: SettingTextRecord = {
       placeholder: '',
       value: '',
-      callback: null as ((value: string) => void | Promise<void>) | null,
+      callback: null,
     };
-    const text = {
-      setPlaceholder(p: string) { record.placeholder = p; return text; },
-      setValue(v: string) { record.value = v; return text; },
-      onChange(fn: (value: string) => void | Promise<void>) { record.callback = fn; return text; },
+    const text: SettingTextHandle = {
+      setPlaceholder(p: string): SettingTextHandle {
+        record.placeholder = p;
+        return text;
+      },
+      setValue(v: string): SettingTextHandle {
+        record.value = v;
+        return text;
+      },
+      onChange(fn): SettingTextHandle {
+        record.callback = fn;
+        return text;
+      },
     };
     cb(text);
     this.texts.push(record);
     return this;
   }
-  addToggle(cb: (toggle: any) => void): this {
-    const record = { value: false, tooltip: '', callback: null as ((value: boolean) => void) | null };
-    const toggle = {
-      setValue(v: boolean) { record.value = v; return toggle; },
-      setTooltip(t: string) { record.tooltip = t; return toggle; },
-      onChange(fn: (value: boolean) => void) { record.callback = fn; return toggle; },
+
+  addToggle(cb: (toggle: SettingToggleHandle) => void): this {
+    const record: SettingToggleRecord = {
+      value: false,
+      tooltip: '',
+      callback: null,
+    };
+    const toggle: SettingToggleHandle = {
+      setValue(v: boolean): SettingToggleHandle {
+        record.value = v;
+        return toggle;
+      },
+      setTooltip(t: string): SettingToggleHandle {
+        record.tooltip = t;
+        return toggle;
+      },
+      onChange(fn): SettingToggleHandle {
+        record.callback = fn;
+        return toggle;
+      },
     };
     cb(toggle);
     this.toggles.push(record);
     return this;
   }
-  addButton(cb: (btn: any) => void): this {
-    const record = { text: '', disabled: false, callback: null as (() => void) | null };
-    const btn = {
+
+  addButton(cb: (btn: SettingButtonHandle) => void): this {
+    const record: SettingButtonRecord = {
+      text: '',
+      disabled: false,
+      callback: null,
+    };
+    const btn: SettingButtonHandle = {
       buttonEl: { disabled: false },
-      setButtonText(t: string) { record.text = t; return btn; },
-      setCta() { return btn; },
-      onClick(fn: () => void) { record.callback = fn; return btn; },
+      setButtonText(t: string): SettingButtonHandle {
+        record.text = t;
+        return btn;
+      },
+      setCta(): SettingButtonHandle {
+        return btn;
+      },
+      onClick(fn: () => void): SettingButtonHandle {
+        record.callback = fn;
+        return btn;
+      },
     };
     cb(btn);
     record.disabled = btn.buttonEl.disabled;
     this.buttons.push(record);
     return this;
   }
-  addExtraButton(cb: (btn: any) => void): this {
-    const record = { icon: '', tooltip: '', callback: null as (() => void) | null };
-    const btn = {
-      setIcon(icon: string) { record.icon = icon; return btn; },
-      setTooltip(t: string) { record.tooltip = t; return btn; },
-      onClick(fn: () => void) { record.callback = fn; return btn; },
+
+  addExtraButton(cb: (btn: SettingExtraButtonHandle) => void): this {
+    const record: SettingExtraButtonRecord = {
+      icon: '',
+      tooltip: '',
+      callback: null,
+    };
+    const btn: SettingExtraButtonHandle = {
+      setIcon(icon: string): SettingExtraButtonHandle {
+        record.icon = icon;
+        return btn;
+      },
+      setTooltip(t: string): SettingExtraButtonHandle {
+        record.tooltip = t;
+        return btn;
+      },
+      onClick(fn: () => void): SettingExtraButtonHandle {
+        record.callback = fn;
+        return btn;
+      },
     };
     cb(btn);
     this.extraButtons.push(record);
@@ -187,16 +355,16 @@ export class TFile {
   name = '';
   basename = '';
   extension = '';
-  parent: any = null;
+  parent: unknown = null;
   stat = { ctime: 0, mtime: 0, size: 0 };
-  vault: any = null;
+  vault: unknown = null;
 }
 
 export class TFolder {
   path = '';
   name = '';
-  parent: any = null;
-  children: any[] = [];
+  parent: unknown = null;
+  children: unknown[] = [];
   isRoot(): boolean {
     return this.path === '/';
   }
@@ -205,39 +373,108 @@ export class TFolder {
 export class TAbstractFile {
   path = '';
   name = '';
-  parent: any = null;
-  vault: any = null;
+  parent: unknown = null;
+  vault: unknown = null;
 }
 
 export class Vault {
-  static recurseChildren(_root: any, _cb: (file: any) => void): void {
+  static recurseChildren(_root: unknown, _cb: (file: unknown) => void): void {
     // no-op
   }
 }
 
 export class App {
-  vault: any = new Vault();
-  workspace: any = {};
-  metadataCache: any = {};
+  vault: Vault = new Vault();
+  workspace: Record<string, unknown> = {};
+  metadataCache: Record<string, unknown> = {};
 }
 
 export class Notice {
-  constructor(_message: string, _timeout?: number) {}
+  constructor(_message: string, _timeout?: number) {
+    // no-op
+  }
 }
 
-export function setIcon(el: any, icon: string): void {
+export function setIcon(el: { _icon?: string } | null, icon: string): void {
   if (el) el._icon = icon;
 }
 
+export interface MockModalContentEl {
+  createEl: () => Record<string, never>;
+  empty: () => void;
+}
+
 export class Modal {
-  app: any;
-  contentEl: any = {
-    createEl: () => ({}),
-    empty: () => {},
+  app: unknown;
+  contentEl: MockModalContentEl = {
+    createEl: (): Record<string, never> => ({}),
+    empty: (): void => {},
   };
-  constructor(_app: any) {
-    this.app = _app;
+
+  constructor(app: unknown) {
+    this.app = app;
   }
-  open(): void {}
-  close(): void {}
+
+  open(): void {
+    // no-op
+  }
+
+  close(): void {
+    // no-op
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Typed factories for tests — matches the shape production code uses.
+ * ------------------------------------------------------------------ */
+
+export interface MockVaultAdapter {
+  basePath: string;
+  exists: (path: string) => Promise<boolean>;
+  read: (path: string) => Promise<string>;
+  write: (path: string, content: string) => Promise<void>;
+  append: (path: string, content: string) => Promise<void>;
+  stat: (path: string) => Promise<null>;
+}
+
+export interface MockVault {
+  configDir: string;
+  adapter: MockVaultAdapter;
+}
+
+export interface MockApp {
+  vault: MockVault;
+  workspace: Record<string, unknown>;
+  metadataCache: Record<string, unknown>;
+}
+
+export function mockVaultAdapter(
+  overrides: Partial<MockVaultAdapter> = {},
+): MockVaultAdapter {
+  return {
+    basePath: '/tmp/vault',
+    exists: (): Promise<boolean> => Promise.resolve(false),
+    read: (): Promise<string> => Promise.resolve(''),
+    write: (): Promise<void> => Promise.resolve(),
+    append: (): Promise<void> => Promise.resolve(),
+    stat: (): Promise<null> => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+export function mockVault(overrides: Partial<MockVault> = {}): MockVault {
+  return {
+    configDir: '.obsidian',
+    adapter: mockVaultAdapter(),
+    ...overrides,
+  };
+}
+
+export function mockApp(overrides: Partial<MockApp> = {}): MockApp {
+  return {
+    vault: mockVault(),
+    workspace: {},
+    metadataCache: {},
+    ...overrides,
+  };
 }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,32 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { App, PluginManifest } from 'obsidian';
 import McpPlugin from '../src/main';
+import { mockApp, type MockApp, type MockManifest } from './__mocks__/obsidian';
 
 interface TestPlugin extends McpPlugin {
   loadData: () => Promise<Record<string, unknown> | null>;
   saveData: (data: unknown) => Promise<void>;
 }
 
+interface MutablePluginFields {
+  app: MockApp;
+  manifest: MockManifest;
+}
+
 function createPlugin(persisted: Record<string, unknown> | null): TestPlugin {
-  const app = {
-    vault: {
-      configDir: '.obsidian',
-      adapter: {
-        basePath: '/tmp/vault',
-        exists: (): Promise<boolean> => Promise.resolve(false),
-        read: (): Promise<string> => Promise.resolve(''),
-        write: (): Promise<void> => Promise.resolve(),
-        append: (): Promise<void> => Promise.resolve(),
-        stat: (): Promise<null> => Promise.resolve(null),
-      },
-    },
-    workspace: {},
-    metadataCache: {},
-  };
-  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-  const plugin = new McpPlugin(app as any, { id: 'obsidian-mcp', version: '0.0.0' } as any) as unknown as TestPlugin;
-  (plugin as any).app = app;
-  (plugin as any).manifest = { id: 'obsidian-mcp', version: '0.0.0' };
-  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+  const app = mockApp();
+  const manifest: MockManifest = { id: 'obsidian-mcp', version: '0.0.0' };
+  const plugin = new McpPlugin(
+    app as unknown as App,
+    manifest as unknown as PluginManifest,
+  ) as unknown as TestPlugin;
+  const mutable = plugin as unknown as MutablePluginFields;
+  mutable.app = app;
+  mutable.manifest = manifest;
   plugin.loadData = vi.fn().mockResolvedValue(persisted);
   plugin.saveData = vi.fn().mockResolvedValue(undefined);
   return plugin;


### PR DESCRIPTION
## Summary

- Rewrite `tests/__mocks__/obsidian.ts` with explicit interfaces for every stub surface (`MockElement`, the four Setting handles, `Plugin`, `App`, `Vault`, …). Drop the file-level `eslint-disable` block entirely.
- Where looseness is unavoidable (reusable fields like `parent`/`app`), fall back to `unknown` — never `any`.
- Add `mockApp()` / `mockVault()` / `mockVaultAdapter()` factories per the issue spec so tests can construct realistic app stubs without re-declaring the shape each time.
- Update `tests/main.test.ts` to use `mockApp()` and drop its inline `no-explicit-any` / `no-unsafe-*` disables in favour of targeted casts through typed interfaces.

## Changes

- `tests/__mocks__/obsidian.ts` — full rewrite, no `any`, no file-level disables.
- `tests/main.test.ts` — use `mockApp`, drop the inline disables.

## Test plan

- [x] `npm test` — 410 passing (no change from main; pure refactor)
- [x] `npm run lint` — no new warnings, no errors. The only remaining warnings are the two pre-existing ones in `tests/settings.test.ts` flagged in CLAUDE.md as allowed.
- [x] `npm run typecheck` — clean
- [x] Grep: no file-level `eslint-disable` in `tests/__mocks__/obsidian.ts` (verified)
- [x] Grep: no inline `eslint-disable` for `no-explicit-any` / `no-unsafe-*` in `tests/main.test.ts` (verified)

Closes #188