### PR TITLE
fix(tools): bounds-check editor positions and guard workspace_open_file

### DIFF
--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -8,6 +8,40 @@ type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
 
+/**
+ * Require a value to be a non-negative safe integer. Defensive belt-and-braces
+ * alongside the Zod schema: until the dispatcher enforces `schema.parse()` at
+ * runtime (#174), handlers still receive untyped params and need the guard.
+ */
+function isNonNegativeInt(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+/**
+ * Validate a `(line, ch)` position against the editor's current line count.
+ * `allowEnd` extends the upper line bound by one to cover operations that can
+ * legitimately target EOF (e.g. inserting at the end of the last line).
+ */
+function assertEditorPosition(
+  line: unknown,
+  ch: unknown,
+  lineCount: number,
+  { allowEnd = false }: { allowEnd?: boolean } = {},
+): void {
+  if (!isNonNegativeInt(line) || !isNonNegativeInt(ch)) {
+    throw new RangeError('Position must be a non-negative integer pair');
+  }
+  const maxLine = allowEnd ? lineCount : lineCount - 1;
+  if (line > maxLine) {
+    throw new RangeError('Position is out of range for the active editor');
+  }
+}
+
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
   return {
     getContent: (): Promise<CallToolResult> => {
@@ -21,10 +55,37 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       return Promise.resolve(text(path));
     },
     insert: (params): Promise<CallToolResult> => {
-      const ok = adapter.insertTextAt(params.line as number, params.ch as number, params.text as string);
+      const lineCount = adapter.getActiveLineCount();
+      if (lineCount === null) return Promise.resolve(err('No active editor'));
+      try {
+        assertEditorPosition(params.line, params.ch, lineCount, {
+          allowEnd: true,
+        });
+      } catch (error) {
+        return Promise.resolve(
+          err(error instanceof Error ? error.message : String(error)),
+        );
+      }
+      const ok = adapter.insertTextAt(
+        params.line as number,
+        params.ch as number,
+        params.text as string,
+      );
       return Promise.resolve(ok ? text('Text inserted') : err('No active editor'));
     },
     replace: (params): Promise<CallToolResult> => {
+      const lineCount = adapter.getActiveLineCount();
+      if (lineCount === null) return Promise.resolve(err('No active editor'));
+      try {
+        assertEditorPosition(params.fromLine, params.fromCh, lineCount);
+        assertEditorPosition(params.toLine, params.toCh, lineCount, {
+          allowEnd: true,
+        });
+      } catch (error) {
+        return Promise.resolve(
+          err(error instanceof Error ? error.message : String(error)),
+        );
+      }
       const ok = adapter.replaceRange(
         params.fromLine as number, params.fromCh as number,
         params.toLine as number, params.toCh as number, params.text as string,
@@ -32,6 +93,18 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       return Promise.resolve(ok ? text('Text replaced') : err('No active editor'));
     },
     deleteRange: (params): Promise<CallToolResult> => {
+      const lineCount = adapter.getActiveLineCount();
+      if (lineCount === null) return Promise.resolve(err('No active editor'));
+      try {
+        assertEditorPosition(params.fromLine, params.fromCh, lineCount);
+        assertEditorPosition(params.toLine, params.toCh, lineCount, {
+          allowEnd: true,
+        });
+      } catch (error) {
+        return Promise.resolve(
+          err(error instanceof Error ? error.message : String(error)),
+        );
+      }
       const ok = adapter.deleteRange(
         params.fromLine as number, params.fromCh as number,
         params.toLine as number, params.toCh as number,
@@ -44,7 +117,19 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       return Promise.resolve(text(JSON.stringify(pos)));
     },
     setCursor: (params): Promise<CallToolResult> => {
-      const ok = adapter.setCursorPosition(params.line as number, params.ch as number);
+      const lineCount = adapter.getActiveLineCount();
+      if (lineCount === null) return Promise.resolve(err('No active editor'));
+      try {
+        assertEditorPosition(params.line, params.ch, lineCount);
+      } catch (error) {
+        return Promise.resolve(
+          err(error instanceof Error ? error.message : String(error)),
+        );
+      }
+      const ok = adapter.setCursorPosition(
+        params.line as number,
+        params.ch as number,
+      );
       return Promise.resolve(ok ? text('Cursor set') : err('No active editor'));
     },
     getSelection: (): Promise<CallToolResult> => {
@@ -53,6 +138,18 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       return Promise.resolve(text(JSON.stringify(sel)));
     },
     setSelection: (params): Promise<CallToolResult> => {
+      const lineCount = adapter.getActiveLineCount();
+      if (lineCount === null) return Promise.resolve(err('No active editor'));
+      try {
+        assertEditorPosition(params.fromLine, params.fromCh, lineCount);
+        assertEditorPosition(params.toLine, params.toCh, lineCount, {
+          allowEnd: true,
+        });
+      } catch (error) {
+        return Promise.resolve(
+          err(error instanceof Error ? error.message : String(error)),
+        );
+      }
       const ok = adapter.setSelection(
         params.fromLine as number, params.fromCh as number,
         params.toLine as number, params.toCh as number,
@@ -75,13 +172,13 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
       return [
         { name: 'editor_get_content', description: 'Get content of active editor', schema: {}, handler: h.getContent, annotations: annotations.read },
         { name: 'editor_get_active_file', description: 'Get active file path', schema: {}, handler: h.getActivePath, annotations: annotations.read },
-        { name: 'editor_insert', description: 'Insert text at position', schema: { line: z.number(), ch: z.number(), text: z.string() }, handler: h.insert, annotations: annotations.additive },
-        { name: 'editor_replace', description: 'Replace text in range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number(), text: z.string() }, handler: h.replace, annotations: annotations.destructive },
-        { name: 'editor_delete', description: 'Delete text in range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number() }, handler: h.deleteRange, annotations: annotations.destructive },
+        { name: 'editor_insert', description: 'Insert text at position', schema: { line: z.number().int().min(0), ch: z.number().int().min(0), text: z.string() }, handler: h.insert, annotations: annotations.additive },
+        { name: 'editor_replace', description: 'Replace text in range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0), text: z.string() }, handler: h.replace, annotations: annotations.destructive },
+        { name: 'editor_delete', description: 'Delete text in range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0) }, handler: h.deleteRange, annotations: annotations.destructive },
         { name: 'editor_get_cursor', description: 'Get cursor position', schema: {}, handler: h.getCursor, annotations: annotations.read },
-        { name: 'editor_set_cursor', description: 'Set cursor position', schema: { line: z.number(), ch: z.number() }, handler: h.setCursor, annotations: annotations.additive },
+        { name: 'editor_set_cursor', description: 'Set cursor position', schema: { line: z.number().int().min(0), ch: z.number().int().min(0) }, handler: h.setCursor, annotations: annotations.additive },
         { name: 'editor_get_selection', description: 'Get current selection', schema: {}, handler: h.getSelection, annotations: annotations.read },
-        { name: 'editor_set_selection', description: 'Set selection range', schema: { fromLine: z.number(), fromCh: z.number(), toLine: z.number(), toCh: z.number() }, handler: h.setSelection, annotations: annotations.additive },
+        { name: 'editor_set_selection', description: 'Set selection range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0) }, handler: h.setSelection, annotations: annotations.additive },
         { name: 'editor_get_line_count', description: 'Get line count of active editor', schema: {}, handler: h.getLineCount, annotations: annotations.read },
       ];
     },

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
+import { validateVaultPath } from '../../utils/path-guard';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -9,6 +10,7 @@ function text(t: string): CallToolResult { return { content: [{ type: 'text', te
 function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
 
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+  const vaultPath = adapter.getVaultPath();
   return {
     getActiveLeaf: (): Promise<CallToolResult> => {
       const info = adapter.getActiveLeafInfo();
@@ -17,8 +19,9 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     },
     async openFile(params): Promise<CallToolResult> {
       try {
-        await adapter.openFile(params.path as string, params.mode as string | undefined);
-        return text(`Opened: ${params.path as string}`);
+        const path = validateVaultPath(params.path as string, vaultPath);
+        await adapter.openFile(path, params.mode as string | undefined);
+        return text(`Opened: ${path}`);
       } catch (error) {
         return err(error instanceof Error ? error.message : String(error));
       }

--- a/tests/tools/editor/editor.test.ts
+++ b/tests/tools/editor/editor.test.ts
@@ -74,5 +74,70 @@ describe('editor module', () => {
       const pos = JSON.parse(getText(result)) as { line: number; ch: number };
       expect(pos).toEqual({ line: 0, ch: 3 });
     });
+
+    describe('bounds checking', () => {
+      it('rejects negative line in editor_set_cursor', async () => {
+        adapter.setActiveEditor('test.md', 'line1\nline2');
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_set_cursor')!;
+        const result = await tool.handler({ line: -1, ch: 0 });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain('non-negative');
+      });
+
+      it('rejects line beyond EOF in editor_set_cursor', async () => {
+        adapter.setActiveEditor('test.md', 'line1\nline2'); // lineCount === 2
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_set_cursor')!;
+        const result = await tool.handler({ line: 99, ch: 0 });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain('out of range');
+      });
+
+      it('rejects non-integer positions in editor_insert', async () => {
+        adapter.setActiveEditor('test.md', 'hello');
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_insert')!;
+        const result = await tool.handler({ line: 0.5, ch: 0, text: 'x' });
+        expect(result.isError).toBe(true);
+      });
+
+      it('accepts editor_insert at the last valid line', async () => {
+        adapter.setActiveEditor('test.md', 'line1\nline2\nline3');
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_insert')!;
+        // lineCount === 3 → line index 2 is the last valid line.
+        const result = await tool.handler({ line: 2, ch: 0, text: 'x' });
+        expect(result.isError).toBeUndefined();
+      });
+
+      it('rejects out-of-range fromLine in editor_replace', async () => {
+        adapter.setActiveEditor('test.md', 'only');
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_replace')!;
+        const result = await tool.handler({
+          fromLine: 5,
+          fromCh: 0,
+          toLine: 5,
+          toCh: 1,
+          text: 'x',
+        });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain('out of range');
+      });
+
+      it('rejects negative toCh in editor_delete', async () => {
+        adapter.setActiveEditor('test.md', 'hello');
+        const module = createEditorModule(adapter);
+        const tool = module.tools().find((t) => t.name === 'editor_delete')!;
+        const result = await tool.handler({
+          fromLine: 0,
+          fromCh: 0,
+          toLine: 0,
+          toCh: -1,
+        });
+        expect(result.isError).toBe(true);
+      });
+    });
   });
 });

--- a/tests/tools/workspace/workspace.test.ts
+++ b/tests/tools/workspace/workspace.test.ts
@@ -48,4 +48,27 @@ describe('workspace module', () => {
     const result = await tool.handler({});
     expect(result.isError).toBeUndefined();
   });
+
+  describe('workspace_open_file path guard', () => {
+    it('rejects path traversal attempts', async () => {
+      const module = createWorkspaceModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'workspace_open_file')!;
+      const result = await tool.handler({ path: '../../etc/passwd' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects empty path', async () => {
+      const module = createWorkspaceModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'workspace_open_file')!;
+      const result = await tool.handler({ path: '' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects backslash separators', async () => {
+      const module = createWorkspaceModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'workspace_open_file')!;
+      const result = await tool.handler({ path: 'a\\b.md' });
+      expect(result.isError).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Handler-level defence-in-depth for the editor and workspace tool modules, complementing the schema tightening slated for #174/#175.

- **Editor:** every position-taking tool (`insert`, `replace`, `delete`, `set_cursor`, `set_selection`) now asks the adapter for the current line count and validates `(line, ch)` pairs are non-negative safe integers within range. Out-of-range inputs return a clear MCP error instead of silent no-ops. Schemas pick up `.int().min(0)` bounds so strict clients reject bad inputs upfront.
- **Workspace:** `workspace_open_file` now runs its `path` through `validateVaultPath`, matching every other vault-touching tool. Empty paths, backslashes, and traversal attempts are rejected uniformly.

## Changes

- `src/tools/editor/index.ts` — `assertEditorPosition()` helper + per-handler bounds check; `.int().min(0)` on every position field.
- `src/tools/workspace/index.ts` — `validateVaultPath()` on `workspace_open_file`.
- `tests/tools/editor/editor.test.ts` — 6 bounds tests (negative, out-of-range, non-integer, last-valid-line, range endpoints).
- `tests/tools/workspace/workspace.test.ts` — 3 path-guard tests (traversal, empty, backslash).

## Test plan

- [x] `npm test` — 424 passing (+9 new)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #182