### PR TITLE
feat(tools): add `CHARACTER_LIMIT` constant + response truncation helper

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Maximum characters a single tool response should emit before we truncate
+ * and inform the caller. Picked to leave plenty of headroom in a model's
+ * context window while still letting common reads/searches fit unchanged.
+ */
+export const CHARACTER_LIMIT = 25_000;
+
+/**
+ * Maximum bytes a binary vault read will return in a single call. Larger
+ * files are refused with a clear error so callers know to fetch the file
+ * out-of-band (or chunk once chunked reads land).
+ */
+export const BINARY_BYTE_LIMIT = 1_048_576; // 1 MiB

--- a/src/tools/search/handlers.ts
+++ b/src/tools/search/handlers.ts
@@ -1,11 +1,17 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
+import { truncateText } from '../shared/truncate';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function textResult(text: string): CallToolResult {
   return { content: [{ type: 'text', text }] };
+}
+
+function truncatedResult(text: string, hint?: string): CallToolResult {
+  const result = truncateText(text, hint ? { hint } : {});
+  return { content: [{ type: 'text', text: result.text }] };
 }
 
 function errorResult(message: string): CallToolResult {
@@ -20,7 +26,10 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
       try {
         const query = params.query as string;
         const results = await adapter.searchContent(query);
-        return textResult(JSON.stringify(results));
+        return truncatedResult(
+          JSON.stringify(results),
+          'Narrow the query or add filters to reduce match count.',
+        );
       } catch (error) {
         return errorResult(error instanceof Error ? error.message : String(error));
       }

--- a/src/tools/shared/truncate.ts
+++ b/src/tools/shared/truncate.ts
@@ -1,0 +1,37 @@
+import { CHARACTER_LIMIT } from '../../constants';
+
+export interface TruncationResult {
+  /** The possibly-truncated text, with a `[TRUNCATED: ...]` footer appended when cut. */
+  text: string;
+  /** True when the original text exceeded the limit. */
+  truncated: boolean;
+  /** Present only when truncated; human-readable guidance for the caller. */
+  truncation_message?: string;
+}
+
+/**
+ * Cap a tool response to `limit` characters. When the payload is over the
+ * limit the function slices off the tail and appends a `[TRUNCATED: ...]`
+ * footer so the model sees the truncation inside the text. The returned
+ * object also reports `truncated: true` and a `truncation_message` so
+ * structured-content-aware callers (see #176) can surface it as data.
+ */
+export function truncateText(
+  text: string,
+  {
+    limit = CHARACTER_LIMIT,
+    hint = 'Narrow your query or request a specific subset.',
+  }: { limit?: number; hint?: string } = {},
+): TruncationResult {
+  if (text.length <= limit) {
+    return { text, truncated: false };
+  }
+  const truncation_message = `Response exceeded ${String(limit)} characters. ${hint}`;
+  const footer = `\n\n[TRUNCATED: ${truncation_message}]`;
+  const sliceLength = Math.max(0, limit - footer.length);
+  return {
+    text: text.slice(0, sliceLength) + footer,
+    truncated: true,
+    truncation_message,
+  };
+}

--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -1,6 +1,8 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
+import { truncateText } from '../shared/truncate';
+import { BINARY_BYTE_LIMIT } from '../../constants';
 
 export class WriteMutex {
   private locks: Map<string, Promise<void>> = new Map();
@@ -27,6 +29,11 @@ export class WriteMutex {
 
 function textResult(text: string): CallToolResult {
   return { content: [{ type: 'text', text }] };
+}
+
+function truncatedResult(text: string, hint?: string): CallToolResult {
+  const result = truncateText(text, hint ? { hint } : {});
+  return { content: [{ type: 'text', text: result.text }] };
 }
 
 function errorResult(message: string): CallToolResult {
@@ -86,7 +93,10 @@ export function createHandlers(
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const content = await adapter.readFile(path);
-        return textResult(content);
+        return truncatedResult(
+          content,
+          'Read a specific range via editor_* tools or ask for a summary.',
+        );
       } catch (error) {
         return errorResult(error instanceof Error ? error.message : String(error));
       }
@@ -246,7 +256,12 @@ export function createHandlers(
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const result = adapter.listRecursive(path);
-        return Promise.resolve(textResult(JSON.stringify(result)));
+        return Promise.resolve(
+          truncatedResult(
+            JSON.stringify(result),
+            'List a subfolder instead of the whole vault to reduce the result size.',
+          ),
+        );
       } catch (error) {
         return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
       }
@@ -256,6 +271,11 @@ export function createHandlers(
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const data = await adapter.readBinary(path);
+        if (data.byteLength > BINARY_BYTE_LIMIT) {
+          return errorResult(
+            `Binary file too large (${String(data.byteLength)} bytes, limit ${String(BINARY_BYTE_LIMIT)}). Fetch the file out-of-band or use a chunked read when available.`,
+          );
+        }
         const base64 = Buffer.from(data).toString('base64');
         return textResult(base64);
       } catch (error) {

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -56,6 +56,19 @@ describe('search handlers', () => {
       const data = JSON.parse(getText(result)) as Array<{ path: string }>;
       expect(data).toHaveLength(1);
     });
+
+    it('truncates oversized results with a clear footer', async () => {
+      // Build a payload well over CHARACTER_LIMIT by indexing many matching
+      // lines in one file.
+      const big = Array.from({ length: 5000 }, (_, i) => `match ${String(i)}`).join(
+        '\n',
+      );
+      adapter.addFile('big.md', big);
+      const result = await handlers.searchFulltext({ query: 'match' });
+      const out = getText(result);
+      expect(out).toContain('[TRUNCATED:');
+      expect(out).toContain('Narrow the query');
+    });
   });
 
   describe('searchFrontmatter', () => {

--- a/tests/tools/shared/truncate.test.ts
+++ b/tests/tools/shared/truncate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { truncateText } from '../../../src/tools/shared/truncate';
+import { CHARACTER_LIMIT } from '../../../src/constants';
+
+describe('truncateText', () => {
+  it('returns the input unchanged when below the limit', () => {
+    const result = truncateText('hello world');
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe('hello world');
+    expect(result.truncation_message).toBeUndefined();
+  });
+
+  it('truncates and appends a [TRUNCATED: ...] footer when over the limit', () => {
+    const oversized = 'x'.repeat(CHARACTER_LIMIT + 500);
+    const result = truncateText(oversized);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    expect(result.text).toContain('[TRUNCATED:');
+    expect(result.truncation_message).toContain(String(CHARACTER_LIMIT));
+  });
+
+  it('honours a custom limit and hint', () => {
+    const result = truncateText('abcdefghij', {
+      limit: 5,
+      hint: 'Use search_fulltext with a narrower query.',
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.text).toContain('[TRUNCATED:');
+    expect(result.truncation_message).toContain(
+      'Use search_fulltext with a narrower query.',
+    );
+  });
+});

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -362,3 +362,39 @@ describe('WriteMutex', () => {
     expect(order[0]).toBe('b');
   });
 });
+
+describe('vault handlers truncation and size limits', () => {
+  let adapter: MockObsidianAdapter;
+  let handlers: ReturnType<typeof createHandlers>;
+
+  beforeEach(() => {
+    adapter = new MockObsidianAdapter();
+    handlers = createHandlers(adapter, new WriteMutex());
+  });
+
+  it('truncates oversized listRecursive output with a clear footer', async () => {
+    adapter.addFolder('lots');
+    for (let i = 0; i < 4000; i++) {
+      adapter.addFile(`lots/file-${String(i).padStart(5, '0')}.md`, 'x');
+    }
+    const result = await handlers.listRecursive({ path: 'lots' });
+    expect(getText(result)).toContain('[TRUNCATED:');
+  });
+
+  it('truncates oversized readFile content with a clear footer', async () => {
+    const big = 'x'.repeat(50_000);
+    adapter.addFile('big.md', big);
+    const result = await handlers.readFile({ path: 'big.md' });
+    expect(getText(result)).toContain('[TRUNCATED:');
+  });
+
+  it('refuses readBinary when the file is larger than the byte limit', async () => {
+    // Seed a 2 MiB blob via the writeBinary adapter path so the mock adapter
+    // returns a buffer that exceeds BINARY_BYTE_LIMIT (1 MiB).
+    const bigBuffer = new ArrayBuffer(2_000_000);
+    await adapter.writeBinary('huge.bin', bigBuffer);
+    const result = await handlers.readBinary({ path: 'huge.bin' });
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('too large');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/constants.ts` with `CHARACTER_LIMIT = 25_000` and `BINARY_BYTE_LIMIT = 1_048_576`.
- Add `src/tools/shared/truncate.ts` — `truncateText()` caps responses at the character limit, appends a `[TRUNCATED: …]` footer, and reports `truncated: true` + a `truncation_message` for future structured-content callers (#176).
- Apply to the tools that today return unbounded payloads:
  - `search_fulltext`
  - `vault_read`
  - `vault_list_recursive`
- `vault_read_binary` refuses above `BINARY_BYTE_LIMIT` with a clear error pointing the caller at out-of-band transfer or a future chunked read (groundwork for pagination #178).

## Changes

- `src/constants.ts`, `src/tools/shared/truncate.ts` — new.
- `src/tools/search/handlers.ts`, `src/tools/vault/handlers.ts` — wire the helper + binary limit.
- `tests/tools/shared/truncate.test.ts` — helper tests.
- `tests/tools/search/search.test.ts` — oversized `search_fulltext` truncation test.
- `tests/tools/vault/handlers.test.ts` — truncation tests for `readFile` + `listRecursive` and byte-limit refusal for `readBinary`.

## Test plan

- [x] `npm test` — 436 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` — above thresholds
- [x] `npm run docs:check` — snapshot still matches

## Out of scope

- Pagination wiring (tracked in #178) — this PR only adds the truncation safety net.
- `structuredContent` wrapping (#176) — the truncation info lands in text today; the returned `TruncationResult` shape is ready for that work.

Closes #177