### PR TITLE
refactor(tools): tighten Zod schemas with describes and bounds

### DIFF
--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -170,16 +170,105 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'editor', name: 'Editor Operations', description: 'Access and manipulate the active editor' },
     tools(): ToolDefinition[] {
       return [
-        { name: 'editor_get_content', description: 'Get content of active editor', schema: {}, handler: h.getContent, annotations: annotations.read },
-        { name: 'editor_get_active_file', description: 'Get active file path', schema: {}, handler: h.getActivePath, annotations: annotations.read },
-        { name: 'editor_insert', description: 'Insert text at position', schema: { line: z.number().int().min(0), ch: z.number().int().min(0), text: z.string() }, handler: h.insert, annotations: annotations.additive },
-        { name: 'editor_replace', description: 'Replace text in range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0), text: z.string() }, handler: h.replace, annotations: annotations.destructive },
-        { name: 'editor_delete', description: 'Delete text in range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0) }, handler: h.deleteRange, annotations: annotations.destructive },
-        { name: 'editor_get_cursor', description: 'Get cursor position', schema: {}, handler: h.getCursor, annotations: annotations.read },
-        { name: 'editor_set_cursor', description: 'Set cursor position', schema: { line: z.number().int().min(0), ch: z.number().int().min(0) }, handler: h.setCursor, annotations: annotations.additive },
-        { name: 'editor_get_selection', description: 'Get current selection', schema: {}, handler: h.getSelection, annotations: annotations.read },
-        { name: 'editor_set_selection', description: 'Set selection range', schema: { fromLine: z.number().int().min(0), fromCh: z.number().int().min(0), toLine: z.number().int().min(0), toCh: z.number().int().min(0) }, handler: h.setSelection, annotations: annotations.additive },
-        { name: 'editor_get_line_count', description: 'Get line count of active editor', schema: {}, handler: h.getLineCount, annotations: annotations.read },
+        {
+          name: 'editor_get_content',
+          description: 'Get content of active editor',
+          schema: {},
+          handler: h.getContent,
+          annotations: annotations.read,
+        },
+        {
+          name: 'editor_get_active_file',
+          description: 'Get active file path',
+          schema: {},
+          handler: h.getActivePath,
+          annotations: annotations.read,
+        },
+        {
+          name: 'editor_insert',
+          description: 'Insert text at position',
+          schema: {
+            line: z.number().int().min(0).describe('Zero-based line index'),
+            ch: z.number().int().min(0).describe('Zero-based column index'),
+            text: z
+              .string()
+              .max(5_000_000)
+              .describe('Text to insert at (line, ch)'),
+          },
+          handler: h.insert,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'editor_replace',
+          description: 'Replace text in range',
+          schema: {
+            fromLine: z.number().int().min(0).describe('Start line (inclusive, zero-based)'),
+            fromCh: z.number().int().min(0).describe('Start column (inclusive, zero-based)'),
+            toLine: z.number().int().min(0).describe('End line (exclusive, zero-based)'),
+            toCh: z.number().int().min(0).describe('End column (exclusive, zero-based)'),
+            text: z
+              .string()
+              .max(5_000_000)
+              .describe('Replacement text for the range'),
+          },
+          handler: h.replace,
+          annotations: annotations.destructive,
+        },
+        {
+          name: 'editor_delete',
+          description: 'Delete text in range',
+          schema: {
+            fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
+            fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
+            toLine: z.number().int().min(0).describe('End line (exclusive)'),
+            toCh: z.number().int().min(0).describe('End column (exclusive)'),
+          },
+          handler: h.deleteRange,
+          annotations: annotations.destructive,
+        },
+        {
+          name: 'editor_get_cursor',
+          description: 'Get cursor position',
+          schema: {},
+          handler: h.getCursor,
+          annotations: annotations.read,
+        },
+        {
+          name: 'editor_set_cursor',
+          description: 'Set cursor position',
+          schema: {
+            line: z.number().int().min(0).describe('Zero-based line index'),
+            ch: z.number().int().min(0).describe('Zero-based column index'),
+          },
+          handler: h.setCursor,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'editor_get_selection',
+          description: 'Get current selection',
+          schema: {},
+          handler: h.getSelection,
+          annotations: annotations.read,
+        },
+        {
+          name: 'editor_set_selection',
+          description: 'Set selection range',
+          schema: {
+            fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
+            fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
+            toLine: z.number().int().min(0).describe('End line (exclusive)'),
+            toCh: z.number().int().min(0).describe('End column (exclusive)'),
+          },
+          handler: h.setSelection,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'editor_get_line_count',
+          description: 'Get line count of active editor',
+          schema: {},
+          handler: h.getLineCount,
+          annotations: annotations.read,
+        },
       ];
     },
   };

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -54,11 +54,65 @@ export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule 
     metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater' },
     tools(): ToolDefinition[] {
       return [
-        { name: 'plugin_list', description: 'List installed plugins with status', schema: {}, handler: h.listPlugins, annotations: annotations.readExternal },
-        { name: 'plugin_check', description: 'Check if a plugin is installed and enabled', schema: { pluginId: z.string().min(1) }, handler: h.checkPlugin, annotations: annotations.readExternal },
-        { name: 'plugin_dataview_query', description: 'Execute a Dataview query', schema: { query: z.string().min(1) }, handler: h.dataviewQuery, annotations: annotations.readExternal },
-        { name: 'plugin_templater_execute', description: 'Execute a Templater template', schema: { templatePath: z.string().min(1) }, handler: h.templaterExecute, annotations: annotations.destructiveExternal },
-        { name: 'plugin_execute_command', description: 'Execute an Obsidian command by ID', schema: { commandId: z.string().min(1) }, handler: h.executeCommand, annotations: annotations.destructiveExternal },
+        {
+          name: 'plugin_list',
+          description: 'List installed plugins with status',
+          schema: {},
+          handler: h.listPlugins,
+          annotations: annotations.readExternal,
+        },
+        {
+          name: 'plugin_check',
+          description: 'Check if a plugin is installed and enabled',
+          schema: {
+            pluginId: z
+              .string()
+              .min(1)
+              .max(200)
+              .describe('Community plugin id (e.g. "dataview")'),
+          },
+          handler: h.checkPlugin,
+          annotations: annotations.readExternal,
+        },
+        {
+          name: 'plugin_dataview_query',
+          description: 'Execute a Dataview query',
+          schema: {
+            query: z
+              .string()
+              .min(1)
+              .max(10_000)
+              .describe('Dataview query (DQL or Dataview-js)'),
+          },
+          handler: h.dataviewQuery,
+          annotations: annotations.readExternal,
+        },
+        {
+          name: 'plugin_templater_execute',
+          description: 'Execute a Templater template',
+          schema: {
+            templatePath: z
+              .string()
+              .min(1)
+              .max(4096)
+              .describe('Vault-relative path to the Templater template'),
+          },
+          handler: h.templaterExecute,
+          annotations: annotations.destructiveExternal,
+        },
+        {
+          name: 'plugin_execute_command',
+          description: 'Execute an Obsidian command by ID',
+          schema: {
+            commandId: z
+              .string()
+              .min(1)
+              .max(200)
+              .describe('Obsidian command id (e.g. "app:reload")'),
+          },
+          handler: h.executeCommand,
+          annotations: annotations.destructiveExternal,
+        },
       ];
     },
   };

--- a/src/tools/search/schemas.ts
+++ b/src/tools/search/schemas.ts
@@ -1,18 +1,34 @@
 import { z } from 'zod';
+import { searchQuerySchema } from '../../utils/validation';
 
 export const searchFulltextSchema = {
-  query: z.string().min(1).describe('Search query string'),
+  query: searchQuerySchema.describe('Case-insensitive substring to search for across file contents'),
 };
 
 export const filePathSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('File path relative to vault root'),
 };
 
 export const searchByTagSchema = {
-  tag: z.string().min(1).describe('Tag to search for (e.g., #project)'),
+  tag: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe('Tag to search for (with or without leading #)'),
 };
 
 export const searchByFrontmatterSchema = {
-  key: z.string().min(1).describe('Frontmatter property key'),
-  value: z.string().describe('Frontmatter property value to match'),
+  key: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe('Frontmatter property key to match'),
+  value: z
+    .string()
+    .max(1000)
+    .describe('Frontmatter property value to match exactly (stringified)'),
 };

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -70,9 +70,51 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'templates', name: 'Templates and Content Generation', description: 'List, create from, and expand templates' },
     tools(): ToolDefinition[] {
       return [
-        { name: 'template_list', description: 'List available templates', schema: {}, handler: h.listTemplates, annotations: annotations.read },
-        { name: 'template_create_from', description: 'Create a file from a template with variable substitution', schema: { templatePath: z.string().min(1), destPath: z.string().min(1), variables: z.record(z.string(), z.string()).optional() }, handler: h.createFromTemplate, annotations: annotations.additive },
-        { name: 'template_expand', description: 'Expand template variables in a string', schema: { template: z.string(), variables: z.record(z.string(), z.string()).optional() }, handler: h.expandVariables, annotations: annotations.read },
+        {
+          name: 'template_list',
+          description: 'List available templates',
+          schema: {},
+          handler: h.listTemplates,
+          annotations: annotations.read,
+        },
+        {
+          name: 'template_create_from',
+          description: 'Create a file from a template with variable substitution',
+          schema: {
+            templatePath: z
+              .string()
+              .min(1)
+              .max(4096)
+              .describe('Vault-relative path to the template source file'),
+            destPath: z
+              .string()
+              .min(1)
+              .max(4096)
+              .describe('Vault-relative path for the new file'),
+            variables: z
+              .record(z.string(), z.string())
+              .optional()
+              .describe('Template variables keyed by name (e.g. { title: "Today" })'),
+          },
+          handler: h.createFromTemplate,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'template_expand',
+          description: 'Expand template variables in a string',
+          schema: {
+            template: z
+              .string()
+              .max(100_000)
+              .describe('Template text containing {{variable}} placeholders'),
+            variables: z
+              .record(z.string(), z.string())
+              .optional()
+              .describe('Template variables keyed by name'),
+          },
+          handler: h.expandVariables,
+          annotations: annotations.read,
+        },
       ];
     },
   };

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -40,9 +40,57 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'ui', name: 'UI Interactions', description: 'Show notices, modals, and prompts in Obsidian' },
     tools(): ToolDefinition[] {
       return [
-        { name: 'ui_notice', description: 'Show a notice/notification', schema: { message: z.string(), duration: z.number().optional() }, handler: h.showNotice, annotations: annotations.additive },
-        { name: 'ui_confirm', description: 'Show a confirmation modal', schema: { message: z.string() }, handler: h.showConfirm, annotations: annotations.additive },
-        { name: 'ui_prompt', description: 'Show an input prompt modal', schema: { message: z.string(), defaultValue: z.string().optional() }, handler: h.showPrompt, annotations: annotations.additive },
+        {
+          name: 'ui_notice',
+          description: 'Show a notice/notification',
+          schema: {
+            message: z
+              .string()
+              .min(1)
+              .max(1000)
+              .describe('Notice text to show to the user'),
+            duration: z
+              .number()
+              .int()
+              .min(0)
+              .max(60_000)
+              .optional()
+              .describe('Milliseconds before the notice auto-dismisses (0 = sticky)'),
+          },
+          handler: h.showNotice,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'ui_confirm',
+          description: 'Show a confirmation modal',
+          schema: {
+            message: z
+              .string()
+              .min(1)
+              .max(1000)
+              .describe('Question to present in the confirmation modal'),
+          },
+          handler: h.showConfirm,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'ui_prompt',
+          description: 'Show an input prompt modal',
+          schema: {
+            message: z
+              .string()
+              .min(1)
+              .max(1000)
+              .describe('Prompt label to show in the input modal'),
+            defaultValue: z
+              .string()
+              .max(1000)
+              .optional()
+              .describe('Pre-filled value for the input field'),
+          },
+          handler: h.showPrompt,
+          annotations: annotations.additive,
+        },
       ];
     },
   };

--- a/src/tools/vault/schemas.ts
+++ b/src/tools/vault/schemas.ts
@@ -1,34 +1,61 @@
 import { z } from 'zod';
+import { base64Schema } from '../../utils/validation';
+
+const path = z
+  .string()
+  .min(1)
+  .max(4096)
+  .describe('File path relative to vault root (POSIX-style, no leading slash)');
+
+const folderPath = z
+  .string()
+  .min(1)
+  .max(4096)
+  .describe('Folder path relative to vault root');
 
 export const createFileSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
-  content: z.string().describe('File content'),
+  path,
+  content: z
+    .string()
+    .max(5_000_000)
+    .describe('Text content to write into the new file'),
 };
 
 export const readFileSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
+  path,
 };
 
 export const updateFileSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
-  content: z.string().describe('New file content'),
+  path,
+  content: z
+    .string()
+    .max(5_000_000)
+    .describe('Replacement content for the file'),
 };
 
 export const deleteFileSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
+  path,
 };
 
 export const appendFileSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
-  content: z.string().describe('Content to append'),
+  path,
+  content: z
+    .string()
+    .min(1)
+    .max(5_000_000)
+    .describe('Content to append to the end of the file'),
 };
 
 export const getMetadataSchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
+  path,
 };
 
 export const renameFileSchema = {
-  path: z.string().min(1).describe('Current file path'),
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Current file path to rename'),
   newName: z
     .string()
     .min(1)
@@ -37,46 +64,67 @@ export const renameFileSchema = {
       /^[^/\\\x00]+$/,
       'newName must not contain path separators or null bytes',
     )
-    .describe('New file name (within the same folder)'),
+    .describe('New file name within the same folder (no separators)'),
 };
 
 export const moveFileSchema = {
-  path: z.string().min(1).describe('Current file path'),
-  newPath: z.string().min(1).describe('New file path (different folder)'),
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Current file path'),
+  newPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('New file path (different folder)'),
 };
 
 export const copyFileSchema = {
-  sourcePath: z.string().min(1).describe('Source file path'),
-  destPath: z.string().min(1).describe('Destination file path'),
+  sourcePath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Source file path'),
+  destPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Destination file path'),
 };
 
 export const createFolderSchema = {
-  path: z.string().min(1).describe('Folder path to create'),
+  path: folderPath.describe('Folder path to create'),
 };
 
 export const deleteFolderSchema = {
-  path: z.string().min(1).describe('Folder path to delete'),
-  recursive: z.boolean().default(false).describe('Delete non-empty folders recursively'),
+  path: folderPath.describe('Folder path to delete'),
+  recursive: z
+    .boolean()
+    .default(false)
+    .describe('Delete non-empty folders recursively'),
 };
 
 export const renameFolderSchema = {
-  path: z.string().min(1).describe('Current folder path'),
-  newPath: z.string().min(1).describe('New folder path'),
+  path: folderPath.describe('Current folder path'),
+  newPath: folderPath.describe('New folder path'),
 };
 
 export const listFolderSchema = {
-  path: z.string().min(1).describe('Folder path to list'),
+  path: folderPath.describe('Folder path to list (non-recursive)'),
 };
 
 export const listRecursiveSchema = {
-  path: z.string().min(1).describe('Folder path to list recursively'),
+  path: folderPath.describe('Folder path to list recursively'),
 };
 
 export const readBinarySchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
+  path,
 };
 
 export const writeBinarySchema = {
-  path: z.string().min(1).describe('File path relative to vault root'),
-  data: z.string().min(1).describe('Base64-encoded file content'),
+  path,
+  data: base64Schema
+    .refine((val) => val.length > 0, 'Base64 content must not be empty')
+    .describe('Base64-encoded binary content (no leading data: prefix)'),
 };

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -47,11 +47,57 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'workspace', name: 'Workspace and Navigation', description: 'Manage panes, open files, and navigate the workspace' },
     tools(): ToolDefinition[] {
       return [
-        { name: 'workspace_get_active_leaf', description: 'Get active pane info', schema: {}, handler: h.getActiveLeaf, annotations: annotations.read },
-        { name: 'workspace_open_file', description: 'Open a file in a pane', schema: { path: z.string().min(1), mode: z.string().optional() }, handler: h.openFile, annotations: annotations.additive },
-        { name: 'workspace_list_leaves', description: 'List all open files and panes', schema: {}, handler: h.listLeaves, annotations: annotations.read },
-        { name: 'workspace_set_active_leaf', description: 'Set focus on a leaf by ID', schema: { leafId: z.string().min(1) }, handler: h.setActiveLeaf, annotations: annotations.additive },
-        { name: 'workspace_get_layout', description: 'Get workspace layout summary', schema: {}, handler: h.getLayout, annotations: annotations.read },
+        {
+          name: 'workspace_get_active_leaf',
+          description: 'Get active pane info',
+          schema: {},
+          handler: h.getActiveLeaf,
+          annotations: annotations.read,
+        },
+        {
+          name: 'workspace_open_file',
+          description: 'Open a file in a pane',
+          schema: {
+            path: z
+              .string()
+              .min(1)
+              .max(4096)
+              .describe('Vault-relative file path to open'),
+            mode: z
+              .enum(['source', 'preview', 'live'])
+              .optional()
+              .describe('Optional view mode for the opened leaf'),
+          },
+          handler: h.openFile,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'workspace_list_leaves',
+          description: 'List all open files and panes',
+          schema: {},
+          handler: h.listLeaves,
+          annotations: annotations.read,
+        },
+        {
+          name: 'workspace_set_active_leaf',
+          description: 'Set focus on a leaf by ID',
+          schema: {
+            leafId: z
+              .string()
+              .min(1)
+              .max(200)
+              .describe('Leaf id returned by workspace_list_leaves'),
+          },
+          handler: h.setActiveLeaf,
+          annotations: annotations.additive,
+        },
+        {
+          name: 'workspace_get_layout',
+          description: 'Get workspace layout summary',
+          schema: {},
+          handler: h.getLayout,
+          annotations: annotations.read,
+        },
       ];
     },
   };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,20 +1,33 @@
 import { z } from 'zod';
 
+/**
+ * Shared Zod fragments for vault-relative paths. Paths are non-empty, capped
+ * at 4096 characters, forbid null bytes, and forbid backslashes (which would
+ * bypass the POSIX-normalising `validateVaultPath`).
+ */
 export const filePathSchema = z
   .string()
   .min(1, 'File path must not be empty')
+  .max(4096, 'File path too long')
   .refine((val) => !val.includes('\0'), 'File path must not contain null bytes')
   .refine((val) => !val.includes('\\'), 'File path must not contain backslashes');
 
 export const folderPathSchema = z
   .string()
   .min(1, 'Folder path must not be empty')
+  .max(4096, 'Folder path too long')
   .refine((val) => !val.includes('\0'), 'Folder path must not contain null bytes')
   .refine((val) => !val.includes('\\'), 'Folder path must not contain backslashes');
 
-export const lineNumberSchema = z.number().int().min(0, 'Line number must be non-negative');
+export const lineNumberSchema = z
+  .number()
+  .int()
+  .min(0, 'Line number must be non-negative');
 
-export const columnNumberSchema = z.number().int().min(0, 'Column number must be non-negative');
+export const columnNumberSchema = z
+  .number()
+  .int()
+  .min(0, 'Column number must be non-negative');
 
 export const positionSchema = z.object({
   line: lineNumberSchema,
@@ -39,3 +52,16 @@ export const base64Schema = z
     (val) => /^[A-Za-z0-9+/]*={0,2}$/.test(val),
     'Invalid base64 string',
   );
+
+/** Free-text query bounded to something a human could plausibly enter. */
+export const searchQuerySchema = z
+  .string()
+  .min(1, 'Query must not be empty')
+  .max(500, 'Query too long');
+
+/** Obsidian command id / plugin id — letters, digits, hyphens, colons, dots. */
+export const identifierSchema = z
+  .string()
+  .min(1, 'Identifier must not be empty')
+  .max(200, 'Identifier too long');
+


### PR DESCRIPTION
## Summary

- Every tool field now has an explicit `.describe()` and bounded `.min()/.max()` values. Paths cap at 4096, queries at 500, identifiers at 200. Editor coordinates remain `.int().min(0)`.
- `vault_write_binary.data` uses `base64Schema` from `src/utils/validation.ts` and adds a non-empty refinement at the use site (keeping `base64Schema` itself permissive for compatibility with existing tests).
- `src/utils/validation.ts` gets matching bounds plus two new fragments — `searchQuerySchema` and `identifierSchema` — that callers opt into.
- No `z.string()` without bounds remains in tool schemas.

## On `.strict()`

The SDK's `registerTool()` consumes the raw shape, not a full `z.object`, so `.strict()` can't live on the exports directly. Strictness moves to the dispatcher in #174 where `schema.parse()` will reject unknown fields. PR #174 can wrap every shape with `z.object(shape).strict()` in one place.

## Test plan

- [x] `npm test` — 436 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — snapshot stable

Closes #175