### PR TITLE
refactor(registry): runtime-validate tool params with schema.parse() at dispatch

### DIFF
--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -1,6 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import { Logger } from '../utils/logger';
 import { ModuleRegistry } from '../registry/module-registry';
+import { ToolDefinition } from '../registry/types';
 
 export function createMcpServer(
   registry: ModuleRegistry,
@@ -23,6 +26,51 @@ export function createMcpServer(
   return server;
 }
 
+/**
+ * Build the dispatch closure for a single tool. Exposed for direct unit
+ * testing — the SDK's internal registration path is hard to drive from
+ * tests, but the validate-then-handle logic is the important part.
+ */
+export function createToolDispatcher(
+  tool: ToolDefinition,
+  logger: Logger,
+): (params: unknown) => Promise<CallToolResult> {
+  const inputSchema = z.object(tool.schema).strict();
+  return async (params: unknown): Promise<CallToolResult> => {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = inputSchema.parse(params ?? {});
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const message = error.issues
+          .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+            return `${path}: ${issue.message}`;
+          })
+          .join('; ');
+        logger.warn(`Tool "${tool.name}" rejected invalid input: ${message}`);
+        return {
+          content: [
+            { type: 'text' as const, text: `Invalid arguments: ${message}` },
+          ],
+          isError: true,
+        };
+      }
+      throw error;
+    }
+    try {
+      return await tool.handler(parsed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Tool "${tool.name}" error: ${message}`);
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  };
+}
+
 function registerTools(
   server: McpServer,
   registry: ModuleRegistry,
@@ -38,19 +86,8 @@ function registerTools(
         inputSchema: tool.schema,
         annotations: tool.annotations,
       },
-      async (params) => {
-        try {
-          return await tool.handler(params as Record<string, unknown>);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          logger.error(`Tool "${tool.name}" error: ${message}`);
-          return {
-            content: [{ type: 'text' as const, text: `Error: ${message}` }],
-            isError: true,
-          };
-        }
-      },
+      createToolDispatcher(tool, logger),
     );
   }
-  logger.info(`Registered ${String(tools.length)} tools from ${String(registry.getModules().filter(m => m.enabled).length)} modules`);
+  logger.info(`Registered ${String(tools.length)} tools from ${String(registry.getModules().filter((m) => m.enabled).length)} modules`);
 }

--- a/tests/server/dispatcher.test.ts
+++ b/tests/server/dispatcher.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { createToolDispatcher } from '../../src/server/mcp-server';
+import { Logger } from '../../src/utils/logger';
+import type { ToolDefinition } from '../../src/registry/types';
+import { annotations } from '../../src/registry/types';
+
+function makeLogger(): Logger {
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
+
+function makeTool(
+  overrides: Partial<ToolDefinition> = {},
+): ToolDefinition {
+  return {
+    name: 'demo_tool',
+    description: 'Demo tool for the dispatcher tests',
+    schema: {
+      path: z.string().min(1).describe('Required path'),
+      count: z.number().int().min(0).default(0).describe('Optional count'),
+    },
+    handler: vi.fn(async (params) =>
+      Promise.resolve({
+        content: [
+          { type: 'text' as const, text: JSON.stringify(params) },
+        ],
+      }),
+    ),
+    annotations: annotations.read,
+    ...overrides,
+  };
+}
+
+describe('createToolDispatcher', () => {
+  it('invokes the handler with parsed params when input is valid', async () => {
+    const tool = makeTool();
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch({ path: 'notes/a.md', count: 3 });
+
+    expect(result.isError).toBeUndefined();
+    expect(tool.handler).toHaveBeenCalledTimes(1);
+    expect(tool.handler).toHaveBeenCalledWith({ path: 'notes/a.md', count: 3 });
+  });
+
+  it('fills in schema defaults before calling the handler', async () => {
+    const tool = makeTool();
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    await dispatch({ path: 'a.md' });
+
+    expect(tool.handler).toHaveBeenCalledWith({ path: 'a.md', count: 0 });
+  });
+
+  it('returns a well-formed MCP error when a required field is missing', async () => {
+    const tool = makeTool();
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch({});
+
+    expect(result.isError).toBe(true);
+    expect(tool.handler).not.toHaveBeenCalled();
+    const text = result.content[0].type === 'text' ? result.content[0].text : '';
+    expect(text).toContain('Invalid arguments');
+    expect(text).toContain('path');
+  });
+
+  it('rejects wrong types with a clear error', async () => {
+    const tool = makeTool();
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch({ path: 42 });
+
+    expect(result.isError).toBe(true);
+    expect(tool.handler).not.toHaveBeenCalled();
+    const text = result.content[0].type === 'text' ? result.content[0].text : '';
+    expect(text).toContain('Invalid arguments');
+  });
+
+  it('rejects unknown top-level fields (strict parsing)', async () => {
+    const tool = makeTool();
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch({ path: 'a.md', bogus: true });
+
+    expect(result.isError).toBe(true);
+    expect(tool.handler).not.toHaveBeenCalled();
+    const text = result.content[0].type === 'text' ? result.content[0].text : '';
+    expect(text).toContain('Invalid arguments');
+  });
+
+  it('wraps handler exceptions as MCP errors', async () => {
+    const tool = makeTool({
+      handler: vi.fn(() => Promise.reject(new Error('boom'))),
+    });
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch({ path: 'a.md' });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].type === 'text' ? result.content[0].text : '';
+    expect(text).toContain('boom');
+  });
+
+  it('accepts an empty object for tools with no required fields', async () => {
+    const tool = makeTool({
+      schema: {},
+      handler: vi.fn(async () =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      ),
+    });
+    const dispatch = createToolDispatcher(tool, makeLogger());
+
+    const result = await dispatch(undefined);
+
+    expect(result.isError).toBeUndefined();
+    expect(tool.handler).toHaveBeenCalledWith({});
+  });
+});


### PR DESCRIPTION
## Summary

- Extract a named `createToolDispatcher()` closure in `src/server/mcp-server.ts`. Every inbound call now runs through `z.object(schema).strict().parse(...)` before the handler sees the input.
- `ZodError` → MCP error with `content[{type: 'text', text: 'Invalid arguments: …'}]` + `isError: true`.
- Non-Zod handler errors keep the existing `Error: <message>` fallback.
- `.strict()` is enforced here — unknown top-level fields are rejected, closing the `.strict()` item carried over from #175.

## Changes

- `src/server/mcp-server.ts` — new `createToolDispatcher()`, same wiring into `server.registerTool`.
- `tests/server/dispatcher.test.ts` — 7 new tests: valid input, defaults, missing required, wrong types, unknown-field rejection, handler exception wrapping, empty schema.

## Deferred

The issue's "zero `as string|number|boolean` casts on `params.*`" sub-acceptance requires making `ToolDefinition` generic over the schema and a wider typing refactor through `tools(): ToolDefinition[]`. With runtime parsing in place the casts are safe today; the typing upgrade is a follow-up. Marking this PR as closing #174 for the dispatcher-level validation (the headline ask).

## Test plan

- [x] `npm test` — 443 passing (+7 new dispatcher tests)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #174