### PR TITLE
refactor(tools): centralise error handling with a shared `handleError()` helper

### DIFF
--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -2,11 +2,12 @@ import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
+import { handleToolError } from '../shared/errors';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
-function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
 /**
  * Require a value to be a non-negative safe integer. Defensive belt-and-braces

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -2,11 +2,12 @@ import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
+import { handleToolError } from '../shared/errors';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
-function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
   return {

--- a/src/tools/search/handlers.ts
+++ b/src/tools/search/handlers.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { truncateText } from '../shared/truncate';
+import { handleToolError } from '../shared/errors';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -12,10 +13,6 @@ function textResult(text: string): CallToolResult {
 function truncatedResult(text: string, hint?: string): CallToolResult {
   const result = truncateText(text, hint ? { hint } : {});
   return { content: [{ type: 'text', text: result.text }] };
-}
-
-function errorResult(message: string): CallToolResult {
-  return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
 }
 
 export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
@@ -31,7 +28,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
           'Narrow the query or add filters to reduce match count.',
         );
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -41,7 +38,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const frontmatter = adapter.getFrontmatter(path);
         return Promise.resolve(textResult(JSON.stringify(frontmatter ?? {})));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -50,7 +47,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const allTags = adapter.getAllTags();
         return Promise.resolve(textResult(JSON.stringify(allTags)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -60,7 +57,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const headings = adapter.getHeadings(path);
         return Promise.resolve(textResult(JSON.stringify(headings)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -70,7 +67,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const links = adapter.getLinks(path);
         return Promise.resolve(textResult(JSON.stringify(links)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -80,7 +77,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const embeds = adapter.getEmbeds(path);
         return Promise.resolve(textResult(JSON.stringify(embeds)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -90,7 +87,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const backlinks = adapter.getBacklinks(path);
         return Promise.resolve(textResult(JSON.stringify(backlinks)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -99,7 +96,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const links = adapter.getResolvedLinks();
         return Promise.resolve(textResult(JSON.stringify(links)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -108,7 +105,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const links = adapter.getUnresolvedLinks();
         return Promise.resolve(textResult(JSON.stringify(links)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -128,7 +125,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
           return textResult(JSON.stringify(blockRefs));
         });
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -140,7 +137,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const files = allTags[normalizedTag] ?? [];
         return Promise.resolve(textResult(JSON.stringify(files)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -158,7 +155,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         }
         return Promise.resolve(textResult(JSON.stringify(matching)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
   };

--- a/src/tools/shared/errors.ts
+++ b/src/tools/shared/errors.ts
@@ -1,0 +1,77 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { PathTraversalError } from '../../utils/path-guard';
+
+/**
+ * Typed error classes the adapter / handlers can throw to signal a particular
+ * failure category. The shared `handleToolError()` helper maps each class to
+ * a consistent MCP error response shape.
+ */
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermissionError';
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}
+
+/**
+ * Map any caught value to a well-formed CallToolResult with `isError: true`.
+ * Callers can use this as a single `catch` target so they don't need to
+ * maintain their own per-module `errorResult()` helper.
+ */
+export function handleToolError(error: unknown): CallToolResult {
+  if (error instanceof z.ZodError) {
+    const details = error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+        return `${path}: ${issue.message}`;
+      })
+      .join('; ');
+    return errorFrom(`Invalid arguments: ${details}`);
+  }
+  if (error instanceof PathTraversalError) {
+    return errorFrom(error.message);
+  }
+  if (error instanceof NotFoundError) {
+    return errorFrom(error.message);
+  }
+  if (error instanceof PermissionError) {
+    return errorFrom(`Permission denied: ${error.message}`);
+  }
+  if (error instanceof ValidationError) {
+    return errorFrom(error.message);
+  }
+  if (error instanceof TimeoutError) {
+    return errorFrom(`Operation timed out: ${error.message}`);
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return errorFrom(message);
+}
+
+function errorFrom(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: `Error: ${message}` }],
+    isError: true,
+  };
+}

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -3,11 +3,12 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
+import { handleToolError } from '../shared/errors';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
-function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
 function expandVariables(template: string, variables: Record<string, string>): string {
   let result = template;

--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { truncateText } from '../shared/truncate';
+import { handleToolError } from '../shared/errors';
 import { BINARY_BYTE_LIMIT } from '../../constants';
 
 export class WriteMutex {
@@ -37,7 +38,7 @@ function truncatedResult(text: string, hint?: string): CallToolResult {
 }
 
 function errorResult(message: string): CallToolResult {
-  return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+  return handleToolError(new Error(message));
 }
 
 const RENAME_TARGET_PATTERN = /^[^/\\\x00]+$/;
@@ -85,7 +86,7 @@ export function createHandlers(
           return textResult(`Created file: ${path}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -98,7 +99,7 @@ export function createHandlers(
           'Read a specific range via editor_* tools or ask for a summary.',
         );
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -111,7 +112,7 @@ export function createHandlers(
           return textResult(`Updated file: ${path}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -123,7 +124,7 @@ export function createHandlers(
           return textResult(`Deleted file: ${path}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -137,7 +138,7 @@ export function createHandlers(
           return textResult(`Appended to file: ${path}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -157,7 +158,7 @@ export function createHandlers(
           }),
         );
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -182,7 +183,7 @@ export function createHandlers(
           return textResult(`Renamed file: ${path} → ${newPath}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -195,7 +196,7 @@ export function createHandlers(
           return textResult(`Moved file: ${path} → ${newPath}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -206,7 +207,7 @@ export function createHandlers(
         await adapter.copyFile(sourcePath, destPath);
         return textResult(`Copied file: ${sourcePath} → ${destPath}`);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -216,7 +217,7 @@ export function createHandlers(
         await adapter.createFolder(path);
         return textResult(`Created folder: ${path}`);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -227,7 +228,7 @@ export function createHandlers(
         await adapter.deleteFolder(path, recursive);
         return textResult(`Deleted folder: ${path}`);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -238,7 +239,7 @@ export function createHandlers(
         await adapter.renameFile(path, newPath);
         return textResult(`Renamed folder: ${path} → ${newPath}`);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -248,7 +249,7 @@ export function createHandlers(
         const result = adapter.list(path);
         return Promise.resolve(textResult(JSON.stringify(result)));
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -263,7 +264,7 @@ export function createHandlers(
           ),
         );
       } catch (error) {
-        return Promise.resolve(errorResult(error instanceof Error ? error.message : String(error)));
+        return Promise.resolve(handleToolError(error));
       }
     },
 
@@ -279,7 +280,7 @@ export function createHandlers(
         const base64 = Buffer.from(data).toString('base64');
         return textResult(base64);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
 
@@ -293,7 +294,7 @@ export function createHandlers(
           return textResult(`Wrote binary file: ${path}`);
         });
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return handleToolError(error);
       }
     },
   };

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -3,11 +3,12 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
+import { handleToolError } from '../shared/errors';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
-function err(m: string): CallToolResult { return { content: [{ type: 'text', text: `Error: ${m}` }], isError: true }; }
+function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
   const vaultPath = adapter.getVaultPath();

--- a/tests/tools/shared/errors.test.ts
+++ b/tests/tools/shared/errors.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  handleToolError,
+  NotFoundError,
+  PermissionError,
+  ValidationError,
+  TimeoutError,
+} from '../../../src/tools/shared/errors';
+import { PathTraversalError } from '../../../src/utils/path-guard';
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+  const item = result.content[0];
+  return item.type === 'text' && item.text !== undefined ? item.text : '';
+}
+
+describe('handleToolError', () => {
+  it('maps ZodError to Invalid arguments with path/message pairs', () => {
+    const schema = z.object({ path: z.string().min(1) });
+    let zodErr: z.ZodError | null = null;
+    try {
+      schema.parse({ path: '' });
+    } catch (e) {
+      if (e instanceof z.ZodError) zodErr = e;
+    }
+    expect(zodErr).not.toBeNull();
+
+    const result = handleToolError(zodErr);
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Invalid arguments');
+    expect(getText(result)).toContain('path');
+  });
+
+  it('maps PathTraversalError to the same message with Error: prefix', () => {
+    const result = handleToolError(new PathTraversalError('Outside vault'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: Outside vault');
+  });
+
+  it('maps NotFoundError to the bare message', () => {
+    const result = handleToolError(new NotFoundError('File not found: a.md'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: File not found: a.md');
+  });
+
+  it('prefixes PermissionError with "Permission denied:"', () => {
+    const result = handleToolError(new PermissionError('read /etc/passwd'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: Permission denied: read /etc/passwd');
+  });
+
+  it('passes ValidationError messages straight through', () => {
+    const result = handleToolError(new ValidationError('bad shape'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: bad shape');
+  });
+
+  it('prefixes TimeoutError with "Operation timed out:"', () => {
+    const result = handleToolError(new TimeoutError('search_fulltext'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: Operation timed out: search_fulltext');
+  });
+
+  it('falls through to the generic Error branch for plain Errors', () => {
+    const result = handleToolError(new Error('plain boom'));
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: plain boom');
+  });
+
+  it('stringifies non-Error values', () => {
+    const result = handleToolError('oops');
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toBe('Error: oops');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/tools/shared/errors.ts` with `handleToolError()` and four typed error classes (`NotFoundError`, `PermissionError`, `ValidationError`, `TimeoutError`).
- `handleToolError()` maps each class — plus `ZodError` and `PathTraversalError` — to a consistent MCP error response.
- Every per-module `err` / `errorResult` helper now delegates to `handleToolError`, and the ~30 catch blocks across vault, search, editor, workspace, templates, and plugin-interop call `handleToolError(error)` directly. No more duplicated one-liners.

## Error taxonomy

| Input                           | Output text                                   |
|---------------------------------|-----------------------------------------------|
| `ZodError`                      | `Error: Invalid arguments: <path>: <message>` |
| `PathTraversalError`            | `Error: <original message>`                    |
| `NotFoundError`                 | `Error: <original message>`                    |
| `PermissionError`               | `Error: Permission denied: <message>`          |
| `ValidationError`               | `Error: <original message>`                    |
| `TimeoutError`                  | `Error: Operation timed out: <message>`        |
| any other `Error` / non-Error   | `Error: <message or String(v)>`                |

## Changes

- `src/tools/shared/errors.ts` — new helper + typed error classes.
- `src/tools/{vault,search,editor,workspace,templates,plugin-interop}/…` — delegate `err` / `errorResult` to `handleToolError`, or call it directly in catch blocks.
- `tests/tools/shared/errors.test.ts` — 8 tests covering every mapping branch.

## Test plan

- [x] `npm test` — 444 passing (+8 new)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #180