### PR TITLE
docs(tools): expand tool descriptions to the mcp-builder template

### DIFF
--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -3,6 +3,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -173,21 +174,42 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'editor_get_content',
-          description: 'Get content of active editor',
+          description: describeTool({
+            summary: 'Get the full text content of the currently active editor.',
+            returns: 'Plain text: the editor\'s current content.',
+            errors: ['"No active editor" if no markdown view is focused.'],
+          }),
           schema: {},
           handler: h.getContent,
           annotations: annotations.read,
         },
         {
           name: 'editor_get_active_file',
-          description: 'Get active file path',
+          description: describeTool({
+            summary: 'Get the vault-relative path of the currently active file.',
+            returns: 'Plain text: the path, e.g. "notes/today.md".',
+            errors: ['"No active file" if no file is open.'],
+          }),
           schema: {},
           handler: h.getActivePath,
           annotations: annotations.read,
         },
         {
           name: 'editor_insert',
-          description: 'Insert text at position',
+          description: describeTool({
+            summary: 'Insert text at a (line, ch) position in the active editor.',
+            args: [
+              'line (integer, ≥0): Zero-based line index.',
+              'ch (integer, ≥0): Zero-based column index within the line.',
+              'text (string): Text to insert (may contain newlines).',
+            ],
+            returns: 'Plain text "Text inserted" on success.',
+            examples: ['Use when: inserting a heading at the top of the file (line 0, ch 0).'],
+            errors: [
+              '"No active editor" if no markdown view is focused.',
+              '"Position is out of range" if (line, ch) is outside the document.',
+            ],
+          }),
           schema: {
             line: z.number().int().min(0).describe('Zero-based line index'),
             ch: z.number().int().min(0).describe('Zero-based column index'),
@@ -201,7 +223,20 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'editor_replace',
-          description: 'Replace text in range',
+          description: describeTool({
+            summary: 'Replace text in a (fromLine, fromCh)→(toLine, toCh) range.',
+            args: [
+              'fromLine / fromCh (integers, ≥0): Start of range (inclusive).',
+              'toLine / toCh (integers, ≥0): End of range (exclusive).',
+              'text (string): Replacement text.',
+            ],
+            returns: 'Plain text "Text replaced" on success.',
+            examples: ['Use when: replacing a paragraph after locating it with search_fulltext.'],
+            errors: [
+              '"No active editor" if no markdown view is focused.',
+              '"Position is out of range" if either endpoint is outside the document.',
+            ],
+          }),
           schema: {
             fromLine: z.number().int().min(0).describe('Start line (inclusive, zero-based)'),
             fromCh: z.number().int().min(0).describe('Start column (inclusive, zero-based)'),
@@ -217,7 +252,18 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'editor_delete',
-          description: 'Delete text in range',
+          description: describeTool({
+            summary: 'Delete text in a (fromLine, fromCh)→(toLine, toCh) range.',
+            args: [
+              'fromLine / fromCh (integers, ≥0): Start of range (inclusive).',
+              'toLine / toCh (integers, ≥0): End of range (exclusive).',
+            ],
+            returns: 'Plain text "Text deleted" on success.',
+            errors: [
+              '"No active editor" if no markdown view is focused.',
+              '"Position is out of range" if either endpoint is outside the document.',
+            ],
+          }),
           schema: {
             fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
             fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
@@ -229,14 +275,29 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'editor_get_cursor',
-          description: 'Get cursor position',
+          description: describeTool({
+            summary: 'Get the current cursor position in the active editor.',
+            returns: 'JSON: { line, ch } (zero-based).',
+            errors: ['"No active editor" if no markdown view is focused.'],
+          }),
           schema: {},
           handler: h.getCursor,
           annotations: annotations.read,
         },
         {
           name: 'editor_set_cursor',
-          description: 'Set cursor position',
+          description: describeTool({
+            summary: 'Move the cursor to a (line, ch) position in the active editor.',
+            args: [
+              'line (integer, ≥0): Zero-based line index.',
+              'ch (integer, ≥0): Zero-based column index.',
+            ],
+            returns: 'Plain text "Cursor set" on success.',
+            errors: [
+              '"No active editor" if no markdown view is focused.',
+              '"Position is out of range" if (line, ch) is outside the document.',
+            ],
+          }),
           schema: {
             line: z.number().int().min(0).describe('Zero-based line index'),
             ch: z.number().int().min(0).describe('Zero-based column index'),
@@ -246,14 +307,29 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'editor_get_selection',
-          description: 'Get current selection',
+          description: describeTool({
+            summary: 'Get the current text selection in the active editor.',
+            returns: 'JSON: { from: {line, ch}, to: {line, ch}, text }.',
+            errors: ['"No active editor or selection" if nothing is selected.'],
+          }),
           schema: {},
           handler: h.getSelection,
           annotations: annotations.read,
         },
         {
           name: 'editor_set_selection',
-          description: 'Set selection range',
+          description: describeTool({
+            summary: 'Select a (fromLine, fromCh)→(toLine, toCh) range in the active editor.',
+            args: [
+              'fromLine / fromCh (integers, ≥0): Start of selection (inclusive).',
+              'toLine / toCh (integers, ≥0): End of selection (exclusive).',
+            ],
+            returns: 'Plain text "Selection set" on success.',
+            errors: [
+              '"No active editor" if no markdown view is focused.',
+              '"Position is out of range" if either endpoint is outside the document.',
+            ],
+          }),
           schema: {
             fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
             fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
@@ -265,7 +341,11 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'editor_get_line_count',
-          description: 'Get line count of active editor',
+          description: describeTool({
+            summary: 'Get the number of lines in the active editor.',
+            returns: 'Plain text: the line count as a decimal integer.',
+            errors: ['"No active editor" if no markdown view is focused.'],
+          }),
           schema: {},
           handler: h.getLineCount,
           annotations: annotations.read,

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -50,7 +51,11 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'get_date',
-          description: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
+          description: describeTool({
+            summary: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
+            returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',
+            examples: ['Use when: stamping a daily note with the current local time.'],
+          }),
           schema: {},
           handler: h.getDate,
           annotations: annotations.read,

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -3,6 +3,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -57,14 +58,21 @@ export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule 
       return [
         {
           name: 'plugin_list',
-          description: 'List installed plugins with status',
+          description: describeTool({
+            summary: 'List every installed community plugin with its enabled flag.',
+            returns: 'JSON: [{ id, name, enabled, ... }].',
+          }),
           schema: {},
           handler: h.listPlugins,
           annotations: annotations.readExternal,
         },
         {
           name: 'plugin_check',
-          description: 'Check if a plugin is installed and enabled',
+          description: describeTool({
+            summary: 'Check whether a plugin is installed and enabled.',
+            args: ['pluginId (string, 1..200): Plugin id, e.g. "dataview".'],
+            returns: 'JSON: { pluginId, installed, enabled }.',
+          }),
           schema: {
             pluginId: z
               .string()
@@ -77,7 +85,12 @@ export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule 
         },
         {
           name: 'plugin_dataview_query',
-          description: 'Execute a Dataview query',
+          description: describeTool({
+            summary: 'Execute a Dataview (DQL / dataview-js) query.',
+            args: ['query (string, 1..10000): Dataview query text.'],
+            returns: 'JSON envelope with the query echoed; full execution requires the Dataview plugin at runtime.',
+            errors: ['"Dataview plugin is not installed or enabled" if the plugin is missing.'],
+          }),
           schema: {
             query: z
               .string()
@@ -90,7 +103,12 @@ export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule 
         },
         {
           name: 'plugin_templater_execute',
-          description: 'Execute a Templater template',
+          description: describeTool({
+            summary: 'Execute a Templater template file.',
+            args: ['templatePath (string): Vault-relative path to the Templater template.'],
+            returns: 'JSON envelope noting the template path; full execution requires the Templater plugin.',
+            errors: ['"Templater plugin is not installed or enabled" if the plugin is missing.'],
+          }),
           schema: {
             templatePath: z
               .string()
@@ -103,7 +121,13 @@ export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule 
         },
         {
           name: 'plugin_execute_command',
-          description: 'Execute an Obsidian command by ID',
+          description: describeTool({
+            summary: 'Execute any Obsidian command by its id.',
+            args: ['commandId (string, 1..200): Command id, e.g. "app:reload".'],
+            returns: 'Plain text "Executed command: <id>" or an error if the command is unknown.',
+            examples: ['Use when: triggering "editor:save-file" programmatically.'],
+            errors: ['"Command not found" if the id is not registered.'],
+          }),
           schema: {
             commandId: z
               .string()

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -1,6 +1,7 @@
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createSearchHandlers } from './handlers';
+import { describeTool } from '../shared/describe';
 import {
   searchFulltextSchema,
   filePathSchema,
@@ -22,84 +23,142 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'search_fulltext',
-          description: 'Full-text search across vault contents',
+          description: describeTool({
+            summary: 'Case-insensitive substring search across all vault file contents.',
+            args: ['query (string, 1..500): Substring to look for.'],
+            returns: 'JSON: [{ path, matches: string[] }]. Truncated at 25 000 characters.',
+            examples: ['Use when: "find everything mentioning Obsidian".'],
+            errors: ['"Query must not be empty" on empty input.'],
+          }),
           schema: searchFulltextSchema,
           handler: handlers.searchFulltext,
           annotations: annotations.read,
         },
         {
           name: 'search_frontmatter',
-          description: 'Query frontmatter properties for a given file',
+          description: describeTool({
+            summary: 'Get the parsed YAML frontmatter block for a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: the frontmatter object, or {} when absent.',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchFrontmatter,
           annotations: annotations.read,
         },
         {
           name: 'search_tags',
-          description: 'Query all tags in the vault with file associations',
+          description: describeTool({
+            summary: 'List every tag used anywhere in the vault with the files that use it.',
+            returns: 'JSON: Record<tag, string[]>. Each key is the tag including leading #.',
+          }),
           schema: {},
           handler: handlers.searchTags,
           annotations: annotations.read,
         },
         {
           name: 'search_headings',
-          description: 'Query headings for a given file',
+          description: describeTool({
+            summary: 'List headings (with levels) for a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ heading, level }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchHeadings,
           annotations: annotations.read,
         },
         {
           name: 'search_outgoing_links',
-          description: 'Query all outgoing links for a given file',
+          description: describeTool({
+            summary: 'List outgoing links from a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ link, displayText? }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchOutgoingLinks,
           annotations: annotations.read,
         },
         {
           name: 'search_embeds',
-          description: 'Query all embeds for a given file',
+          description: describeTool({
+            summary: 'List embedded resources (![[...]]) referenced by a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ link, displayText? }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchEmbeds,
           annotations: annotations.read,
         },
         {
           name: 'search_backlinks',
-          description: 'Get all backlinks for a given file',
+          description: describeTool({
+            summary: 'List files that link TO a given file (reverse links).',
+            args: ['path (string): Target file path.'],
+            returns: 'JSON: string[] of paths that reference the target.',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchBacklinks,
           annotations: annotations.read,
         },
         {
           name: 'search_resolved_links',
-          description: 'Get resolved links across the vault',
+          description: describeTool({
+            summary: 'Get the vault-wide map of resolved links (targets that exist).',
+            returns: 'JSON: Record<source, Record<target, count>>.',
+          }),
           schema: {},
           handler: handlers.searchResolvedLinks,
           annotations: annotations.read,
         },
         {
           name: 'search_unresolved_links',
-          description: 'Get unresolved links across the vault',
+          description: describeTool({
+            summary: 'Get the vault-wide map of unresolved links (targets that do not exist).',
+            returns: 'JSON: Record<source, Record<target, count>>.',
+            examples: ['Use when: hunting for broken [[wikilinks]] to clean up.'],
+          }),
           schema: {},
           handler: handlers.searchUnresolvedLinks,
           annotations: annotations.read,
         },
         {
           name: 'search_block_references',
-          description: 'Query block references for a given file',
+          description: describeTool({
+            summary: 'List block references (^block-id) defined in a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ id, line }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: filePathSchema,
           handler: handlers.searchBlockReferences,
           annotations: annotations.read,
         },
         {
           name: 'search_by_tag',
-          description: 'Search files by tag',
+          description: describeTool({
+            summary: 'Find files tagged with a given tag (with or without leading #).',
+            args: ['tag (string, 1..200): Tag to search for, e.g. "project" or "#project".'],
+            returns: 'JSON: string[] of vault-relative file paths.',
+          }),
           schema: searchByTagSchema,
           handler: handlers.searchByTag,
           annotations: annotations.read,
         },
         {
           name: 'search_by_frontmatter',
-          description: 'Search files by frontmatter property value',
+          description: describeTool({
+            summary: 'Find files whose YAML frontmatter has a key with a given value.',
+            args: [
+              'key (string, 1..200): Frontmatter property name.',
+              'value (string, ≤1000): Expected value (compared as stringified).',
+            ],
+            returns: 'JSON: string[] of matching file paths.',
+            examples: ['Use when: "find all notes where status == done".'],
+          }),
           schema: searchByFrontmatterSchema,
           handler: handlers.searchByFrontmatter,
           annotations: annotations.read,

--- a/src/tools/shared/describe.ts
+++ b/src/tools/shared/describe.ts
@@ -1,0 +1,56 @@
+/**
+ * Build a consistent tool description in the mcp-builder format:
+ *
+ *   <summary>
+ *
+ *   Args:
+ *     - name (type): description.
+ *
+ *   Returns:
+ *     <return shape>
+ *
+ *   Examples:
+ *     - Use when: ...
+ *     - Don't use when: ...
+ *
+ *   Errors:
+ *     - "msg" when ...
+ *
+ * All sections are optional — pass only what's relevant. A model reading
+ * these descriptions picks better tools and makes fewer invalid calls.
+ */
+export interface ToolDoc {
+  summary: string;
+  args?: string[];
+  returns?: string;
+  examples?: string[];
+  errors?: string[];
+}
+
+export function describeTool(doc: ToolDoc): string {
+  const lines: string[] = [doc.summary.trim()];
+
+  if (doc.args && doc.args.length > 0) {
+    lines.push('', 'Args:');
+    for (const arg of doc.args) lines.push(`  - ${arg}`);
+  }
+
+  if (doc.returns) {
+    lines.push('', 'Returns:');
+    for (const line of doc.returns.trim().split('\n')) {
+      lines.push(`  ${line}`);
+    }
+  }
+
+  if (doc.examples && doc.examples.length > 0) {
+    lines.push('', 'Examples:');
+    for (const ex of doc.examples) lines.push(`  - ${ex}`);
+  }
+
+  if (doc.errors && doc.errors.length > 0) {
+    lines.push('', 'Errors:');
+    for (const e of doc.errors) lines.push(`  - ${e}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -4,6 +4,7 @@ import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { handleToolError } from '../shared/errors';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -73,14 +74,29 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'template_list',
-          description: 'List available templates',
+          description: describeTool({
+            summary: 'List files in the vault\'s "templates" folder.',
+            returns: 'JSON: string[] of template file paths. Empty array if the folder is missing.',
+          }),
           schema: {},
           handler: h.listTemplates,
           annotations: annotations.read,
         },
         {
           name: 'template_create_from',
-          description: 'Create a file from a template with variable substitution',
+          description: describeTool({
+            summary: 'Create a file by expanding {{variable}} placeholders in a template.',
+            args: [
+              'templatePath (string): Template source file.',
+              'destPath (string): New file path.',
+              'variables (Record<string,string>, optional): Variable map. date/time/title are built in.',
+            ],
+            returns: 'Plain text "Created <dest> from template <src>".',
+            errors: [
+              '"File not found" if templatePath is missing.',
+              '"File already exists" if destPath is taken.',
+            ],
+          }),
           schema: {
             templatePath: z
               .string()
@@ -102,7 +118,14 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'template_expand',
-          description: 'Expand template variables in a string',
+          description: describeTool({
+            summary: 'Expand {{variable}} placeholders in a supplied string without writing any file.',
+            args: [
+              'template (string): Template body containing {{variable}} tokens.',
+              'variables (Record<string,string>, optional): Variable map.',
+            ],
+            returns: 'Plain text: the expanded string.',
+          }),
           schema: {
             template: z
               .string()

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -42,7 +43,14 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'ui_notice',
-          description: 'Show a notice/notification',
+          description: describeTool({
+            summary: 'Show a transient notice/toast in Obsidian.',
+            args: [
+              'message (string, 1..1000): Notice text.',
+              'duration (integer ms, 0..60000, optional): Auto-dismiss delay (0 = sticky).',
+            ],
+            returns: 'Plain text "Notice shown".',
+          }),
           schema: {
             message: z
               .string()
@@ -62,7 +70,11 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'ui_confirm',
-          description: 'Show a confirmation modal',
+          description: describeTool({
+            summary: 'Stub for a confirmation modal — user interaction cannot be captured via MCP.',
+            args: ['message (string, 1..1000): Question text.'],
+            returns: 'JSON envelope noting that confirmation modals need UI interaction.',
+          }),
           schema: {
             message: z
               .string()
@@ -75,7 +87,14 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'ui_prompt',
-          description: 'Show an input prompt modal',
+          description: describeTool({
+            summary: 'Stub for an input prompt modal — user input cannot be captured via MCP.',
+            args: [
+              'message (string, 1..1000): Prompt label.',
+              'defaultValue (string, ≤1000, optional): Pre-filled value.',
+            ],
+            returns: 'JSON envelope noting that prompts need UI interaction.',
+          }),
           schema: {
             message: z
               .string()

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -1,6 +1,7 @@
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createHandlers, WriteMutex } from './handlers';
+import { describeTool } from '../shared/describe';
 import {
   createFileSchema,
   readFileSchema,
@@ -35,112 +36,259 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'vault_create',
-          description: 'Create a new file with specified path and content',
+          description: describeTool({
+            summary: 'Create a new file at a vault-relative path with text content.',
+            args: [
+              'path (string): Vault-relative path for the new file.',
+              'content (string): Initial file contents (UTF-8 text).',
+            ],
+            returns: 'Plain text confirmation "Created file: <path>".',
+            examples: [
+              'Use when: creating notes/ideas.md with "# Ideas"',
+              'Don\'t use when: the file already exists — call vault_update instead.',
+            ],
+            errors: [
+              '"File already exists" if the target path is taken.',
+              '"Path must not traverse outside the vault" on traversal attempts.',
+            ],
+          }),
           schema: createFileSchema,
           handler: handlers.createFile,
           annotations: annotations.additive,
         },
         {
           name: 'vault_read',
-          description: 'Read the full content of a file by path',
+          description: describeTool({
+            summary: 'Read the full UTF-8 content of a file by vault-relative path.',
+            args: ['path (string): Vault-relative path to the file.'],
+            returns: 'The full file content as text. Payloads over 25 000 characters are truncated with a [TRUNCATED: ...] footer.',
+            examples: [
+              'Use when: "show me the README" -> { path: "README.md" }',
+              'Don\'t use when: you only need specific lines (use editor_* or search tools).',
+            ],
+            errors: [
+              '"File not found" if the path does not exist.',
+              '"Path must not traverse outside the vault" on traversal attempts.',
+            ],
+          }),
           schema: readFileSchema,
           handler: handlers.readFile,
           annotations: annotations.read,
         },
         {
           name: 'vault_update',
-          description: 'Update (overwrite) the content of an existing file',
+          description: describeTool({
+            summary: 'Overwrite an existing file with new content.',
+            args: [
+              'path (string): Vault-relative path to an existing file.',
+              'content (string): Replacement file contents.',
+            ],
+            returns: 'Plain text confirmation "Updated file: <path>".',
+            examples: [
+              'Use when: replacing a draft with a final version.',
+              'Don\'t use when: you only need to append (use vault_append).',
+            ],
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: updateFileSchema,
           handler: handlers.updateFile,
           annotations: annotations.destructiveIdempotent,
         },
         {
           name: 'vault_delete',
-          description: 'Delete a file by path',
+          description: describeTool({
+            summary: 'Delete a file by vault-relative path.',
+            args: ['path (string): Vault-relative path to the file.'],
+            returns: 'Plain text confirmation "Deleted file: <path>".',
+            examples: ['Use when: removing an outdated note.'],
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: deleteFileSchema,
           handler: handlers.deleteFile,
           annotations: annotations.destructiveIdempotent,
         },
         {
           name: 'vault_append',
-          description: 'Append content to the end of an existing file',
+          description: describeTool({
+            summary: 'Append content to the end of an existing file.',
+            args: [
+              'path (string): Vault-relative path to an existing file.',
+              'content (string): Text to append.',
+            ],
+            returns: 'Plain text confirmation "Appended to file: <path>".',
+            examples: ['Use when: adding a new bullet to a daily note.'],
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: appendFileSchema,
           handler: handlers.appendFile,
           annotations: annotations.additive,
         },
         {
           name: 'vault_get_metadata',
-          description: 'Get file metadata (size, creation date, modification date)',
+          description: describeTool({
+            summary: 'Get file stat metadata (size, creation date, modification date).',
+            args: ['path (string): Vault-relative path to the file.'],
+            returns: 'JSON: { path, size, created (ISO), modified (ISO) }.',
+            examples: ['Use when: checking if a note has changed recently.'],
+            errors: ['"File not found" if the path does not exist.'],
+          }),
           schema: getMetadataSchema,
           handler: handlers.getMetadata,
           annotations: annotations.read,
         },
         {
           name: 'vault_rename',
-          description: 'Rename a file within the same folder',
+          description: describeTool({
+            summary: 'Rename a file within its current folder.',
+            args: [
+              'path (string): Current vault-relative path.',
+              'newName (string): New basename — must not contain / or \\.',
+            ],
+            returns: 'Plain text "Renamed file: <old> → <new>".',
+            examples: ['Use when: renaming "draft.md" to "final.md" in the same folder.'],
+            errors: [
+              '"Invalid rename target" if newName contains path separators.',
+              '"File not found" if path does not exist.',
+            ],
+          }),
           schema: renameFileSchema,
           handler: handlers.renameFile,
           annotations: annotations.destructive,
         },
         {
           name: 'vault_move',
-          description: 'Move a file to a different folder',
+          description: describeTool({
+            summary: 'Move a file to a different path (can change folder and name).',
+            args: [
+              'path (string): Current vault-relative path.',
+              'newPath (string): New vault-relative path.',
+            ],
+            returns: 'Plain text "Moved file: <old> → <new>".',
+            examples: ['Use when: archiving a note by moving it to "archive/<name>.md".'],
+            errors: ['"File not found" if path does not exist.'],
+          }),
           schema: moveFileSchema,
           handler: handlers.moveFile,
           annotations: annotations.destructive,
         },
         {
           name: 'vault_copy',
-          description: 'Copy a file to a new path',
+          description: describeTool({
+            summary: 'Copy a file to a new path, leaving the original in place.',
+            args: [
+              'sourcePath (string): Existing vault-relative file.',
+              'destPath (string): New vault-relative path.',
+            ],
+            returns: 'Plain text "Copied file: <src> → <dest>".',
+            examples: ['Use when: duplicating a template before editing.'],
+            errors: ['"File not found" if sourcePath does not exist.'],
+          }),
           schema: copyFileSchema,
           handler: handlers.copyFile,
           annotations: annotations.additive,
         },
         {
           name: 'vault_create_folder',
-          description: 'Create a new folder',
+          description: describeTool({
+            summary: 'Create a new folder at a vault-relative path.',
+            args: ['path (string): Folder path to create.'],
+            returns: 'Plain text "Created folder: <path>".',
+            examples: ['Use when: creating a "projects" folder before adding notes.'],
+            errors: ['"Folder already exists" if the path is taken.'],
+          }),
           schema: createFolderSchema,
           handler: handlers.createFolder,
           annotations: annotations.additive,
         },
         {
           name: 'vault_delete_folder',
-          description: 'Delete a folder (optionally recursive)',
+          description: describeTool({
+            summary: 'Delete a folder, optionally recursively.',
+            args: [
+              'path (string): Folder to delete.',
+              'recursive (boolean, default=false): Delete non-empty folders recursively.',
+            ],
+            returns: 'Plain text "Deleted folder: <path>".',
+            examples: ['Use when: removing an empty "old-drafts" folder.'],
+            errors: ['"Folder not empty" if non-empty and recursive=false.'],
+          }),
           schema: deleteFolderSchema,
           handler: handlers.deleteFolder,
           annotations: annotations.destructiveIdempotent,
         },
         {
           name: 'vault_rename_folder',
-          description: 'Rename or move a folder',
+          description: describeTool({
+            summary: 'Rename or move a folder.',
+            args: [
+              'path (string): Current folder path.',
+              'newPath (string): New folder path.',
+            ],
+            returns: 'Plain text "Renamed folder: <old> → <new>".',
+            examples: ['Use when: renaming "WIP" to "Archive".'],
+            errors: ['"Folder not found" if path does not exist.'],
+          }),
           schema: renameFolderSchema,
           handler: handlers.renameFolder,
           annotations: annotations.destructive,
         },
         {
           name: 'vault_list',
-          description: 'List files and folders at a given path (non-recursive)',
+          description: describeTool({
+            summary: 'List files and folders directly under a path (non-recursive).',
+            args: ['path (string): Folder to list.'],
+            returns: 'JSON: { files: string[], folders: string[] } (names only, no recursion).',
+            examples: ['Use when: inspecting the top level of the vault.'],
+            errors: ['"Folder not found" if path does not exist.'],
+          }),
           schema: listFolderSchema,
           handler: handlers.listFolder,
           annotations: annotations.read,
         },
         {
           name: 'vault_list_recursive',
-          description: 'List files and folders recursively from a given path',
+          description: describeTool({
+            summary: 'List all files and folders under a path, recursively.',
+            args: ['path (string): Folder to walk.'],
+            returns: 'JSON: { files: string[], folders: string[] }. Truncated at 25 000 characters with a footer.',
+            examples: [
+              'Use when: building an index of a subfolder.',
+              'Don\'t use when: the folder is very large — list a narrower subfolder.',
+            ],
+            errors: ['"Folder not found" if path does not exist.'],
+          }),
           schema: listRecursiveSchema,
           handler: handlers.listRecursive,
           annotations: annotations.read,
         },
         {
           name: 'vault_read_binary',
-          description: 'Read binary file content as base64',
+          description: describeTool({
+            summary: 'Read binary file contents as base64.',
+            args: ['path (string): Vault-relative path to the file.'],
+            returns: 'Plain text: the base64 string. Refuses files over 1 MiB.',
+            examples: ['Use when: embedding an image referenced from a note.'],
+            errors: [
+              '"File not found" if path does not exist.',
+              '"Binary file too large" if the file exceeds 1 MiB.',
+            ],
+          }),
           schema: readBinarySchema,
           handler: handlers.readBinary,
           annotations: annotations.read,
         },
         {
           name: 'vault_write_binary',
-          description: 'Write binary file content from base64',
+          description: describeTool({
+            summary: 'Write binary file contents from a base64 string.',
+            args: [
+              'path (string): Vault-relative destination path.',
+              'data (string): Base64-encoded binary content (no data: prefix).',
+            ],
+            returns: 'Plain text "Wrote binary file: <path>".',
+            examples: ['Use when: attaching a downloaded PDF to the vault.'],
+            errors: ['"Invalid base64 string" if data is not valid base64.'],
+          }),
           schema: writeBinarySchema,
           handler: handlers.writeBinary,
           annotations: annotations.destructiveIdempotent,

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -4,6 +4,7 @@ import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { handleToolError } from '../shared/errors';
+import { describeTool } from '../shared/describe';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -50,14 +51,26 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
       return [
         {
           name: 'workspace_get_active_leaf',
-          description: 'Get active pane info',
+          description: describeTool({
+            summary: 'Get info about the currently-focused leaf (pane).',
+            returns: 'JSON: { id, type, ... } describing the active leaf.',
+            errors: ['"No active leaf" if no leaf is focused.'],
+          }),
           schema: {},
           handler: h.getActiveLeaf,
           annotations: annotations.read,
         },
         {
           name: 'workspace_open_file',
-          description: 'Open a file in a pane',
+          description: describeTool({
+            summary: 'Open a file in a leaf, optionally requesting a view mode.',
+            args: [
+              'path (string): Vault-relative file path.',
+              'mode (enum, optional): "source" | "preview" | "live".',
+            ],
+            returns: 'Plain text "Opened: <path>".',
+            errors: ['"Path must not traverse outside the vault" on traversal attempts.'],
+          }),
           schema: {
             path: z
               .string()
@@ -74,14 +87,22 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'workspace_list_leaves',
-          description: 'List all open files and panes',
+          description: describeTool({
+            summary: 'List every open leaf and the file it holds.',
+            returns: 'JSON: [{ path, leafId }].',
+          }),
           schema: {},
           handler: h.listLeaves,
           annotations: annotations.read,
         },
         {
           name: 'workspace_set_active_leaf',
-          description: 'Set focus on a leaf by ID',
+          description: describeTool({
+            summary: 'Focus a specific leaf by id.',
+            args: ['leafId (string): Leaf id from workspace_list_leaves.'],
+            returns: 'Plain text "Active leaf set" on success.',
+            errors: ['"Leaf not found" if the id does not match any leaf.'],
+          }),
           schema: {
             leafId: z
               .string()
@@ -94,7 +115,10 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         },
         {
           name: 'workspace_get_layout',
-          description: 'Get workspace layout summary',
+          description: describeTool({
+            summary: 'Get a summary of the current workspace layout.',
+            returns: 'JSON: Obsidian\'s layout descriptor (nested splits and leaves).',
+          }),
           schema: {},
           handler: h.getLayout,
           annotations: annotations.read,


### PR DESCRIPTION
## Summary

- Add `src/tools/shared/describe.ts` with a `describeTool()` helper that renders the mcp-builder 6-section description format: summary, Args, Returns, Examples, Errors.
- Apply it to every one of the 55 tools across vault, editor, search, workspace, ui, templates, plugin-interop, and extras.
- Descriptions now tell the calling model what each tool does, what each argument means, what shape the response has, when to pick the tool vs. a neighbour, and which error messages to expect.

## Test plan

- [x] `npm test` — 443 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — snapshot stable

Closes #179