### PR TITLE
feat(plugin-interop): allowlist `executeCommand` to block destructive Obsidian commands

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -162,6 +162,17 @@ default. Today this contains:
 
 - `get_date` — returns the current local time as ISO-8601 with offset.
 
+### Execute Command Allowlist
+
+The `plugin_execute_command` tool in Plugin Interop can run any Obsidian
+command — including destructive ones (e.g. `app:delete-file`). By default
+the allowlist is empty, which means the tool refuses every call with a
+clear error. To enable specific commands, add their ids (one per line) to
+the **Execute Command Allowlist** section in settings. Only commands on the
+allowlist will run; everything else is rejected with the command id echoed
+back. Keep the list short and curated — you're granting MCP clients the
+same power as the Obsidian command palette.
+
 A **Refresh** button at the top of this section re-discovers modules without
 restarting Obsidian (useful when developing modules).
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,7 +242,10 @@ export default class McpPlugin extends Plugin {
   }
 
   private registerDiscoveredModules(): void {
-    for (const module of discoverModules(this.adapter)) {
+    const modules = discoverModules(this.adapter, {
+      getExecuteCommandAllowlist: () => this.settings.executeCommandAllowlist,
+    });
+    for (const module of modules) {
       this.registry.registerModule(module);
     }
     this.registry.applyState(this.settings.moduleStates);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -28,7 +28,32 @@ export class McpSettingsTab extends PluginSettingTab {
     this.renderServerSettings(containerEl);
     this.renderMcpConfig(containerEl);
     this.renderModuleToggles(containerEl);
+    this.renderExecuteCommandAllowlist(containerEl);
     this.renderDiagnostics(containerEl);
+  }
+
+  private renderExecuteCommandAllowlist(containerEl: HTMLElement): void {
+    containerEl.createEl('h2', { text: 'Execute Command Allowlist' });
+
+    containerEl.createEl('p', {
+      cls: 'setting-item-description',
+      text: 'The plugin_execute_command tool refuses every call by default. To enable specific Obsidian commands for MCP execution, list their ids here (one per line). Leave empty to keep the tool disabled.',
+    });
+
+    const current = this.plugin.settings.executeCommandAllowlist.join('\n');
+    const textarea = containerEl.createEl('textarea', {
+      cls: 'mcp-execute-command-allowlist',
+      attr: { rows: '6', placeholder: 'app:reload\neditor:save-file' },
+    });
+    textarea.value = current;
+    textarea.addEventListener('change', () => {
+      const next = textarea.value
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      this.plugin.settings.executeCommandAllowlist = next;
+      void this.plugin.saveSettings();
+    });
   }
 
   private scheme(): 'http' | 'https' {
@@ -694,6 +719,17 @@ export function migrateSettings(
     if (data.useCustomTls === undefined) data.useCustomTls = false;
     if (data.customTlsCertPath === undefined) data.customTlsCertPath = null;
     if (data.customTlsKeyPath === undefined) data.customTlsKeyPath = null;
+  }
+
+  if ((data.schemaVersion as number) < 8) {
+    data.schemaVersion = 8;
+    // V7 -> V8: executeCommand allowlist. Default to empty (disabled) so
+    // existing installs cannot accidentally run destructive Obsidian
+    // commands via `plugin_execute_command` — users must opt in per
+    // command.
+    if (!Array.isArray(data.executeCommandAllowlist)) {
+      data.executeCommandAllowlist = [];
+    }
   }
 
   return data;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,7 +9,19 @@ import { createUiModule } from './ui';
 import { createVaultModule } from './vault';
 import { createWorkspaceModule } from './workspace';
 
-export type ModuleFactory = (adapter: ObsidianAdapter) => ToolModule;
+/**
+ * Options passed through to every module factory. Modules ignore fields
+ * they don't care about; only plugin-interop currently reads
+ * `getExecuteCommandAllowlist`.
+ */
+export interface ModuleOptions {
+  getExecuteCommandAllowlist?: () => string[];
+}
+
+export type ModuleFactory = (
+  adapter: ObsidianAdapter,
+  options?: ModuleOptions,
+) => ToolModule;
 
 export const MODULE_FACTORIES: ModuleFactory[] = [
   createVaultModule,
@@ -22,6 +34,9 @@ export const MODULE_FACTORIES: ModuleFactory[] = [
   createExtrasModule,
 ];
 
-export function discoverModules(adapter: ObsidianAdapter): ToolModule[] {
-  return MODULE_FACTORIES.map((factory) => factory(adapter));
+export function discoverModules(
+  adapter: ObsidianAdapter,
+  options: ModuleOptions = {},
+): ToolModule[] {
+  return MODULE_FACTORIES.map((factory) => factory(adapter, options));
 }

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -4,13 +4,17 @@ import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
+import type { ModuleOptions } from '../index';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
-function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+function createHandlers(
+  adapter: ObsidianAdapter,
+  getExecuteCommandAllowlist: () => string[],
+): Record<string, Handler> {
   return {
     listPlugins: (): Promise<CallToolResult> => {
       const plugins = adapter.getInstalledPlugins();
@@ -44,14 +48,35 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     },
     executeCommand: (params): Promise<CallToolResult> => {
       const commandId = params.commandId as string;
+      const allowlist = getExecuteCommandAllowlist();
+      if (allowlist.length === 0) {
+        return Promise.resolve(
+          err(
+            'Command execution disabled — enable commands individually in Obsidian MCP settings.',
+          ),
+        );
+      }
+      if (!allowlist.includes(commandId)) {
+        return Promise.resolve(
+          err(
+            `Command "${commandId}" is not on the executeCommand allowlist. Add it in Obsidian MCP settings if you trust it.`,
+          ),
+        );
+      }
       const ok = adapter.executeCommand(commandId);
       return Promise.resolve(ok ? text(`Executed command: ${commandId}`) : err(`Command not found: ${commandId}`));
     },
   };
 }
 
-export function createPluginInteropModule(adapter: ObsidianAdapter): ToolModule {
-  const h = createHandlers(adapter);
+export function createPluginInteropModule(
+  adapter: ObsidianAdapter,
+  options: ModuleOptions = {},
+): ToolModule {
+  const h = createHandlers(
+    adapter,
+    options.getExecuteCommandAllowlist ?? ((): string[] => []),
+  );
   return {
     metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater' },
     tools(): ToolDefinition[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,12 @@ export interface McpPluginSettings {
   debugMode: boolean;
   /** Auto-start the MCP server when Obsidian launches */
   autoStart: boolean;
+  /**
+   * Allowlist of Obsidian command ids that `plugin_execute_command` is
+   * permitted to run. Empty (the default) means command execution is
+   * disabled and the tool refuses every call with a clear error.
+   */
+  executeCommandAllowlist: string[];
   /** Per-module enabled/disabled state, keyed by module ID */
   moduleStates: Record<string, ModuleState>;
 }
@@ -39,7 +45,7 @@ export interface ModuleState {
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 7,
+  schemaVersion: 8,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: false,
@@ -51,5 +57,6 @@ export const DEFAULT_SETTINGS: McpPluginSettings = {
   customTlsKeyPath: null,
   debugMode: false,
   autoStart: false,
+  executeCommandAllowlist: [],
   moduleStates: {},
 };

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,7 +7,7 @@ describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to current schema', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -25,7 +25,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -43,7 +43,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
@@ -59,7 +59,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.autoStart).toBe(false);
   });
 
@@ -78,7 +78,7 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
@@ -97,7 +97,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.tlsCertificate).toBeNull();
   });
 
@@ -114,7 +114,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.authEnabled).toBe(false);
   });
 
@@ -124,7 +124,7 @@ describe('migrateSettings', () => {
       accessKey: 'pre-existing-key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.authEnabled).toBe(false);
     expect(result.accessKey).toBe('pre-existing-key');
   });
@@ -135,7 +135,7 @@ describe('migrateSettings', () => {
       authEnabled: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.authEnabled).toBe(true);
   });
 
@@ -173,7 +173,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.useCustomTls).toBe(false);
     expect(result.customTlsCertPath).toBeNull();
     expect(result.customTlsKeyPath).toBeNull();
@@ -189,7 +189,7 @@ describe('migrateSettings', () => {
       customTlsKeyPath: '/etc/ssl/my.key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.useCustomTls).toBe(true);
     expect(result.customTlsCertPath).toBe('/etc/ssl/my.crt');
     expect(result.customTlsKeyPath).toBe('/etc/ssl/my.key');
@@ -201,7 +201,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.tlsCertificate).toEqual({
       cert: 'EXISTING_CERT',
       key: 'EXISTING_KEY',
@@ -213,7 +213,7 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
@@ -234,7 +234,7 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
@@ -287,8 +287,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
   });
 
-  it('declares schemaVersion 7', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(7);
+  it('declares schemaVersion 8', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(8);
   });
 
   it('defaults custom TLS fields to off/null', () => {

--- a/tests/tools/plugin-interop/plugin-interop.test.ts
+++ b/tests/tools/plugin-interop/plugin-interop.test.ts
@@ -46,11 +46,53 @@ describe('plugin interop module', () => {
     expect(result.isError).toBe(true);
   });
 
-  it('should execute a command', async () => {
-    const module = createPluginInteropModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
-    const result = await tool.handler({ commandId: 'app:toggle-left-sidebar' });
-    expect(result.isError).toBeUndefined();
-    expect(adapter.getExecutedCommands()).toContain('app:toggle-left-sidebar');
+  describe('plugin_execute_command allowlist', () => {
+    it('refuses every call when the allowlist is empty (default)', async () => {
+      const module = createPluginInteropModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
+      const result = await tool.handler({ commandId: 'app:toggle-left-sidebar' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('Command execution disabled');
+      expect(adapter.getExecutedCommands()).not.toContain('app:toggle-left-sidebar');
+    });
+
+    it('refuses commands not on the allowlist', async () => {
+      const module = createPluginInteropModule(adapter, {
+        getExecuteCommandAllowlist: () => ['app:reload'],
+      });
+      const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
+      const result = await tool.handler({ commandId: 'app:toggle-left-sidebar' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not on the executeCommand allowlist');
+      expect(adapter.getExecutedCommands()).not.toContain('app:toggle-left-sidebar');
+    });
+
+    it('runs commands that are on the allowlist', async () => {
+      const module = createPluginInteropModule(adapter, {
+        getExecuteCommandAllowlist: () => ['app:toggle-left-sidebar'],
+      });
+      const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
+      const result = await tool.handler({ commandId: 'app:toggle-left-sidebar' });
+      expect(result.isError).toBeUndefined();
+      expect(adapter.getExecutedCommands()).toContain('app:toggle-left-sidebar');
+    });
+
+    it('reads the allowlist lazily on each call', async () => {
+      let allowed: string[] = [];
+      const module = createPluginInteropModule(adapter, {
+        getExecuteCommandAllowlist: () => allowed,
+      });
+      const tool = module.tools().find((t) => t.name === 'plugin_execute_command')!;
+
+      // First call: not on list.
+      const r1 = await tool.handler({ commandId: 'app:reload' });
+      expect(r1.isError).toBe(true);
+
+      // User adds the command — next call should succeed without re-creating
+      // the module.
+      allowed = ['app:reload'];
+      const r2 = await tool.handler({ commandId: 'app:reload' });
+      expect(r2.isError).toBeUndefined();
+    });
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 7', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(7);
+  it('should have schema version 8', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(8);
   });
 
   it('has bring-your-own-cert disabled by default', () => {

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -65,7 +65,7 @@ function makeModule(
 }
 
 const baseSettings: McpPluginSettings = {
-  schemaVersion: 7,
+  schemaVersion: 8,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: true,
@@ -77,6 +77,7 @@ const baseSettings: McpPluginSettings = {
   customTlsKeyPath: null,
   debugMode: true,
   autoStart: false,
+  executeCommandAllowlist: [],
   moduleStates: {},
 };
 


### PR DESCRIPTION
## Summary

- Add settings field `executeCommandAllowlist: string[]` (default `[]`, meaning disabled). SchemaVersion bumps to 8 with a migration that seeds the empty array on upgrade.
- `plugin_execute_command` now refuses every call when the allowlist is empty ("Command execution disabled — enable commands individually in Obsidian MCP settings"). When non-empty, only exact-match command ids run; others are rejected with the attempted id echoed back.
- Wire a `getExecuteCommandAllowlist` callback through a new `ModuleOptions` param on `discoverModules()`, so the module reads the live list on every call (lazy). The plugin passes `() => this.settings.executeCommandAllowlist` — edits take effect without re-registering modules.
- New settings tab section "Execute Command Allowlist" with a textarea (one command id per line). Saves on change.
- Update `docs/help/en.md` with the allowlist explainer.

## Screenshots

UI change is small (one new settings section with a textarea). Host-side Obsidian rendering not available in this session — will attach before/after screenshots when the host pipeline is reachable.

## Test plan

- [x] `npm test` — 459 passing (+4 allowlist tests, +1 migration update)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — snapshot stable

Closes #181