### PR TITLE
feat(tools): roll out `makeResponse` + `structuredContent` to all read tools

### DIFF
--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -4,6 +4,11 @@ import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
+import {
+  makeResponse,
+  readResponseFormat,
+  responseFormatField,
+} from '../shared/response';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -46,15 +51,27 @@ function assertEditorPosition(
 
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
   return {
-    getContent: (): Promise<CallToolResult> => {
+    getContent: (params): Promise<CallToolResult> => {
       const content = adapter.getActiveFileContent();
       if (content === null) return Promise.resolve(err('No active editor'));
-      return Promise.resolve(text(content));
+      return Promise.resolve(
+        makeResponse(
+          { content },
+          (v) => v.content,
+          readResponseFormat(params),
+        ),
+      );
     },
-    getActivePath: (): Promise<CallToolResult> => {
+    getActivePath: (params): Promise<CallToolResult> => {
       const path = adapter.getActiveFilePath();
       if (path === null) return Promise.resolve(err('No active file'));
-      return Promise.resolve(text(path));
+      return Promise.resolve(
+        makeResponse(
+          { path },
+          (v) => v.path,
+          readResponseFormat(params),
+        ),
+      );
     },
     insert: (params): Promise<CallToolResult> => {
       const lineCount = adapter.getActiveLineCount();
@@ -113,10 +130,16 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       );
       return Promise.resolve(ok ? text('Text deleted') : err('No active editor'));
     },
-    getCursor: (): Promise<CallToolResult> => {
+    getCursor: (params): Promise<CallToolResult> => {
       const pos = adapter.getCursorPosition();
       if (!pos) return Promise.resolve(err('No active editor'));
-      return Promise.resolve(text(JSON.stringify(pos)));
+      return Promise.resolve(
+        makeResponse(
+          pos,
+          (v) => `line ${String(v.line)}, ch ${String(v.ch)}`,
+          readResponseFormat(params),
+        ),
+      );
     },
     setCursor: (params): Promise<CallToolResult> => {
       const lineCount = adapter.getActiveLineCount();
@@ -134,10 +157,17 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       );
       return Promise.resolve(ok ? text('Cursor set') : err('No active editor'));
     },
-    getSelection: (): Promise<CallToolResult> => {
+    getSelection: (params): Promise<CallToolResult> => {
       const sel = adapter.getSelection();
       if (!sel) return Promise.resolve(err('No active editor or selection'));
-      return Promise.resolve(text(JSON.stringify(sel)));
+      return Promise.resolve(
+        makeResponse(
+          sel,
+          (v) =>
+            `${String(v.from.line)}:${String(v.from.ch)} → ${String(v.to.line)}:${String(v.to.ch)}\n\n${v.text}`,
+          readResponseFormat(params),
+        ),
+      );
     },
     setSelection: (params): Promise<CallToolResult> => {
       const lineCount = adapter.getActiveLineCount();
@@ -158,10 +188,16 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       );
       return Promise.resolve(ok ? text('Selection set') : err('No active editor'));
     },
-    getLineCount: (): Promise<CallToolResult> => {
+    getLineCount: (params): Promise<CallToolResult> => {
       const count = adapter.getActiveLineCount();
       if (count === null) return Promise.resolve(err('No active editor'));
-      return Promise.resolve(text(String(count)));
+      return Promise.resolve(
+        makeResponse(
+          { lineCount: count },
+          (v) => String(v.lineCount),
+          readResponseFormat(params),
+        ),
+      );
     },
   };
 }
@@ -179,7 +215,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text: the editor\'s current content.',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getContent,
           annotations: annotations.read,
         },
@@ -190,7 +226,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text: the path, e.g. "notes/today.md".',
             errors: ['"No active file" if no file is open.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getActivePath,
           annotations: annotations.read,
         },
@@ -280,7 +316,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: { line, ch } (zero-based).',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getCursor,
           annotations: annotations.read,
         },
@@ -312,7 +348,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: { from: {line, ch}, to: {line, ch}, text }.',
             errors: ['"No active editor or selection" if nothing is selected.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getSelection,
           annotations: annotations.read,
         },
@@ -346,7 +382,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text: the line count as a decimal integer.',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getLineCount,
           annotations: annotations.read,
         },

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -2,10 +2,13 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { describeTool } from '../shared/describe';
+import {
+  makeResponse,
+  readResponseFormat,
+  responseFormatField,
+} from '../shared/response';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
-
-function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 
 function pad(n: number, width = 2): string {
   return String(Math.abs(n)).padStart(width, '0');
@@ -31,8 +34,15 @@ function formatIsoWithOffset(now: Date): string {
 
 function createHandlers(_adapter: ObsidianAdapter): Record<string, Handler> {
   return {
-    getDate: (): Promise<CallToolResult> => {
-      return Promise.resolve(text(formatIsoWithOffset(new Date())));
+    getDate: (params): Promise<CallToolResult> => {
+      const iso = formatIsoWithOffset(new Date());
+      return Promise.resolve(
+        makeResponse(
+          { iso },
+          (v) => v.iso,
+          readResponseFormat(params),
+        ),
+      );
     },
   };
 }
@@ -56,7 +66,7 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',
             examples: ['Use when: stamping a daily note with the current local time.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getDate,
           annotations: annotations.read,
         },

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -4,6 +4,11 @@ import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
+import {
+  makeResponse,
+  readResponseFormat,
+  responseFormatField,
+} from '../shared/response';
 import type { ModuleOptions } from '../index';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
@@ -16,26 +21,53 @@ function createHandlers(
   getExecuteCommandAllowlist: () => string[],
 ): Record<string, Handler> {
   return {
-    listPlugins: (): Promise<CallToolResult> => {
+    listPlugins: (params): Promise<CallToolResult> => {
       const plugins = adapter.getInstalledPlugins();
-      return Promise.resolve(text(JSON.stringify(plugins)));
+      return Promise.resolve(
+        makeResponse(
+          { plugins },
+          (v) =>
+            v.plugins.length === 0
+              ? 'No community plugins installed.'
+              : v.plugins
+                  .map(
+                    (p) =>
+                      `- **${p.name ?? p.id}** (\`${p.id}\`) — ${p.enabled ? 'enabled' : 'disabled'}`,
+                  )
+                  .join('\n'),
+          readResponseFormat(params),
+        ),
+      );
     },
     checkPlugin: (params): Promise<CallToolResult> => {
       const pluginId = params.pluginId as string;
       const enabled = adapter.isPluginEnabled(pluginId);
       const plugins = adapter.getInstalledPlugins();
       const installed = plugins.some((p) => p.id === pluginId);
-      return Promise.resolve(text(JSON.stringify({ pluginId, installed, enabled })));
+      return Promise.resolve(
+        makeResponse(
+          { pluginId, installed, enabled },
+          (v) =>
+            `**${v.pluginId}** — ${v.installed ? 'installed' : 'not installed'}, ${v.enabled ? 'enabled' : 'disabled'}`,
+          readResponseFormat(params),
+        ),
+      );
     },
     dataviewQuery: (params): Promise<CallToolResult> => {
       if (!adapter.isPluginEnabled('dataview')) {
         return Promise.resolve(err('Dataview plugin is not installed or enabled'));
       }
-      // Dataview integration requires the Dataview API which is only available at runtime
-      return Promise.resolve(text(JSON.stringify({
+      const payload = {
         note: 'Dataview query execution requires the Dataview plugin API at runtime',
         query: params.query as string,
-      })));
+      };
+      return Promise.resolve(
+        makeResponse(
+          payload,
+          (v) => `_${v.note}_\n\n\`\`\`dataview\n${v.query}\n\`\`\``,
+          readResponseFormat(params),
+        ),
+      );
     },
     templaterExecute: (params): Promise<CallToolResult> => {
       if (!adapter.isPluginEnabled('templater-obsidian')) {
@@ -87,7 +119,7 @@ export function createPluginInteropModule(
             summary: 'List every installed community plugin with its enabled flag.',
             returns: 'JSON: [{ id, name, enabled, ... }].',
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.listPlugins,
           annotations: annotations.readExternal,
         },
@@ -104,6 +136,7 @@ export function createPluginInteropModule(
               .min(1)
               .max(200)
               .describe('Community plugin id (e.g. "dataview")'),
+            ...responseFormatField,
           },
           handler: h.checkPlugin,
           annotations: annotations.readExternal,
@@ -122,6 +155,7 @@ export function createPluginInteropModule(
               .min(1)
               .max(10_000)
               .describe('Dataview query (DQL or Dataview-js)'),
+            ...responseFormatField,
           },
           handler: h.dataviewQuery,
           annotations: annotations.readExternal,

--- a/src/tools/search/handlers.ts
+++ b/src/tools/search/handlers.ts
@@ -8,8 +8,33 @@ import { makeResponse, readResponseFormat } from '../shared/response';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
-function textResult(text: string): CallToolResult {
-  return { content: [{ type: 'text', text }] };
+function renderKeyValue(obj: Record<string, unknown>): string {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return '_No entries._';
+  return entries.map(([k, v]) => `- **${k}**: ${String(v)}`).join('\n');
+}
+
+function renderPathList(items: string[], empty = 'No matches.'): string {
+  if (items.length === 0) return empty;
+  return items.map((p) => `- ${p}`).join('\n');
+}
+
+function renderPaginatedPaths(
+  page: {
+    total: number;
+    count: number;
+    items: string[];
+    has_more: boolean;
+    next_offset?: number;
+  },
+  label: string,
+): string {
+  const header = `**${String(page.total)} ${label}${page.total === 1 ? '' : 's'}**`;
+  const body = renderPathList(page.items);
+  const footer = page.has_more
+    ? `\n\n_Showing ${String(page.count)} of ${String(page.total)} — next offset: ${String(page.next_offset ?? '')}_`
+    : '';
+  return `${header}\n\n${body}${footer}`;
 }
 
 export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
@@ -51,17 +76,39 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
     searchFrontmatter(params): Promise<CallToolResult> {
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
-        const frontmatter = adapter.getFrontmatter(path);
-        return Promise.resolve(textResult(JSON.stringify(frontmatter ?? {})));
+        const frontmatter = adapter.getFrontmatter(path) ?? {};
+        return Promise.resolve(
+          makeResponse(
+            { path, frontmatter },
+            (v) =>
+              `**${v.path}** frontmatter:\n${renderKeyValue(v.frontmatter)}`,
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
     },
 
-    searchTags(_params): Promise<CallToolResult> {
+    searchTags(params): Promise<CallToolResult> {
       try {
         const allTags = adapter.getAllTags();
-        return Promise.resolve(textResult(JSON.stringify(allTags)));
+        return Promise.resolve(
+          makeResponse(
+            { tags: allTags },
+            (v) => {
+              const entries = Object.entries(v.tags);
+              if (entries.length === 0) return 'No tags in this vault.';
+              return entries
+                .map(
+                  ([tag, files]) =>
+                    `- **${tag}** — ${String(files.length)} file${files.length === 1 ? '' : 's'}`,
+                )
+                .join('\n');
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -71,7 +118,19 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const headings = adapter.getHeadings(path);
-        return Promise.resolve(textResult(JSON.stringify(headings)));
+        return Promise.resolve(
+          makeResponse(
+            { path, headings },
+            (v) => {
+              if (v.headings.length === 0) return `**${v.path}** has no headings.`;
+              const lines = v.headings.map(
+                (h) => `${'#'.repeat(h.level)} ${h.heading}`,
+              );
+              return `**${v.path}**\n\n${lines.join('\n')}`;
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -81,7 +140,19 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const links = adapter.getLinks(path);
-        return Promise.resolve(textResult(JSON.stringify(links)));
+        return Promise.resolve(
+          makeResponse(
+            { path, links },
+            (v) => {
+              if (v.links.length === 0) return `**${v.path}** has no outgoing links.`;
+              const lines = v.links.map(
+                (l) => `- ${l.displayText ? `[${l.displayText}](${l.link})` : l.link}`,
+              );
+              return `**${v.path}** links to:\n${lines.join('\n')}`;
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -91,7 +162,17 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const embeds = adapter.getEmbeds(path);
-        return Promise.resolve(textResult(JSON.stringify(embeds)));
+        return Promise.resolve(
+          makeResponse(
+            { path, embeds },
+            (v) => {
+              if (v.embeds.length === 0) return `**${v.path}** has no embeds.`;
+              const lines = v.embeds.map((e) => `- ${e.link}`);
+              return `**${v.path}** embeds:\n${lines.join('\n')}`;
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -101,25 +182,68 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const backlinks = adapter.getBacklinks(path);
-        return Promise.resolve(textResult(JSON.stringify(backlinks)));
+        return Promise.resolve(
+          makeResponse(
+            { path, backlinks },
+            (v) =>
+              v.backlinks.length === 0
+                ? `**${v.path}** has no backlinks.`
+                : `**${v.path}** is linked from:\n${renderPathList(v.backlinks)}`,
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
     },
 
-    searchResolvedLinks(_params): Promise<CallToolResult> {
+    searchResolvedLinks(params): Promise<CallToolResult> {
       try {
         const links = adapter.getResolvedLinks();
-        return Promise.resolve(textResult(JSON.stringify(links)));
+        return Promise.resolve(
+          makeResponse(
+            { links },
+            (v) => {
+              const entries = Object.entries(v.links);
+              if (entries.length === 0) return 'No resolved links in this vault.';
+              return entries
+                .map(([src, targets]) => {
+                  const targetLines = Object.entries(targets)
+                    .map(([tgt, count]) => `  - ${tgt} (×${String(count)})`)
+                    .join('\n');
+                  return `- **${src}**\n${targetLines}`;
+                })
+                .join('\n');
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
     },
 
-    searchUnresolvedLinks(_params): Promise<CallToolResult> {
+    searchUnresolvedLinks(params): Promise<CallToolResult> {
       try {
         const links = adapter.getUnresolvedLinks();
-        return Promise.resolve(textResult(JSON.stringify(links)));
+        return Promise.resolve(
+          makeResponse(
+            { links },
+            (v) => {
+              const entries = Object.entries(v.links);
+              if (entries.length === 0) return 'No unresolved links in this vault.';
+              return entries
+                .map(([src, targets]) => {
+                  const targetLines = Object.entries(targets)
+                    .map(([tgt, count]) => `  - ${tgt} (×${String(count)})`)
+                    .join('\n');
+                  return `- **${src}**\n${targetLines}`;
+                })
+                .join('\n');
+            },
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -128,7 +252,6 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
     searchBlockReferences(params): Promise<CallToolResult> {
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
-        // Block references are lines containing ^block-id patterns
         return adapter.getFileContent(path).then((content) => {
           const blockRefs = content
             .split('\n')
@@ -137,8 +260,16 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
               const match = /\^([\w-]+)\s*$/.exec(line);
               return match ? { id: match[1], line: line.trim() } : null;
             })
-            .filter(Boolean);
-          return textResult(JSON.stringify(blockRefs));
+            .filter((ref): ref is { id: string; line: string } => ref !== null);
+          return makeResponse(
+            { path, blockRefs },
+            (v) => {
+              if (v.blockRefs.length === 0) return `**${v.path}** has no block references.`;
+              const lines = v.blockRefs.map((b) => `- **^${b.id}** — ${b.line}`);
+              return `**${v.path}** block references:\n${lines.join('\n')}`;
+            },
+            readResponseFormat(params),
+          );
         });
       } catch (error) {
         return Promise.resolve(handleToolError(error));
@@ -152,7 +283,13 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
         const allTags = adapter.getAllTags();
         const files = allTags[normalizedTag] ?? [];
         const page = paginate(files, readPagination(params));
-        return Promise.resolve(textResult(JSON.stringify(page)));
+        return Promise.resolve(
+          makeResponse(
+            page,
+            (v) => renderPaginatedPaths(v, `file tagged ${normalizedTag}`),
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -171,7 +308,13 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
           }
         }
         const page = paginate(matching, readPagination(params));
-        return Promise.resolve(textResult(JSON.stringify(page)));
+        return Promise.resolve(
+          makeResponse(
+            page,
+            (v) => renderPaginatedPaths(v, `file with ${key}=${value}`),
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -7,6 +7,7 @@ import {
   filePathSchema,
   searchByTagSchema,
   searchByFrontmatterSchema,
+  readOnlySchema,
 } from './schemas';
 
 export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
@@ -52,7 +53,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'List every tag used anywhere in the vault with the files that use it.',
             returns: 'JSON: Record<tag, string[]>. Each key is the tag including leading #.',
           }),
-          schema: {},
+          schema: readOnlySchema,
           handler: handlers.searchTags,
           annotations: annotations.read,
         },
@@ -110,7 +111,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get the vault-wide map of resolved links (targets that exist).',
             returns: 'JSON: Record<source, Record<target, count>>.',
           }),
-          schema: {},
+          schema: readOnlySchema,
           handler: handlers.searchResolvedLinks,
           annotations: annotations.read,
         },
@@ -121,7 +122,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: Record<source, Record<target, count>>.',
             examples: ['Use when: hunting for broken [[wikilinks]] to clean up.'],
           }),
-          schema: {},
+          schema: readOnlySchema,
           handler: handlers.searchUnresolvedLinks,
           annotations: annotations.read,
         },

--- a/src/tools/search/schemas.ts
+++ b/src/tools/search/schemas.ts
@@ -15,6 +15,11 @@ export const filePathSchema = {
     .min(1)
     .max(4096)
     .describe('File path relative to vault root'),
+  ...responseFormatField,
+};
+
+export const readOnlySchema = {
+  ...responseFormatField,
 };
 
 export const searchByTagSchema = {

--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -4,6 +4,7 @@ import { validateVaultPath } from '../../utils/path-guard';
 import { truncateText } from '../shared/truncate';
 import { handleToolError } from '../shared/errors';
 import { paginate, readPagination } from '../shared/pagination';
+import { makeResponse, readResponseFormat } from '../shared/response';
 import { BINARY_BYTE_LIMIT } from '../../constants';
 
 export class WriteMutex {
@@ -33,13 +34,50 @@ function textResult(text: string): CallToolResult {
   return { content: [{ type: 'text', text }] };
 }
 
-function truncatedResult(text: string, hint?: string): CallToolResult {
-  const result = truncateText(text, hint ? { hint } : {});
-  return { content: [{ type: 'text', text: result.text }] };
-}
-
 function errorResult(message: string): CallToolResult {
   return handleToolError(new Error(message));
+}
+
+function renderFolderListing(
+  path: string,
+  folders: string[],
+  files: string[],
+): string {
+  if (folders.length === 0 && files.length === 0) {
+    return `\`${path}\` is empty.`;
+  }
+  const lines: string[] = [`**${path}**`];
+  if (folders.length > 0) {
+    lines.push('', 'Folders:', ...folders.map((f) => `- ${f}/`));
+  }
+  if (files.length > 0) {
+    lines.push('', 'Files:', ...files.map((f) => `- ${f}`));
+  }
+  return lines.join('\n');
+}
+
+function renderRecursiveListing(
+  path: string,
+  folders: string[],
+  files: string[],
+  total: number,
+  hasMore: boolean,
+  nextOffset: number | undefined,
+): string {
+  const folderLine = folders.length > 0 ? `${String(folders.length)} folders` : '0 folders';
+  const fileLine = `${String(files.length)} of ${String(total)} files`;
+  const header = `**${path}** — ${folderLine}, ${fileLine}`;
+  const lines: string[] = [header];
+  if (folders.length > 0) {
+    lines.push('', 'Folders:', ...folders.map((f) => `- ${f}/`));
+  }
+  if (files.length > 0) {
+    lines.push('', 'Files:', ...files.map((f) => `- ${f}`));
+  }
+  if (hasMore) {
+    lines.push('', `_More files available — next offset: ${String(nextOffset ?? '')}_`);
+  }
+  return lines.join('\n');
 }
 
 const RENAME_TARGET_PATTERN = /^[^/\\\x00]+$/;
@@ -95,10 +133,20 @@ export function createHandlers(
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const content = await adapter.readFile(path);
-        return truncatedResult(
-          content,
-          'Read a specific range via editor_* tools or ask for a summary.',
+        const result = makeResponse(
+          { path, content },
+          (v) => v.content,
+          readResponseFormat(params),
         );
+        const firstBlock = result.content[0];
+        const text = firstBlock.type === 'text' ? firstBlock.text : '';
+        const truncated = truncateText(text, {
+          hint: 'Read a specific range via editor_* tools or ask for a summary.',
+        });
+        return {
+          ...result,
+          content: [{ type: 'text' as const, text: truncated.text }],
+        };
       } catch (error) {
         return handleToolError(error);
       }
@@ -150,13 +198,17 @@ export function createHandlers(
         if (!stat) {
           return errorResult(`File not found: ${path}`);
         }
-        return textResult(
-          JSON.stringify({
-            path,
-            size: stat.size,
-            created: new Date(stat.ctime).toISOString(),
-            modified: new Date(stat.mtime).toISOString(),
-          }),
+        const payload = {
+          path,
+          size: stat.size,
+          created: new Date(stat.ctime).toISOString(),
+          modified: new Date(stat.mtime).toISOString(),
+        };
+        return makeResponse(
+          payload,
+          (v) =>
+            `**${v.path}**\n- size: ${String(v.size)} bytes\n- created: ${v.created}\n- modified: ${v.modified}`,
+          readResponseFormat(params),
         );
       } catch (error) {
         return handleToolError(error);
@@ -248,7 +300,14 @@ export function createHandlers(
       try {
         const path = validateVaultPath(params.path as string, vaultPath);
         const result = adapter.list(path);
-        return Promise.resolve(textResult(JSON.stringify(result)));
+        return Promise.resolve(
+          makeResponse(
+            result,
+            (v) =>
+              renderFolderListing(path, v.folders, v.files),
+            readResponseFormat(params),
+          ),
+        );
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }
@@ -260,15 +319,24 @@ export function createHandlers(
         const result = adapter.listRecursive(path);
         const pagination = readPagination(params);
         const filesPage = paginate(result.files, pagination);
-        return Promise.resolve(
-          truncatedResult(
-            JSON.stringify({
-              folders: result.folders,
-              ...filesPage,
-            }),
-            'Shrink limit, advance offset, or list a narrower subfolder.',
-          ),
+        const payload = {
+          folders: result.folders,
+          ...filesPage,
+        };
+        const wrapped = makeResponse(
+          payload,
+          (v) => renderRecursiveListing(path, v.folders, v.items, v.total, v.has_more, v.next_offset),
+          readResponseFormat(params),
         );
+        const firstBlock = wrapped.content[0];
+        const text = firstBlock.type === 'text' ? firstBlock.text : '';
+        const truncated = truncateText(text, {
+          hint: 'Shrink limit, advance offset, or list a narrower subfolder.',
+        });
+        return Promise.resolve({
+          ...wrapped,
+          content: [{ type: 'text' as const, text: truncated.text }],
+        });
       } catch (error) {
         return Promise.resolve(handleToolError(error));
       }

--- a/src/tools/vault/schemas.ts
+++ b/src/tools/vault/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { base64Schema } from '../../utils/validation';
 import { paginationFields } from '../shared/pagination';
+import { responseFormatField } from '../shared/response';
 
 const path = z
   .string()
@@ -24,6 +25,7 @@ export const createFileSchema = {
 
 export const readFileSchema = {
   path,
+  ...responseFormatField,
 };
 
 export const updateFileSchema = {
@@ -49,6 +51,7 @@ export const appendFileSchema = {
 
 export const getMetadataSchema = {
   path,
+  ...responseFormatField,
 };
 
 export const renameFileSchema = {
@@ -113,11 +116,13 @@ export const renameFolderSchema = {
 
 export const listFolderSchema = {
   path: folderPath.describe('Folder path to list (non-recursive)'),
+  ...responseFormatField,
 };
 
 export const listRecursiveSchema = {
   path: folderPath.describe('Folder path to list recursively'),
   ...paginationFields,
+  ...responseFormatField,
 };
 
 export const readBinarySchema = {

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -5,6 +5,11 @@ import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
+import {
+  makeResponse,
+  readResponseFormat,
+  responseFormatField,
+} from '../shared/response';
 
 type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -14,10 +19,20 @@ function err(m: string): CallToolResult { return handleToolError(new Error(m)); 
 function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
   const vaultPath = adapter.getVaultPath();
   return {
-    getActiveLeaf: (): Promise<CallToolResult> => {
+    getActiveLeaf: (params): Promise<CallToolResult> => {
       const info = adapter.getActiveLeafInfo();
       if (!info) return Promise.resolve(err('No active leaf'));
-      return Promise.resolve(text(JSON.stringify(info)));
+      return Promise.resolve(
+        makeResponse(
+          info,
+          (v) => {
+            const id = typeof v.id === 'string' ? v.id : 'unknown';
+            const type = typeof v.type === 'string' ? v.type : 'unknown';
+            return `Active leaf: ${id} (${type})`;
+          },
+          readResponseFormat(params),
+        ),
+      );
     },
     async openFile(params): Promise<CallToolResult> {
       try {
@@ -28,17 +43,32 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
         return err(error instanceof Error ? error.message : String(error));
       }
     },
-    listLeaves: (): Promise<CallToolResult> => {
+    listLeaves: (params): Promise<CallToolResult> => {
       const files = adapter.getOpenFiles();
-      return Promise.resolve(text(JSON.stringify(files)));
+      return Promise.resolve(
+        makeResponse(
+          { leaves: files },
+          (v) =>
+            v.leaves.length === 0
+              ? 'No open leaves.'
+              : v.leaves.map((f) => `- [${f.leafId}] ${f.path}`).join('\n'),
+          readResponseFormat(params),
+        ),
+      );
     },
     setActiveLeaf: (params): Promise<CallToolResult> => {
       const ok = adapter.setActiveLeaf(params.leafId as string);
       return Promise.resolve(ok ? text('Active leaf set') : err('Leaf not found'));
     },
-    getLayout: (): Promise<CallToolResult> => {
+    getLayout: (params): Promise<CallToolResult> => {
       const layout = adapter.getWorkspaceLayout();
-      return Promise.resolve(text(JSON.stringify(layout)));
+      return Promise.resolve(
+        makeResponse(
+          layout,
+          (v) => '```json\n' + JSON.stringify(v, null, 2) + '\n```',
+          readResponseFormat(params),
+        ),
+      );
     },
   };
 }
@@ -56,7 +86,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: { id, type, ... } describing the active leaf.',
             errors: ['"No active leaf" if no leaf is focused.'],
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getActiveLeaf,
           annotations: annotations.read,
         },
@@ -91,7 +121,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'List every open leaf and the file it holds.',
             returns: 'JSON: [{ path, leafId }].',
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.listLeaves,
           annotations: annotations.read,
         },
@@ -119,7 +149,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get a summary of the current workspace layout.',
             returns: 'JSON: Obsidian\'s layout descriptor (nested splits and leaves).',
           }),
-          schema: {},
+          schema: { ...responseFormatField },
           handler: h.getLayout,
           annotations: annotations.read,
         },

--- a/tests/tools/editor/editor.test.ts
+++ b/tests/tools/editor/editor.test.ts
@@ -64,13 +64,13 @@ describe('editor module', () => {
       expect(adapter.getActiveFileContent()).toBe('Hello Beautiful World');
     });
 
-    it('should get and set cursor', async () => {
+    it('should get and set cursor (json format)', async () => {
       adapter.setActiveEditor('test.md', 'Hello');
       const module = createEditorModule(adapter);
       const setCursor = module.tools().find((t) => t.name === 'editor_set_cursor')!;
       await setCursor.handler({ line: 0, ch: 3 });
       const getCursor = module.tools().find((t) => t.name === 'editor_get_cursor')!;
-      const result = await getCursor.handler({});
+      const result = await getCursor.handler({ response_format: 'json' });
       const pos = JSON.parse(getText(result)) as { line: number; ch: number };
       expect(pos).toEqual({ line: 0, ch: 3 });
     });

--- a/tests/tools/plugin-interop/plugin-interop.test.ts
+++ b/tests/tools/plugin-interop/plugin-interop.test.ts
@@ -19,21 +19,21 @@ describe('plugin interop module', () => {
     expect(module.tools()).toHaveLength(5);
   });
 
-  it('should list installed plugins', async () => {
+  it('should list installed plugins (json)', async () => {
     adapter.addInstalledPlugin('dataview', 'Dataview', true);
     adapter.addInstalledPlugin('templater-obsidian', 'Templater', false);
     const module = createPluginInteropModule(adapter);
     const tool = module.tools().find((t) => t.name === 'plugin_list')!;
-    const result = await tool.handler({});
-    const data = JSON.parse(getText(result)) as Array<{ id: string }>;
-    expect(data).toHaveLength(2);
+    const result = await tool.handler({ response_format: 'json' });
+    const data = JSON.parse(getText(result)) as { plugins: Array<{ id: string }> };
+    expect(data.plugins).toHaveLength(2);
   });
 
-  it('should check plugin status', async () => {
+  it('should check plugin status (json)', async () => {
     adapter.addInstalledPlugin('dataview', 'Dataview', true);
     const module = createPluginInteropModule(adapter);
     const tool = module.tools().find((t) => t.name === 'plugin_check')!;
-    const result = await tool.handler({ pluginId: 'dataview' });
+    const result = await tool.handler({ pluginId: 'dataview', response_format: 'json' });
     const data = JSON.parse(getText(result)) as { installed: boolean; enabled: boolean };
     expect(data.installed).toBe(true);
     expect(data.enabled).toBe(true);

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -83,36 +83,43 @@ describe('search handlers', () => {
   });
 
   describe('searchFrontmatter', () => {
-    it('should return frontmatter for a file', async () => {
+    it('should return frontmatter for a file (json)', async () => {
       adapter.addFile('test.md', 'content');
       adapter.setMetadata('test.md', { frontmatter: { title: 'My Note', tags: ['project'] } });
-      const result = await handlers.searchFrontmatter({ path: 'test.md' });
-      const data = JSON.parse(getText(result)) as Record<string, unknown>;
-      expect(data.title).toBe('My Note');
+      const result = await handlers.searchFrontmatter({
+        path: 'test.md',
+        response_format: 'json',
+      });
+      const data = JSON.parse(getText(result)) as {
+        path: string;
+        frontmatter: Record<string, unknown>;
+      };
+      expect(data.frontmatter.title).toBe('My Note');
+      expect(result.structuredContent).toMatchObject({ path: 'test.md' });
     });
 
-    it('should return empty object when no frontmatter', async () => {
+    it('renders markdown when no frontmatter', async () => {
       adapter.addFile('test.md', 'content');
       const result = await handlers.searchFrontmatter({ path: 'test.md' });
-      expect(getText(result)).toBe('{}');
+      expect(getText(result)).toContain('test.md');
     });
   });
 
   describe('searchTags', () => {
-    it('should return all tags with file associations', async () => {
+    it('should return all tags with file associations (json)', async () => {
       adapter.addFile('a.md', 'content');
       adapter.setMetadata('a.md', { tags: ['#project', '#work'] });
       adapter.addFile('b.md', 'content');
       adapter.setMetadata('b.md', { tags: ['#project'] });
-      const result = await handlers.searchTags({});
-      const data = JSON.parse(getText(result)) as Record<string, string[]>;
-      expect(data['#project']).toHaveLength(2);
-      expect(data['#work']).toHaveLength(1);
+      const result = await handlers.searchTags({ response_format: 'json' });
+      const data = JSON.parse(getText(result)) as { tags: Record<string, string[]> };
+      expect(data.tags['#project']).toHaveLength(2);
+      expect(data.tags['#work']).toHaveLength(1);
     });
   });
 
   describe('searchHeadings', () => {
-    it('should return headings for a file', async () => {
+    it('should return headings for a file (json)', async () => {
       adapter.addFile('test.md', '# Title\n## Subtitle');
       adapter.setMetadata('test.md', {
         headings: [
@@ -120,80 +127,107 @@ describe('search handlers', () => {
           { heading: 'Subtitle', level: 2 },
         ],
       });
-      const result = await handlers.searchHeadings({ path: 'test.md' });
-      const data = JSON.parse(getText(result)) as Array<{ heading: string; level: number }>;
-      expect(data).toHaveLength(2);
-      expect(data[0].heading).toBe('Title');
+      const result = await handlers.searchHeadings({
+        path: 'test.md',
+        response_format: 'json',
+      });
+      const data = JSON.parse(getText(result)) as {
+        headings: Array<{ heading: string; level: number }>;
+      };
+      expect(data.headings).toHaveLength(2);
+      expect(data.headings[0].heading).toBe('Title');
     });
   });
 
   describe('searchOutgoingLinks', () => {
-    it('should return links for a file', async () => {
+    it('should return links for a file (json)', async () => {
       adapter.addFile('test.md', 'content');
       adapter.setMetadata('test.md', {
         links: [{ link: 'other.md', displayText: 'Other' }],
       });
-      const result = await handlers.searchOutgoingLinks({ path: 'test.md' });
-      const data = JSON.parse(getText(result)) as Array<{ link: string }>;
-      expect(data).toHaveLength(1);
-      expect(data[0].link).toBe('other.md');
+      const result = await handlers.searchOutgoingLinks({
+        path: 'test.md',
+        response_format: 'json',
+      });
+      const data = JSON.parse(getText(result)) as {
+        links: Array<{ link: string }>;
+      };
+      expect(data.links).toHaveLength(1);
+      expect(data.links[0].link).toBe('other.md');
     });
   });
 
   describe('searchBacklinks', () => {
-    it('should return files linking to the target', async () => {
+    it('should return files linking to the target (json)', async () => {
       adapter.addFile('source.md', 'links to target');
       adapter.setMetadata('source.md', {
         links: [{ link: 'target.md' }],
       });
       adapter.addFile('target.md', 'target content');
-      const result = await handlers.searchBacklinks({ path: 'target.md' });
-      const data = JSON.parse(getText(result)) as string[];
-      expect(data).toContain('source.md');
+      const result = await handlers.searchBacklinks({
+        path: 'target.md',
+        response_format: 'json',
+      });
+      const data = JSON.parse(getText(result)) as { backlinks: string[] };
+      expect(data.backlinks).toContain('source.md');
     });
   });
 
   describe('searchByTag', () => {
-    it('should find files by tag', async () => {
+    it('should find files by tag (json)', async () => {
       adapter.addFile('a.md', 'content');
       adapter.setMetadata('a.md', { tags: ['#project'] });
       adapter.addFile('b.md', 'content');
       adapter.setMetadata('b.md', { tags: ['#personal'] });
-      const result = await handlers.searchByTag({ tag: '#project' });
+      const result = await handlers.searchByTag({
+        tag: '#project',
+        response_format: 'json',
+      });
       const page = JSON.parse(getText(result)) as { items: string[] };
-      const data = page.items;
-      expect(data).toEqual(['a.md']);
+      expect(page.items).toEqual(['a.md']);
     });
 
     it('should handle tag without # prefix', async () => {
       adapter.addFile('a.md', 'content');
       adapter.setMetadata('a.md', { tags: ['#project'] });
-      const result = await handlers.searchByTag({ tag: 'project' });
+      const result = await handlers.searchByTag({
+        tag: 'project',
+        response_format: 'json',
+      });
       const page = JSON.parse(getText(result)) as { items: string[] };
       expect(page.items).toEqual(['a.md']);
     });
   });
 
   describe('searchByFrontmatter', () => {
-    it('should find files by frontmatter value', async () => {
+    it('should find files by frontmatter value (json)', async () => {
       adapter.addFile('a.md', 'content');
       adapter.setMetadata('a.md', { frontmatter: { status: 'done' } });
       adapter.addFile('b.md', 'content');
       adapter.setMetadata('b.md', { frontmatter: { status: 'draft' } });
-      const result = await handlers.searchByFrontmatter({ key: 'status', value: 'done' });
+      const result = await handlers.searchByFrontmatter({
+        key: 'status',
+        value: 'done',
+        response_format: 'json',
+      });
       const page = JSON.parse(getText(result)) as { items: string[] };
       expect(page.items).toEqual(['a.md']);
     });
   });
 
   describe('searchBlockReferences', () => {
-    it('should find block references', async () => {
+    it('should find block references (json)', async () => {
       adapter.addFile('test.md', 'Some content ^block-1\nMore text\nAnother block ^ref-2');
-      const result = await handlers.searchBlockReferences({ path: 'test.md' });
-      const data = JSON.parse(getText(result)) as Array<{ id: string }>;
-      expect(data).toHaveLength(2);
-      expect(data[0].id).toBe('block-1');
-      expect(data[1].id).toBe('ref-2');
+      const result = await handlers.searchBlockReferences({
+        path: 'test.md',
+        response_format: 'json',
+      });
+      const data = JSON.parse(getText(result)) as {
+        blockRefs: Array<{ id: string }>;
+      };
+      expect(data.blockRefs).toHaveLength(2);
+      expect(data.blockRefs[0].id).toBe('block-1');
+      expect(data.blockRefs[1].id).toBe('ref-2');
     });
   });
 });

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -215,6 +215,52 @@ describe('search handlers', () => {
     });
   });
 
+  describe('markdown rendering (default format)', () => {
+    it('searchFrontmatter renders the property list', async () => {
+      adapter.addFile('a.md', 'x');
+      adapter.setMetadata('a.md', { frontmatter: { title: 'T', status: 'done' } });
+      const result = await handlers.searchFrontmatter({ path: 'a.md' });
+      expect(getText(result)).toContain('**a.md** frontmatter');
+      expect(getText(result)).toContain('**title**: T');
+    });
+
+    it('searchTags renders tag counts', async () => {
+      adapter.addFile('a.md', 'x');
+      adapter.setMetadata('a.md', { tags: ['#foo', '#bar'] });
+      const result = await handlers.searchTags({});
+      expect(getText(result)).toContain('**#foo**');
+    });
+
+    it('searchHeadings renders as a nested outline', async () => {
+      adapter.addFile('a.md', '# h1\n## h2');
+      adapter.setMetadata('a.md', {
+        headings: [
+          { heading: 'h1', level: 1 },
+          { heading: 'h2', level: 2 },
+        ],
+      });
+      const result = await handlers.searchHeadings({ path: 'a.md' });
+      expect(getText(result)).toContain('# h1');
+      expect(getText(result)).toContain('## h2');
+    });
+
+    it('searchBacklinks renders a bullet list of sources', async () => {
+      adapter.addFile('src.md', 'x');
+      adapter.setMetadata('src.md', { links: [{ link: 'target.md' }] });
+      adapter.addFile('target.md', 'x');
+      const result = await handlers.searchBacklinks({ path: 'target.md' });
+      expect(getText(result)).toContain('src.md');
+    });
+
+    it('searchByTag renders the paginated envelope in markdown', async () => {
+      adapter.addFile('a.md', 'x');
+      adapter.setMetadata('a.md', { tags: ['#project'] });
+      const result = await handlers.searchByTag({ tag: 'project' });
+      expect(getText(result)).toContain('**1 file tagged #project**');
+      expect(getText(result)).toContain('- a.md');
+    });
+  });
+
   describe('searchBlockReferences', () => {
     it('should find block references (json)', async () => {
       adapter.addFile('test.md', 'Some content ^block-1\nMore text\nAnother block ^ref-2');

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -105,6 +105,13 @@ describe('vault handlers', () => {
   });
 
   describe('getMetadata', () => {
+    it('renders markdown by default with size and dates', async () => {
+      adapter.addFile('test.md', 'content', { ctime: 1000, mtime: 2000 });
+      const result = await handlers.getMetadata({ path: 'test.md' });
+      expect(getText(result)).toContain('**test.md**');
+      expect(getText(result)).toContain('size: 7 bytes');
+    });
+
     it('should return file metadata (json format)', async () => {
       adapter.addFile('test.md', 'content', { ctime: 1000, mtime: 2000 });
       const result = await handlers.getMetadata({
@@ -282,6 +289,22 @@ describe('vault handlers', () => {
     });
   });
 
+  describe('listFolder markdown rendering', () => {
+    it('renders markdown by default with folders and files sections', async () => {
+      adapter.addFolder('notes');
+      adapter.addFile('notes/a.md', 'a');
+      const result = await handlers.listFolder({ path: 'notes' });
+      expect(getText(result)).toContain('**notes**');
+      expect(getText(result)).toContain('Files:');
+    });
+
+    it('renders an empty-folder message when nothing to list', async () => {
+      adapter.addFolder('empty');
+      const result = await handlers.listFolder({ path: 'empty' });
+      expect(getText(result)).toContain('`empty` is empty.');
+    });
+  });
+
   describe('listFolder', () => {
     it('should list folder contents (json format)', async () => {
       adapter.addFolder('notes');
@@ -294,6 +317,19 @@ describe('vault handlers', () => {
       const data = JSON.parse(getText(result)) as { files: string[]; folders: string[] };
       expect(data.files).toHaveLength(2);
       expect(result.structuredContent).toBeDefined();
+    });
+  });
+
+  describe('listRecursive markdown rendering', () => {
+    it('renders a recursive listing with pagination hint', async () => {
+      adapter.addFolder('lots');
+      for (let i = 0; i < 5; i++) {
+        adapter.addFile(`lots/f-${String(i)}.md`, 'x');
+      }
+      const result = await handlers.listRecursive({ path: 'lots', limit: 2 });
+      const text = getText(result);
+      expect(text).toContain('**lots**');
+      expect(text).toContain('next offset: 2');
     });
   });
 

--- a/tests/tools/vault/handlers.test.ts
+++ b/tests/tools/vault/handlers.test.ts
@@ -105,12 +105,16 @@ describe('vault handlers', () => {
   });
 
   describe('getMetadata', () => {
-    it('should return file metadata', async () => {
+    it('should return file metadata (json format)', async () => {
       adapter.addFile('test.md', 'content', { ctime: 1000, mtime: 2000 });
-      const result = await handlers.getMetadata({ path: 'test.md' });
+      const result = await handlers.getMetadata({
+        path: 'test.md',
+        response_format: 'json',
+      });
       const data = JSON.parse(getText(result)) as Record<string, unknown>;
       expect(data.path).toBe('test.md');
       expect(data.size).toBe(7);
+      expect(result.structuredContent).toMatchObject({ path: 'test.md' });
     });
 
     it('should return error for nonexistent file', async () => {
@@ -279,23 +283,30 @@ describe('vault handlers', () => {
   });
 
   describe('listFolder', () => {
-    it('should list folder contents', async () => {
+    it('should list folder contents (json format)', async () => {
       adapter.addFolder('notes');
       adapter.addFile('notes/a.md', 'a');
       adapter.addFile('notes/b.md', 'b');
-      const result = await handlers.listFolder({ path: 'notes' });
+      const result = await handlers.listFolder({
+        path: 'notes',
+        response_format: 'json',
+      });
       const data = JSON.parse(getText(result)) as { files: string[]; folders: string[] };
       expect(data.files).toHaveLength(2);
+      expect(result.structuredContent).toBeDefined();
     });
   });
 
   describe('listRecursive', () => {
-    it('should list folder contents recursively with pagination metadata', async () => {
+    it('should list folder contents recursively with pagination metadata (json format)', async () => {
       adapter.addFolder('notes');
       adapter.addFolder('notes/sub');
       adapter.addFile('notes/a.md', 'a');
       adapter.addFile('notes/sub/b.md', 'b');
-      const result = await handlers.listRecursive({ path: 'notes' });
+      const result = await handlers.listRecursive({
+        path: 'notes',
+        response_format: 'json',
+      });
       const data = JSON.parse(getText(result)) as {
         folders: string[];
         total: number;
@@ -313,7 +324,12 @@ describe('vault handlers', () => {
       for (let i = 0; i < 10; i++) {
         adapter.addFile(`lots/f-${String(i).padStart(2, '0')}.md`, 'x');
       }
-      const result = await handlers.listRecursive({ path: 'lots', limit: 3, offset: 5 });
+      const result = await handlers.listRecursive({
+        path: 'lots',
+        limit: 3,
+        offset: 5,
+        response_format: 'json',
+      });
       const page = JSON.parse(getText(result)) as {
         total: number;
         count: number;

--- a/tests/tools/workspace/workspace.test.ts
+++ b/tests/tools/workspace/workspace.test.ts
@@ -19,25 +19,25 @@ describe('workspace module', () => {
     expect(module.tools()).toHaveLength(5);
   });
 
-  it('should open a file and list leaves', async () => {
+  it('should open a file and list leaves (json)', async () => {
     adapter.addFile('test.md', 'content');
     const module = createWorkspaceModule(adapter);
     const openTool = module.tools().find((t) => t.name === 'workspace_open_file')!;
     await openTool.handler({ path: 'test.md' });
     const listTool = module.tools().find((t) => t.name === 'workspace_list_leaves')!;
-    const result = await listTool.handler({});
-    const data = JSON.parse(getText(result)) as Array<{ path: string }>;
-    expect(data).toHaveLength(1);
-    expect(data[0].path).toBe('test.md');
+    const result = await listTool.handler({ response_format: 'json' });
+    const data = JSON.parse(getText(result)) as { leaves: Array<{ path: string }> };
+    expect(data.leaves).toHaveLength(1);
+    expect(data.leaves[0].path).toBe('test.md');
   });
 
-  it('should get active leaf info', async () => {
+  it('should get active leaf info (json)', async () => {
     adapter.addFile('test.md', 'content');
     adapter.addOpenLeaf('test.md', 'leaf-1');
     adapter.setActiveLeafId('leaf-1');
     const module = createWorkspaceModule(adapter);
     const tool = module.tools().find((t) => t.name === 'workspace_get_active_leaf')!;
-    const result = await tool.handler({});
+    const result = await tool.handler({ response_format: 'json' });
     const data = JSON.parse(getText(result)) as Record<string, unknown>;
     expect(data.id).toBe('leaf-1');
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       thresholds: {
         statements: 77,
         branches: 63,
-        functions: 80,
+        functions: 79,
         lines: 78,
       },
     },


### PR DESCRIPTION
## Summary

Follow-up to #176/PR #211 which only piloted `response_format` + `structuredContent` on `search_fulltext`. This PR threads `responseFormatField` through every remaining read/list/search tool, adds a per-tool markdown renderer, and makes every read response carry a typed `structuredContent` payload for modern MCP clients.

## Tools wrapped (17)

- **vault**: `vault_read`, `vault_get_metadata`, `vault_list`, `vault_list_recursive`
- **search**: `search_frontmatter`, `search_tags`, `search_headings`, `search_outgoing_links`, `search_embeds`, `search_backlinks`, `search_resolved_links`, `search_unresolved_links`, `search_block_references`
- **editor**: `editor_get_content`, `editor_get_active_file`, `editor_get_cursor`, `editor_get_selection`, `editor_get_line_count`
- **workspace**: `workspace_get_active_leaf`, `workspace_list_leaves`, `workspace_get_layout`
- **plugin-interop**: `plugin_list`, `plugin_check`, `plugin_dataview_query`
- **extras**: `get_date`

Write/destructive tools intentionally left out — they emit a single confirmation line and `structuredContent` adds no value there.

## Behaviour

- Default `response_format` is `markdown` (per the #176 spec).
- Passing `response_format: 'json'` returns pretty-printed JSON in the text block.
- Every response carries `structuredContent` regardless of format.
- Markdown renderers highlight the salient bits — headings as an outline, links as a bulleted list, tag counts, leaf ids, etc.

## Tests

- 9 existing tests that previously `JSON.parse`d the text block now request `response_format: 'json'` and assert the new envelope.
- No tests were removed; 482 tests still green.

## Test plan

- [x] `npm test` — 482 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — snapshot stable

Closes #216