### PR TITLE
refactor(registry): add generic ToolDefinition<Shape> + defineTool() helper

### DIFF
--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -3,12 +3,49 @@ import { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types
 
 export type { ToolAnnotations };
 
-export interface ToolDefinition {
+/**
+ * Inferred parameter type for a handler whose schema is `Shape` — the
+ * resolved output of `z.object(Shape).parse(...)` in the dispatcher.
+ */
+export type InferredParams<Shape extends z.ZodRawShape> = z.infer<
+  z.ZodObject<Shape>
+>;
+
+/**
+ * A tool's public contract. Generic over `Shape` so each handler can be
+ * typed against its own schema. `tools(): ToolDefinition[]` erases the
+ * generic at the module boundary — the dispatcher then treats every
+ * `handler` uniformly via the `TypedHandler` alias below.
+ */
+export interface ToolDefinition<
+  Shape extends z.ZodRawShape = z.ZodRawShape,
+> {
   name: string;
   description: string;
-  schema: Record<string, z.ZodType>;
-  handler: (params: Record<string, unknown>) => Promise<CallToolResult>;
+  schema: Shape;
+  handler: TypedHandler<Shape>;
   annotations: ToolAnnotations;
+}
+
+export type TypedHandler<Shape extends z.ZodRawShape> = (
+  params: InferredParams<Shape>,
+) => Promise<CallToolResult>;
+
+/**
+ * Define a single tool with full schema-driven type-checking on its handler
+ * — `schema` infers `Shape`, then `handler`'s `params` is typed as
+ * `z.infer<z.ZodObject<Shape>>`. Returns the erased `ToolDefinition` so
+ * modules can collect mixed-shape tools into a single array.
+ *
+ * Callers that want a handler defined in a separate factory (e.g.
+ * `createHandlers()`) can keep the untyped signature and pass the
+ * function here — TS still checks the schema and the handler's return
+ * type. The generic form below is the preferred one for new code.
+ */
+export function defineTool<Shape extends z.ZodRawShape>(
+  def: ToolDefinition<Shape>,
+): ToolDefinition {
+  return def as unknown as ToolDefinition;
 }
 
 /**


### PR DESCRIPTION
## Summary

First slice of #217: lay down the generic infrastructure for type-safe tool handlers.

- `ToolDefinition<Shape extends z.ZodRawShape = z.ZodRawShape>` — each tool's handler can now be typed against its own schema via `z.infer<z.ZodObject<Shape>>`.
- `defineTool()` helper — infers `Shape` from `schema` and type-checks `handler`'s `params` at the definition site. Returns the erased `ToolDefinition` so modules can keep collecting mixed-shape tools into one array.
- `InferredParams<Shape>` + `TypedHandler<Shape>` type aliases for downstream consumers.

Dispatcher behaviour is unchanged — the erased form still carries the same runtime contract.

## What's NOT in this PR

The issue's "zero `as string | number | boolean` casts on `params.*`" acceptance item needs per-module migration: each `createHandlers()` factory currently returns `Record<string, Handler>` with an erased signature, which throws away the schema type. Migrating requires per-method typed signatures in every handler module (vault, search, editor, workspace, templates, plugin-interop, extras).

This PR lands only the infrastructure. The migration is mechanical but touches every tool file and interacts with the pending PR #219 (makeResponse rollout) — it's cleaner to merge the infra first and do the cast removal in follow-up PRs, one module at a time.

## Test plan

- [x] `npm test` — 482 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `defineTool({ schema, handler })` — TS catches a handler that reads a field not in the schema (verified locally)

Progress on #217.