### PR TITLE
test(ci): ratchet coverage thresholds upward (78/66/79/79)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,14 +13,17 @@ export default defineConfig({
       // Obsidian's runtime and require a real app. Leaving it out until we
       // can drive Obsidian headlessly; everything else is in scope.
       exclude: ['src/obsidian/adapter.ts'],
-      // Thresholds are set a few points below the current coverage floor so
-      // meaningful regressions (>~1-2%) fail CI while we ratchet up from
-      // here. See GitHub issue #187 for the aspirational targets.
+      // Thresholds ratchet upward as coverage grows. The aim is to catch
+      // meaningful regressions (~1-2%) without flapping on small changes,
+      // and to close the gap with the aspirational 75/85/85/85 target over
+      // a handful of PRs. Current floor on main: ~78/67/79/79 with the
+      // makeResponse rollout landed; numbers below are the floor minus a
+      // small buffer. See GitHub issues #187 + #218 for the history.
       thresholds: {
-        statements: 77,
-        branches: 63,
+        statements: 78,
+        branches: 66,
         functions: 79,
-        lines: 78,
+        lines: 79,
       },
     },
   },


### PR DESCRIPTION
## Summary

Raise the thresholds in `vitest.config.ts` from **77/63/80/78** to **78/66/79/79**.

## Why these numbers

The floor has moved since #187 set the original thresholds:

| Scenario | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| Current main (pre-#219) | 79.79 | 69.95 | 82.75 | 80.99 |
| With PR #219 rollout stacked | 78.35 | 67.21 | 79.46 | 79.89 |
| **New threshold** | **78** | **66** | **79** | **79** |

The new numbers sit safely below both scenarios, so #219 can merge before or after this PR without flapping. Branches gets the biggest bump (63 → 66) because explicit markdown-path assertions have pushed it hardest. Functions stays at 79 to match the value PR #219 already adjusted to.

## What's still deferred

- **`adapter.ts` coverage** — still excluded (still ~0%); getting it on the board needs a headless-Obsidian test harness. Separate piece of work.
- **Aspirational 75/85/85/85 targets** from #187 — a future ratchet can bump closer once the remaining renderer / handler tests land.

## Test plan

- [x] `npm run test:coverage` — exits 0 with the new thresholds
- [x] `npm test` — 482 passing
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean

Closes #218