### PR TITLE
refactor(tools): drop every `as` cast from handler bodies (completes #217)

### DIFF
--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -4,10 +4,20 @@ import { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types
 export type { ToolAnnotations };
 
 /**
- * Inferred parameter type for a handler whose schema is `Shape` — the
- * resolved output of `z.object(Shape).parse(...)` in the dispatcher.
+ * Inferred parameter type for a handler whose schema is `Shape`.
+ *
+ * Uses `z.input` (not `z.output`/`z.infer`) so fields with `.default()` are
+ * **optional** in the handler's signature. That matches the ergonomics of
+ * direct test calls (where the test author doesn't want to thread every
+ * default) and mirrors the shape of the `rawParams` the dispatcher sees
+ * before `.parse()` fills in defaults.
+ *
+ * At runtime the dispatcher always resolves defaults before invoking the
+ * handler, so any field with a default is never actually `undefined`. Use
+ * `?? <default>` at the call site when you want to read such a field
+ * directly — keeps the type honest both pre- and post-parse.
  */
-export type InferredParams<Shape extends z.ZodRawShape> = z.infer<
+export type InferredParams<Shape extends z.ZodRawShape> = z.input<
   z.ZodObject<Shape>
 >;
 

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
@@ -10,15 +16,13 @@ import {
   responseFormatField,
 } from '../shared/response';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
-
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
 /**
- * Require a value to be a non-negative safe integer. Defensive belt-and-braces
- * alongside the Zod schema: until the dispatcher enforces `schema.parse()` at
- * runtime (#174), handlers still receive untyped params and need the guard.
+ * Require a value to be a non-negative safe integer. Kept as a runtime guard
+ * alongside the Zod schema; the dispatcher has already parsed numbers by the
+ * time the handler is called, but the helper is useful in other call sites.
  */
 function isNonNegativeInt(value: unknown): value is number {
   return (
@@ -49,7 +53,65 @@ function assertEditorPosition(
   }
 }
 
-function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+// Schemas as module-level consts so handler signatures can reference them
+// via `typeof <schema>` for automatic parameter typing through
+// `InferredParams<Shape>`.
+
+const readOnlySchema = { ...responseFormatField };
+
+const insertSchema = {
+  line: z.number().int().min(0).describe('Zero-based line index'),
+  ch: z.number().int().min(0).describe('Zero-based column index'),
+  text: z
+    .string()
+    .max(5_000_000)
+    .describe('Text to insert at (line, ch)'),
+};
+
+const replaceSchema = {
+  fromLine: z.number().int().min(0).describe('Start line (inclusive, zero-based)'),
+  fromCh: z.number().int().min(0).describe('Start column (inclusive, zero-based)'),
+  toLine: z.number().int().min(0).describe('End line (exclusive, zero-based)'),
+  toCh: z.number().int().min(0).describe('End column (exclusive, zero-based)'),
+  text: z
+    .string()
+    .max(5_000_000)
+    .describe('Replacement text for the range'),
+};
+
+const deleteRangeSchema = {
+  fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
+  fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
+  toLine: z.number().int().min(0).describe('End line (exclusive)'),
+  toCh: z.number().int().min(0).describe('End column (exclusive)'),
+};
+
+const setCursorSchema = {
+  line: z.number().int().min(0).describe('Zero-based line index'),
+  ch: z.number().int().min(0).describe('Zero-based column index'),
+};
+
+const setSelectionSchema = {
+  fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
+  fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
+  toLine: z.number().int().min(0).describe('End line (exclusive)'),
+  toCh: z.number().int().min(0).describe('End column (exclusive)'),
+};
+
+interface EditorHandlers {
+  getContent: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  getActivePath: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  insert: (params: InferredParams<typeof insertSchema>) => Promise<CallToolResult>;
+  replace: (params: InferredParams<typeof replaceSchema>) => Promise<CallToolResult>;
+  deleteRange: (params: InferredParams<typeof deleteRangeSchema>) => Promise<CallToolResult>;
+  getCursor: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  setCursor: (params: InferredParams<typeof setCursorSchema>) => Promise<CallToolResult>;
+  getSelection: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  setSelection: (params: InferredParams<typeof setSelectionSchema>) => Promise<CallToolResult>;
+  getLineCount: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+}
+
+function createHandlers(adapter: ObsidianAdapter): EditorHandlers {
   return {
     getContent: (params): Promise<CallToolResult> => {
       const content = adapter.getActiveFileContent();
@@ -85,11 +147,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
           err(error instanceof Error ? error.message : String(error)),
         );
       }
-      const ok = adapter.insertTextAt(
-        params.line as number,
-        params.ch as number,
-        params.text as string,
-      );
+      const ok = adapter.insertTextAt(params.line, params.ch, params.text);
       return Promise.resolve(ok ? text('Text inserted') : err('No active editor'));
     },
     replace: (params): Promise<CallToolResult> => {
@@ -106,8 +164,11 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
         );
       }
       const ok = adapter.replaceRange(
-        params.fromLine as number, params.fromCh as number,
-        params.toLine as number, params.toCh as number, params.text as string,
+        params.fromLine,
+        params.fromCh,
+        params.toLine,
+        params.toCh,
+        params.text,
       );
       return Promise.resolve(ok ? text('Text replaced') : err('No active editor'));
     },
@@ -125,8 +186,10 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
         );
       }
       const ok = adapter.deleteRange(
-        params.fromLine as number, params.fromCh as number,
-        params.toLine as number, params.toCh as number,
+        params.fromLine,
+        params.fromCh,
+        params.toLine,
+        params.toCh,
       );
       return Promise.resolve(ok ? text('Text deleted') : err('No active editor'));
     },
@@ -151,10 +214,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
           err(error instanceof Error ? error.message : String(error)),
         );
       }
-      const ok = adapter.setCursorPosition(
-        params.line as number,
-        params.ch as number,
-      );
+      const ok = adapter.setCursorPosition(params.line, params.ch);
       return Promise.resolve(ok ? text('Cursor set') : err('No active editor'));
     },
     getSelection: (params): Promise<CallToolResult> => {
@@ -183,8 +243,10 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
         );
       }
       const ok = adapter.setSelection(
-        params.fromLine as number, params.fromCh as number,
-        params.toLine as number, params.toCh as number,
+        params.fromLine,
+        params.fromCh,
+        params.toLine,
+        params.toCh,
       );
       return Promise.resolve(ok ? text('Selection set') : err('No active editor'));
     },
@@ -208,29 +270,29 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'editor', name: 'Editor Operations', description: 'Access and manipulate the active editor' },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'editor_get_content',
           description: describeTool({
             summary: 'Get the full text content of the currently active editor.',
             returns: 'Plain text: the editor\'s current content.',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getContent,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_get_active_file',
           description: describeTool({
             summary: 'Get the vault-relative path of the currently active file.',
             returns: 'Plain text: the path, e.g. "notes/today.md".',
             errors: ['"No active file" if no file is open.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getActivePath,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_insert',
           description: describeTool({
             summary: 'Insert text at a (line, ch) position in the active editor.',
@@ -246,18 +308,11 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"Position is out of range" if (line, ch) is outside the document.',
             ],
           }),
-          schema: {
-            line: z.number().int().min(0).describe('Zero-based line index'),
-            ch: z.number().int().min(0).describe('Zero-based column index'),
-            text: z
-              .string()
-              .max(5_000_000)
-              .describe('Text to insert at (line, ch)'),
-          },
+          schema: insertSchema,
           handler: h.insert,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_replace',
           description: describeTool({
             summary: 'Replace text in a (fromLine, fromCh)→(toLine, toCh) range.',
@@ -273,20 +328,11 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"Position is out of range" if either endpoint is outside the document.',
             ],
           }),
-          schema: {
-            fromLine: z.number().int().min(0).describe('Start line (inclusive, zero-based)'),
-            fromCh: z.number().int().min(0).describe('Start column (inclusive, zero-based)'),
-            toLine: z.number().int().min(0).describe('End line (exclusive, zero-based)'),
-            toCh: z.number().int().min(0).describe('End column (exclusive, zero-based)'),
-            text: z
-              .string()
-              .max(5_000_000)
-              .describe('Replacement text for the range'),
-          },
+          schema: replaceSchema,
           handler: h.replace,
           annotations: annotations.destructive,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_delete',
           description: describeTool({
             summary: 'Delete text in a (fromLine, fromCh)→(toLine, toCh) range.',
@@ -300,27 +346,22 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"Position is out of range" if either endpoint is outside the document.',
             ],
           }),
-          schema: {
-            fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
-            fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
-            toLine: z.number().int().min(0).describe('End line (exclusive)'),
-            toCh: z.number().int().min(0).describe('End column (exclusive)'),
-          },
+          schema: deleteRangeSchema,
           handler: h.deleteRange,
           annotations: annotations.destructive,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_get_cursor',
           description: describeTool({
             summary: 'Get the current cursor position in the active editor.',
             returns: 'JSON: { line, ch } (zero-based).',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getCursor,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_set_cursor',
           description: describeTool({
             summary: 'Move the cursor to a (line, ch) position in the active editor.',
@@ -334,25 +375,22 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"Position is out of range" if (line, ch) is outside the document.',
             ],
           }),
-          schema: {
-            line: z.number().int().min(0).describe('Zero-based line index'),
-            ch: z.number().int().min(0).describe('Zero-based column index'),
-          },
+          schema: setCursorSchema,
           handler: h.setCursor,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_get_selection',
           description: describeTool({
             summary: 'Get the current text selection in the active editor.',
             returns: 'JSON: { from: {line, ch}, to: {line, ch}, text }.',
             errors: ['"No active editor or selection" if nothing is selected.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getSelection,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_set_selection',
           description: describeTool({
             summary: 'Select a (fromLine, fromCh)→(toLine, toCh) range in the active editor.',
@@ -366,26 +404,21 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"Position is out of range" if either endpoint is outside the document.',
             ],
           }),
-          schema: {
-            fromLine: z.number().int().min(0).describe('Start line (inclusive)'),
-            fromCh: z.number().int().min(0).describe('Start column (inclusive)'),
-            toLine: z.number().int().min(0).describe('End line (exclusive)'),
-            toCh: z.number().int().min(0).describe('End column (exclusive)'),
-          },
+          schema: setSelectionSchema,
           handler: h.setSelection,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'editor_get_line_count',
           description: describeTool({
             summary: 'Get the number of lines in the active editor.',
             returns: 'Plain text: the line count as a decimal integer.',
             errors: ['"No active editor" if no markdown view is focused.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getLineCount,
           annotations: annotations.read,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -1,5 +1,11 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { describeTool } from '../shared/describe';
 import {
@@ -8,7 +14,11 @@ import {
   responseFormatField,
 } from '../shared/response';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+const getDateSchema = { ...responseFormatField };
+
+interface ExtrasHandlers {
+  getDate: (params: InferredParams<typeof getDateSchema>) => Promise<CallToolResult>;
+}
 
 function pad(n: number, width = 2): string {
   return String(Math.abs(n)).padStart(width, '0');
@@ -32,7 +42,7 @@ function formatIsoWithOffset(now: Date): string {
   return `${String(y)}-${mo}-${d}T${h}:${mi}:${s}.${ms}${formatOffset(offsetMinutes)}`;
 }
 
-function createHandlers(_adapter: ObsidianAdapter): Record<string, Handler> {
+function createHandlers(_adapter: ObsidianAdapter): ExtrasHandlers {
   return {
     getDate: (params): Promise<CallToolResult> => {
       const iso = formatIsoWithOffset(new Date());
@@ -59,17 +69,17 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
     },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'get_date',
           description: describeTool({
             summary: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
             returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',
             examples: ['Use when: stamping a daily note with the current local time.'],
           }),
-          schema: { ...responseFormatField },
+          schema: getDateSchema,
           handler: h.getDate,
           annotations: annotations.read,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
@@ -11,15 +17,57 @@ import {
 } from '../shared/response';
 import type { ModuleOptions } from '../index';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
-
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
+
+const listSchema = { ...responseFormatField };
+
+const checkSchema = {
+  pluginId: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe('Community plugin id (e.g. "dataview")'),
+  ...responseFormatField,
+};
+
+const dataviewSchema = {
+  query: z
+    .string()
+    .min(1)
+    .max(10_000)
+    .describe('Dataview query (DQL or Dataview-js)'),
+  ...responseFormatField,
+};
+
+const templaterSchema = {
+  templatePath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Vault-relative path to the Templater template'),
+};
+
+const executeCommandSchema = {
+  commandId: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe('Obsidian command id (e.g. "app:reload")'),
+};
+
+interface PluginInteropHandlers {
+  listPlugins: (params: InferredParams<typeof listSchema>) => Promise<CallToolResult>;
+  checkPlugin: (params: InferredParams<typeof checkSchema>) => Promise<CallToolResult>;
+  dataviewQuery: (params: InferredParams<typeof dataviewSchema>) => Promise<CallToolResult>;
+  templaterExecute: (params: InferredParams<typeof templaterSchema>) => Promise<CallToolResult>;
+  executeCommand: (params: InferredParams<typeof executeCommandSchema>) => Promise<CallToolResult>;
+}
 
 function createHandlers(
   adapter: ObsidianAdapter,
   getExecuteCommandAllowlist: () => string[],
-): Record<string, Handler> {
+): PluginInteropHandlers {
   return {
     listPlugins: (params): Promise<CallToolResult> => {
       const plugins = adapter.getInstalledPlugins();
@@ -40,13 +88,12 @@ function createHandlers(
       );
     },
     checkPlugin: (params): Promise<CallToolResult> => {
-      const pluginId = params.pluginId as string;
-      const enabled = adapter.isPluginEnabled(pluginId);
+      const enabled = adapter.isPluginEnabled(params.pluginId);
       const plugins = adapter.getInstalledPlugins();
-      const installed = plugins.some((p) => p.id === pluginId);
+      const installed = plugins.some((p) => p.id === params.pluginId);
       return Promise.resolve(
         makeResponse(
-          { pluginId, installed, enabled },
+          { pluginId: params.pluginId, installed, enabled },
           (v) =>
             `**${v.pluginId}** — ${v.installed ? 'installed' : 'not installed'}, ${v.enabled ? 'enabled' : 'disabled'}`,
           readResponseFormat(params),
@@ -59,7 +106,7 @@ function createHandlers(
       }
       const payload = {
         note: 'Dataview query execution requires the Dataview plugin API at runtime',
-        query: params.query as string,
+        query: params.query,
       };
       return Promise.resolve(
         makeResponse(
@@ -75,11 +122,10 @@ function createHandlers(
       }
       return Promise.resolve(text(JSON.stringify({
         note: 'Templater execution requires the Templater plugin API at runtime',
-        templatePath: params.templatePath as string,
+        templatePath: params.templatePath,
       })));
     },
     executeCommand: (params): Promise<CallToolResult> => {
-      const commandId = params.commandId as string;
       const allowlist = getExecuteCommandAllowlist();
       if (allowlist.length === 0) {
         return Promise.resolve(
@@ -88,15 +134,19 @@ function createHandlers(
           ),
         );
       }
-      if (!allowlist.includes(commandId)) {
+      if (!allowlist.includes(params.commandId)) {
         return Promise.resolve(
           err(
-            `Command "${commandId}" is not on the executeCommand allowlist. Add it in Obsidian MCP settings if you trust it.`,
+            `Command "${params.commandId}" is not on the executeCommand allowlist. Add it in Obsidian MCP settings if you trust it.`,
           ),
         );
       }
-      const ok = adapter.executeCommand(commandId);
-      return Promise.resolve(ok ? text(`Executed command: ${commandId}`) : err(`Command not found: ${commandId}`));
+      const ok = adapter.executeCommand(params.commandId);
+      return Promise.resolve(
+        ok
+          ? text(`Executed command: ${params.commandId}`)
+          : err(`Command not found: ${params.commandId}`),
+      );
     },
   };
 }
@@ -113,35 +163,28 @@ export function createPluginInteropModule(
     metadata: { id: 'plugin-interop', name: 'Plugin Interop', description: 'List plugins, check status, execute commands, and integrate with Dataview/Templater' },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'plugin_list',
           description: describeTool({
             summary: 'List every installed community plugin with its enabled flag.',
             returns: 'JSON: [{ id, name, enabled, ... }].',
           }),
-          schema: { ...responseFormatField },
+          schema: listSchema,
           handler: h.listPlugins,
           annotations: annotations.readExternal,
-        },
-        {
+        }),
+        defineTool({
           name: 'plugin_check',
           description: describeTool({
             summary: 'Check whether a plugin is installed and enabled.',
             args: ['pluginId (string, 1..200): Plugin id, e.g. "dataview".'],
             returns: 'JSON: { pluginId, installed, enabled }.',
           }),
-          schema: {
-            pluginId: z
-              .string()
-              .min(1)
-              .max(200)
-              .describe('Community plugin id (e.g. "dataview")'),
-            ...responseFormatField,
-          },
+          schema: checkSchema,
           handler: h.checkPlugin,
           annotations: annotations.readExternal,
-        },
-        {
+        }),
+        defineTool({
           name: 'plugin_dataview_query',
           description: describeTool({
             summary: 'Execute a Dataview (DQL / dataview-js) query.',
@@ -149,18 +192,11 @@ export function createPluginInteropModule(
             returns: 'JSON envelope with the query echoed; full execution requires the Dataview plugin at runtime.',
             errors: ['"Dataview plugin is not installed or enabled" if the plugin is missing.'],
           }),
-          schema: {
-            query: z
-              .string()
-              .min(1)
-              .max(10_000)
-              .describe('Dataview query (DQL or Dataview-js)'),
-            ...responseFormatField,
-          },
+          schema: dataviewSchema,
           handler: h.dataviewQuery,
           annotations: annotations.readExternal,
-        },
-        {
+        }),
+        defineTool({
           name: 'plugin_templater_execute',
           description: describeTool({
             summary: 'Execute a Templater template file.',
@@ -168,17 +204,11 @@ export function createPluginInteropModule(
             returns: 'JSON envelope noting the template path; full execution requires the Templater plugin.',
             errors: ['"Templater plugin is not installed or enabled" if the plugin is missing.'],
           }),
-          schema: {
-            templatePath: z
-              .string()
-              .min(1)
-              .max(4096)
-              .describe('Vault-relative path to the Templater template'),
-          },
+          schema: templaterSchema,
           handler: h.templaterExecute,
           annotations: annotations.destructiveExternal,
-        },
-        {
+        }),
+        defineTool({
           name: 'plugin_execute_command',
           description: describeTool({
             summary: 'Execute any Obsidian command by its id.',
@@ -187,16 +217,10 @@ export function createPluginInteropModule(
             examples: ['Use when: triggering "editor:save-file" programmatically.'],
             errors: ['"Command not found" if the id is not registered.'],
           }),
-          schema: {
-            commandId: z
-              .string()
-              .min(1)
-              .max(200)
-              .describe('Obsidian command id (e.g. "app:reload")'),
-          },
+          schema: executeCommandSchema,
           handler: h.executeCommand,
           annotations: annotations.destructiveExternal,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/search/handlers.ts
+++ b/src/tools/search/handlers.ts
@@ -5,8 +5,29 @@ import { truncateText } from '../shared/truncate';
 import { handleToolError } from '../shared/errors';
 import { paginate, readPagination } from '../shared/pagination';
 import { makeResponse, readResponseFormat } from '../shared/response';
+import type { InferredParams } from '../../registry/types';
+import type {
+  searchFulltextSchema,
+  filePathSchema,
+  searchByTagSchema,
+  searchByFrontmatterSchema,
+  readOnlySchema,
+} from './schemas';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
+export interface SearchHandlers {
+  searchFulltext: (params: InferredParams<typeof searchFulltextSchema>) => Promise<CallToolResult>;
+  searchFrontmatter: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchTags: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  searchHeadings: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchOutgoingLinks: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchEmbeds: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchBacklinks: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchResolvedLinks: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  searchUnresolvedLinks: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  searchBlockReferences: (params: InferredParams<typeof filePathSchema>) => Promise<CallToolResult>;
+  searchByTag: (params: InferredParams<typeof searchByTagSchema>) => Promise<CallToolResult>;
+  searchByFrontmatter: (params: InferredParams<typeof searchByFrontmatterSchema>) => Promise<CallToolResult>;
+}
 
 function renderKeyValue(obj: Record<string, unknown>): string {
   const entries = Object.entries(obj);
@@ -37,13 +58,13 @@ function renderPaginatedPaths(
   return `${header}\n\n${body}${footer}`;
 }
 
-export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+export function createSearchHandlers(adapter: ObsidianAdapter): SearchHandlers {
   const vaultPath = adapter.getVaultPath();
 
   return {
     async searchFulltext(params): Promise<CallToolResult> {
       try {
-        const query = params.query as string;
+        const query = params.query;
         const all = await adapter.searchContent(query);
         const page = paginate(all, readPagination(params));
         const result = makeResponse(
@@ -75,7 +96,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchFrontmatter(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const frontmatter = adapter.getFrontmatter(path) ?? {};
         return Promise.resolve(
           makeResponse(
@@ -116,7 +137,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchHeadings(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const headings = adapter.getHeadings(path);
         return Promise.resolve(
           makeResponse(
@@ -138,7 +159,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchOutgoingLinks(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const links = adapter.getLinks(path);
         return Promise.resolve(
           makeResponse(
@@ -160,7 +181,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchEmbeds(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const embeds = adapter.getEmbeds(path);
         return Promise.resolve(
           makeResponse(
@@ -180,7 +201,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchBacklinks(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const backlinks = adapter.getBacklinks(path);
         return Promise.resolve(
           makeResponse(
@@ -251,7 +272,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchBlockReferences(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         return adapter.getFileContent(path).then((content) => {
           const blockRefs = content
             .split('\n')
@@ -278,7 +299,7 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchByTag(params): Promise<CallToolResult> {
       try {
-        const tag = params.tag as string;
+        const tag = params.tag;
         const normalizedTag = tag.startsWith('#') ? tag : `#${tag}`;
         const allTags = adapter.getAllTags();
         const files = allTags[normalizedTag] ?? [];
@@ -297,8 +318,8 @@ export function createSearchHandlers(adapter: ObsidianAdapter): Record<string, H
 
     searchByFrontmatter(params): Promise<CallToolResult> {
       try {
-        const key = params.key as string;
-        const value = params.value as string;
+        const key = params.key;
+        const value = params.value;
         const allFiles = adapter.getAllFiles();
         const matching: string[] = [];
         for (const filePath of allFiles) {

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -1,4 +1,4 @@
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import { ToolModule, ToolDefinition, annotations, defineTool } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createSearchHandlers } from './handlers';
 import { describeTool } from '../shared/describe';
@@ -22,7 +22,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
 
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'search_fulltext',
           description: describeTool({
             summary: 'Case-insensitive substring search across all vault file contents.',
@@ -34,8 +34,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: searchFulltextSchema,
           handler: handlers.searchFulltext,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_frontmatter',
           description: describeTool({
             summary: 'Get the parsed YAML frontmatter block for a file.',
@@ -46,8 +46,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchFrontmatter,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_tags',
           description: describeTool({
             summary: 'List every tag used anywhere in the vault with the files that use it.',
@@ -56,8 +56,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: readOnlySchema,
           handler: handlers.searchTags,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_headings',
           description: describeTool({
             summary: 'List headings (with levels) for a file.',
@@ -68,8 +68,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchHeadings,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_outgoing_links',
           description: describeTool({
             summary: 'List outgoing links from a file.',
@@ -80,8 +80,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchOutgoingLinks,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_embeds',
           description: describeTool({
             summary: 'List embedded resources (![[...]]) referenced by a file.',
@@ -92,8 +92,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchEmbeds,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_backlinks',
           description: describeTool({
             summary: 'List files that link TO a given file (reverse links).',
@@ -104,8 +104,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchBacklinks,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_resolved_links',
           description: describeTool({
             summary: 'Get the vault-wide map of resolved links (targets that exist).',
@@ -114,8 +114,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: readOnlySchema,
           handler: handlers.searchResolvedLinks,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_unresolved_links',
           description: describeTool({
             summary: 'Get the vault-wide map of unresolved links (targets that do not exist).',
@@ -125,8 +125,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: readOnlySchema,
           handler: handlers.searchUnresolvedLinks,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_block_references',
           description: describeTool({
             summary: 'List block references (^block-id) defined in a file.',
@@ -137,8 +137,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: filePathSchema,
           handler: handlers.searchBlockReferences,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_by_tag',
           description: describeTool({
             summary: 'Find files tagged with a given tag (with or without leading #).',
@@ -148,8 +148,8 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: searchByTagSchema,
           handler: handlers.searchByTag,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'search_by_frontmatter',
           description: describeTool({
             summary: 'Find files whose YAML frontmatter has a key with a given value.',
@@ -163,7 +163,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           schema: searchByFrontmatterSchema,
           handler: handlers.searchByFrontmatter,
           annotations: annotations.read,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
-
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
@@ -27,7 +31,43 @@ function expandVariables(template: string, variables: Record<string, string>): s
   return result;
 }
 
-function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+const listTemplatesSchema = {};
+
+const createFromTemplateSchema = {
+  templatePath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Vault-relative path to the template source file'),
+  destPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Vault-relative path for the new file'),
+  variables: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe('Template variables keyed by name (e.g. { title: "Today" })'),
+};
+
+const expandVariablesSchema = {
+  template: z
+    .string()
+    .max(100_000)
+    .describe('Template text containing {{variable}} placeholders'),
+  variables: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe('Template variables keyed by name'),
+};
+
+interface TemplatesHandlers {
+  listTemplates: (params: InferredParams<typeof listTemplatesSchema>) => Promise<CallToolResult>;
+  createFromTemplate: (params: InferredParams<typeof createFromTemplateSchema>) => Promise<CallToolResult>;
+  expandVariables: (params: InferredParams<typeof expandVariablesSchema>) => Promise<CallToolResult>;
+}
+
+function createHandlers(adapter: ObsidianAdapter): TemplatesHandlers {
   const vaultPath = adapter.getVaultPath();
   const templatesFolder = 'templates';
 
@@ -42,9 +82,9 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     },
     async createFromTemplate(params): Promise<CallToolResult> {
       try {
-        const templatePath = validateVaultPath(params.templatePath as string, vaultPath);
-        const destPath = validateVaultPath(params.destPath as string, vaultPath);
-        const variables = (params.variables as Record<string, string>) ?? {};
+        const templatePath = validateVaultPath(params.templatePath, vaultPath);
+        const destPath = validateVaultPath(params.destPath, vaultPath);
+        const variables = params.variables ?? {};
         const templateContent = await adapter.readFile(templatePath);
         const expanded = expandVariables(templateContent, variables);
         await adapter.createFile(destPath, expanded);
@@ -55,9 +95,8 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     },
     expandVariables: (params): Promise<CallToolResult> => {
       try {
-        const template = params.template as string;
-        const variables = (params.variables as Record<string, string>) ?? {};
-        const result = expandVariables(template, variables);
+        const variables = params.variables ?? {};
+        const result = expandVariables(params.template, variables);
         return Promise.resolve(text(result));
       } catch (error) {
         return Promise.resolve(err(error instanceof Error ? error.message : String(error)));
@@ -72,17 +111,17 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'templates', name: 'Templates and Content Generation', description: 'List, create from, and expand templates' },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'template_list',
           description: describeTool({
             summary: 'List files in the vault\'s "templates" folder.',
             returns: 'JSON: string[] of template file paths. Empty array if the folder is missing.',
           }),
-          schema: {},
+          schema: listTemplatesSchema,
           handler: h.listTemplates,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'template_create_from',
           description: describeTool({
             summary: 'Create a file by expanding {{variable}} placeholders in a template.',
@@ -97,26 +136,11 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
               '"File already exists" if destPath is taken.',
             ],
           }),
-          schema: {
-            templatePath: z
-              .string()
-              .min(1)
-              .max(4096)
-              .describe('Vault-relative path to the template source file'),
-            destPath: z
-              .string()
-              .min(1)
-              .max(4096)
-              .describe('Vault-relative path for the new file'),
-            variables: z
-              .record(z.string(), z.string())
-              .optional()
-              .describe('Template variables keyed by name (e.g. { title: "Today" })'),
-          },
+          schema: createFromTemplateSchema,
           handler: h.createFromTemplate,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'template_expand',
           description: describeTool({
             summary: 'Expand {{variable}} placeholders in a supplied string without writing any file.',
@@ -126,19 +150,10 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
             ],
             returns: 'Plain text: the expanded string.',
           }),
-          schema: {
-            template: z
-              .string()
-              .max(100_000)
-              .describe('Template text containing {{variable}} placeholders'),
-            variables: z
-              .record(z.string(), z.string())
-              .optional()
-              .describe('Template variables keyed by name'),
-          },
+          schema: expandVariablesSchema,
           handler: h.expandVariables,
           annotations: annotations.read,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -1,17 +1,63 @@
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { describeTool } from '../shared/describe';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
-
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 
-function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+const showNoticeSchema = {
+  message: z
+    .string()
+    .min(1)
+    .max(1000)
+    .describe('Notice text to show to the user'),
+  duration: z
+    .number()
+    .int()
+    .min(0)
+    .max(60_000)
+    .optional()
+    .describe('Milliseconds before the notice auto-dismisses (0 = sticky)'),
+};
+
+const showConfirmSchema = {
+  message: z
+    .string()
+    .min(1)
+    .max(1000)
+    .describe('Question to present in the confirmation modal'),
+};
+
+const showPromptSchema = {
+  message: z
+    .string()
+    .min(1)
+    .max(1000)
+    .describe('Prompt label to show in the input modal'),
+  defaultValue: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe('Pre-filled value for the input field'),
+};
+
+interface UiHandlers {
+  showNotice: (params: InferredParams<typeof showNoticeSchema>) => Promise<CallToolResult>;
+  showConfirm: (params: InferredParams<typeof showConfirmSchema>) => Promise<CallToolResult>;
+  showPrompt: (params: InferredParams<typeof showPromptSchema>) => Promise<CallToolResult>;
+}
+
+function createHandlers(adapter: ObsidianAdapter): UiHandlers {
   return {
     showNotice: (params): Promise<CallToolResult> => {
-      adapter.showNotice(params.message as string, params.duration as number | undefined);
+      adapter.showNotice(params.message, params.duration);
       return Promise.resolve(text('Notice shown'));
     },
     // Confirmation modals and input prompts require Obsidian UI interaction
@@ -20,15 +66,15 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     showConfirm: (params): Promise<CallToolResult> => {
       return Promise.resolve(text(JSON.stringify({
         type: 'confirm',
-        message: params.message as string,
+        message: params.message,
         note: 'Confirmation modals require user interaction in the Obsidian UI',
       })));
     },
     showPrompt: (params): Promise<CallToolResult> => {
       return Promise.resolve(text(JSON.stringify({
         type: 'prompt',
-        message: params.message as string,
-        defaultValue: (params.defaultValue as string) ?? '',
+        message: params.message,
+        defaultValue: params.defaultValue ?? '',
         note: 'Input prompts require user interaction in the Obsidian UI',
       })));
     },
@@ -41,7 +87,7 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'ui', name: 'UI Interactions', description: 'Show notices, modals, and prompts in Obsidian' },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'ui_notice',
           description: describeTool({
             summary: 'Show a transient notice/toast in Obsidian.',
@@ -51,41 +97,22 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
             ],
             returns: 'Plain text "Notice shown".',
           }),
-          schema: {
-            message: z
-              .string()
-              .min(1)
-              .max(1000)
-              .describe('Notice text to show to the user'),
-            duration: z
-              .number()
-              .int()
-              .min(0)
-              .max(60_000)
-              .optional()
-              .describe('Milliseconds before the notice auto-dismisses (0 = sticky)'),
-          },
+          schema: showNoticeSchema,
           handler: h.showNotice,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'ui_confirm',
           description: describeTool({
             summary: 'Stub for a confirmation modal — user interaction cannot be captured via MCP.',
             args: ['message (string, 1..1000): Question text.'],
             returns: 'JSON envelope noting that confirmation modals need UI interaction.',
           }),
-          schema: {
-            message: z
-              .string()
-              .min(1)
-              .max(1000)
-              .describe('Question to present in the confirmation modal'),
-          },
+          schema: showConfirmSchema,
           handler: h.showConfirm,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'ui_prompt',
           description: describeTool({
             summary: 'Stub for an input prompt modal — user input cannot be captured via MCP.',
@@ -95,21 +122,10 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
             ],
             returns: 'JSON envelope noting that prompts need UI interaction.',
           }),
-          schema: {
-            message: z
-              .string()
-              .min(1)
-              .max(1000)
-              .describe('Prompt label to show in the input modal'),
-            defaultValue: z
-              .string()
-              .max(1000)
-              .optional()
-              .describe('Pre-filled value for the input field'),
-          },
+          schema: showPromptSchema,
           handler: h.showPrompt,
           annotations: annotations.additive,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -6,6 +6,25 @@ import { handleToolError } from '../shared/errors';
 import { paginate, readPagination } from '../shared/pagination';
 import { makeResponse, readResponseFormat } from '../shared/response';
 import { BINARY_BYTE_LIMIT } from '../../constants';
+import type { InferredParams } from '../../registry/types';
+import type {
+  createFileSchema,
+  readFileSchema,
+  updateFileSchema,
+  deleteFileSchema,
+  appendFileSchema,
+  getMetadataSchema,
+  renameFileSchema,
+  moveFileSchema,
+  copyFileSchema,
+  createFolderSchema,
+  deleteFolderSchema,
+  renameFolderSchema,
+  listFolderSchema,
+  listRecursiveSchema,
+  readBinarySchema,
+  writeBinarySchema,
+} from './schemas';
 
 export class WriteMutex {
   private locks: Map<string, Promise<void>> = new Map();
@@ -92,36 +111,37 @@ function isValidRenameTarget(value: unknown): value is string {
   );
 }
 
+export interface VaultHandlers {
+  createFile: (params: InferredParams<typeof createFileSchema>) => Promise<CallToolResult>;
+  readFile: (params: InferredParams<typeof readFileSchema>) => Promise<CallToolResult>;
+  updateFile: (params: InferredParams<typeof updateFileSchema>) => Promise<CallToolResult>;
+  deleteFile: (params: InferredParams<typeof deleteFileSchema>) => Promise<CallToolResult>;
+  appendFile: (params: InferredParams<typeof appendFileSchema>) => Promise<CallToolResult>;
+  renameFile: (params: InferredParams<typeof renameFileSchema>) => Promise<CallToolResult>;
+  moveFile: (params: InferredParams<typeof moveFileSchema>) => Promise<CallToolResult>;
+  copyFile: (params: InferredParams<typeof copyFileSchema>) => Promise<CallToolResult>;
+  getMetadata: (params: InferredParams<typeof getMetadataSchema>) => Promise<CallToolResult>;
+  createFolder: (params: InferredParams<typeof createFolderSchema>) => Promise<CallToolResult>;
+  deleteFolder: (params: InferredParams<typeof deleteFolderSchema>) => Promise<CallToolResult>;
+  renameFolder: (params: InferredParams<typeof renameFolderSchema>) => Promise<CallToolResult>;
+  listFolder: (params: InferredParams<typeof listFolderSchema>) => Promise<CallToolResult>;
+  listRecursive: (params: InferredParams<typeof listRecursiveSchema>) => Promise<CallToolResult>;
+  readBinary: (params: InferredParams<typeof readBinarySchema>) => Promise<CallToolResult>;
+  writeBinary: (params: InferredParams<typeof writeBinarySchema>) => Promise<CallToolResult>;
+}
+
 export function createHandlers(
   adapter: ObsidianAdapter,
   mutex: WriteMutex,
-): {
-  createFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  readFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  updateFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  deleteFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  appendFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  renameFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  moveFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  copyFile: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  getMetadata: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  createFolder: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  deleteFolder: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  renameFolder: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  listFolder: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  listRecursive: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  readBinary: (params: Record<string, unknown>) => Promise<CallToolResult>;
-  writeBinary: (params: Record<string, unknown>) => Promise<CallToolResult>;
-} {
+): VaultHandlers {
   const vaultPath = adapter.getVaultPath();
 
   return {
     async createFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const content = params.content as string;
+        const path = validateVaultPath(params.path, vaultPath);
         return await mutex.acquire(path, async () => {
-          await adapter.createFile(path, content);
+          await adapter.createFile(path, params.content);
           return textResult(`Created file: ${path}`);
         });
       } catch (error) {
@@ -131,7 +151,7 @@ export function createHandlers(
 
     async readFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const content = await adapter.readFile(path);
         const result = makeResponse(
           { path, content },
@@ -154,10 +174,9 @@ export function createHandlers(
 
     async updateFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const content = params.content as string;
+        const path = validateVaultPath(params.path, vaultPath);
         return await mutex.acquire(path, async () => {
-          await adapter.modifyFile(path, content);
+          await adapter.modifyFile(path, params.content);
           return textResult(`Updated file: ${path}`);
         });
       } catch (error) {
@@ -167,7 +186,7 @@ export function createHandlers(
 
     async deleteFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         return await mutex.acquire(path, async () => {
           await adapter.deleteFile(path);
           return textResult(`Deleted file: ${path}`);
@@ -179,11 +198,10 @@ export function createHandlers(
 
     async appendFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const content = params.content as string;
+        const path = validateVaultPath(params.path, vaultPath);
         return await mutex.acquire(path, async () => {
           const existing = await adapter.readFile(path);
-          await adapter.modifyFile(path, existing + content);
+          await adapter.modifyFile(path, existing + params.content);
           return textResult(`Appended to file: ${path}`);
         });
       } catch (error) {
@@ -193,7 +211,7 @@ export function createHandlers(
 
     async getMetadata(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const stat = await adapter.stat(path);
         if (!stat) {
           return errorResult(`File not found: ${path}`);
@@ -217,14 +235,12 @@ export function createHandlers(
 
     async renameFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const rawNewName = params.newName;
-        if (!isValidRenameTarget(rawNewName)) {
+        const path = validateVaultPath(params.path, vaultPath);
+        if (!isValidRenameTarget(params.newName)) {
           return errorResult('Invalid rename target');
         }
-        const newName = rawNewName;
         const parts = path.split('/');
-        parts[parts.length - 1] = newName;
+        parts[parts.length - 1] = params.newName;
         const newPath = parts.join('/');
         try {
           validateVaultPath(newPath, vaultPath);
@@ -242,8 +258,8 @@ export function createHandlers(
 
     async moveFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const newPath = validateVaultPath(params.newPath as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
+        const newPath = validateVaultPath(params.newPath, vaultPath);
         return await mutex.acquire(path, async () => {
           await adapter.renameFile(path, newPath);
           return textResult(`Moved file: ${path} → ${newPath}`);
@@ -255,8 +271,8 @@ export function createHandlers(
 
     async copyFile(params): Promise<CallToolResult> {
       try {
-        const sourcePath = validateVaultPath(params.sourcePath as string, vaultPath);
-        const destPath = validateVaultPath(params.destPath as string, vaultPath);
+        const sourcePath = validateVaultPath(params.sourcePath, vaultPath);
+        const destPath = validateVaultPath(params.destPath, vaultPath);
         await adapter.copyFile(sourcePath, destPath);
         return textResult(`Copied file: ${sourcePath} → ${destPath}`);
       } catch (error) {
@@ -266,7 +282,7 @@ export function createHandlers(
 
     async createFolder(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         await adapter.createFolder(path);
         return textResult(`Created folder: ${path}`);
       } catch (error) {
@@ -276,9 +292,8 @@ export function createHandlers(
 
     async deleteFolder(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const recursive = (params.recursive as boolean) ?? false;
-        await adapter.deleteFolder(path, recursive);
+        const path = validateVaultPath(params.path, vaultPath);
+        await adapter.deleteFolder(path, params.recursive ?? false);
         return textResult(`Deleted folder: ${path}`);
       } catch (error) {
         return handleToolError(error);
@@ -287,8 +302,8 @@ export function createHandlers(
 
     async renameFolder(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const newPath = validateVaultPath(params.newPath as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
+        const newPath = validateVaultPath(params.newPath, vaultPath);
         await adapter.renameFile(path, newPath);
         return textResult(`Renamed folder: ${path} → ${newPath}`);
       } catch (error) {
@@ -298,13 +313,12 @@ export function createHandlers(
 
     listFolder(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const result = adapter.list(path);
         return Promise.resolve(
           makeResponse(
             result,
-            (v) =>
-              renderFolderListing(path, v.folders, v.files),
+            (v) => renderFolderListing(path, v.folders, v.files),
             readResponseFormat(params),
           ),
         );
@@ -315,7 +329,7 @@ export function createHandlers(
 
     listRecursive(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const result = adapter.listRecursive(path);
         const pagination = readPagination(params);
         const filesPage = paginate(result.files, pagination);
@@ -325,7 +339,15 @@ export function createHandlers(
         };
         const wrapped = makeResponse(
           payload,
-          (v) => renderRecursiveListing(path, v.folders, v.items, v.total, v.has_more, v.next_offset),
+          (v) =>
+            renderRecursiveListing(
+              path,
+              v.folders,
+              v.items,
+              v.total,
+              v.has_more,
+              v.next_offset,
+            ),
           readResponseFormat(params),
         );
         const firstBlock = wrapped.content[0];
@@ -344,7 +366,7 @@ export function createHandlers(
 
     async readBinary(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
+        const path = validateVaultPath(params.path, vaultPath);
         const data = await adapter.readBinary(path);
         if (data.byteLength > BINARY_BYTE_LIMIT) {
           return errorResult(
@@ -360,11 +382,13 @@ export function createHandlers(
 
     async writeBinary(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        const base64 = params.data as string;
-        const buffer = Buffer.from(base64, 'base64');
+        const path = validateVaultPath(params.path, vaultPath);
+        const buffer = Buffer.from(params.data, 'base64');
         return await mutex.acquire(path, async () => {
-          await adapter.writeBinary(path, buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+          await adapter.writeBinary(
+            path,
+            buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+          );
           return textResult(`Wrote binary file: ${path}`);
         });
       } catch (error) {

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -1,4 +1,4 @@
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import { ToolModule, ToolDefinition, annotations, defineTool } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createHandlers, WriteMutex } from './handlers';
 import { describeTool } from '../shared/describe';
@@ -34,7 +34,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
 
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'vault_create',
           description: describeTool({
             summary: 'Create a new file at a vault-relative path with text content.',
@@ -55,8 +55,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: createFileSchema,
           handler: handlers.createFile,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_read',
           description: describeTool({
             summary: 'Read the full UTF-8 content of a file by vault-relative path.',
@@ -74,8 +74,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: readFileSchema,
           handler: handlers.readFile,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_update',
           description: describeTool({
             summary: 'Overwrite an existing file with new content.',
@@ -93,8 +93,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: updateFileSchema,
           handler: handlers.updateFile,
           annotations: annotations.destructiveIdempotent,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_delete',
           description: describeTool({
             summary: 'Delete a file by vault-relative path.',
@@ -106,8 +106,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: deleteFileSchema,
           handler: handlers.deleteFile,
           annotations: annotations.destructiveIdempotent,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_append',
           description: describeTool({
             summary: 'Append content to the end of an existing file.',
@@ -122,8 +122,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: appendFileSchema,
           handler: handlers.appendFile,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_get_metadata',
           description: describeTool({
             summary: 'Get file stat metadata (size, creation date, modification date).',
@@ -135,8 +135,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: getMetadataSchema,
           handler: handlers.getMetadata,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_rename',
           description: describeTool({
             summary: 'Rename a file within its current folder.',
@@ -154,8 +154,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: renameFileSchema,
           handler: handlers.renameFile,
           annotations: annotations.destructive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_move',
           description: describeTool({
             summary: 'Move a file to a different path (can change folder and name).',
@@ -170,8 +170,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: moveFileSchema,
           handler: handlers.moveFile,
           annotations: annotations.destructive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_copy',
           description: describeTool({
             summary: 'Copy a file to a new path, leaving the original in place.',
@@ -186,8 +186,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: copyFileSchema,
           handler: handlers.copyFile,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_create_folder',
           description: describeTool({
             summary: 'Create a new folder at a vault-relative path.',
@@ -199,8 +199,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: createFolderSchema,
           handler: handlers.createFolder,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_delete_folder',
           description: describeTool({
             summary: 'Delete a folder, optionally recursively.',
@@ -215,8 +215,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: deleteFolderSchema,
           handler: handlers.deleteFolder,
           annotations: annotations.destructiveIdempotent,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_rename_folder',
           description: describeTool({
             summary: 'Rename or move a folder.',
@@ -231,8 +231,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: renameFolderSchema,
           handler: handlers.renameFolder,
           annotations: annotations.destructive,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_list',
           description: describeTool({
             summary: 'List files and folders directly under a path (non-recursive).',
@@ -244,8 +244,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: listFolderSchema,
           handler: handlers.listFolder,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_list_recursive',
           description: describeTool({
             summary: 'List all files and folders under a path, recursively.',
@@ -260,8 +260,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: listRecursiveSchema,
           handler: handlers.listRecursive,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_read_binary',
           description: describeTool({
             summary: 'Read binary file contents as base64.',
@@ -276,8 +276,8 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: readBinarySchema,
           handler: handlers.readBinary,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'vault_write_binary',
           description: describeTool({
             summary: 'Write binary file contents from a base64 string.',
@@ -292,7 +292,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: writeBinarySchema,
           handler: handlers.writeBinary,
           annotations: annotations.destructiveIdempotent,
-        },
+        }),
       ];
     },
   };

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { ToolModule, ToolDefinition, annotations } from '../../registry/types';
+import {
+  ToolModule,
+  ToolDefinition,
+  annotations,
+  defineTool,
+  type InferredParams,
+} from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { handleToolError } from '../shared/errors';
@@ -11,12 +17,40 @@ import {
   responseFormatField,
 } from '../shared/response';
 
-type Handler = (params: Record<string, unknown>) => Promise<CallToolResult>;
-
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
 function err(m: string): CallToolResult { return handleToolError(new Error(m)); }
 
-function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
+const readOnlySchema = { ...responseFormatField };
+
+const openFileSchema = {
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .describe('Vault-relative file path to open'),
+  mode: z
+    .enum(['source', 'preview', 'live'])
+    .optional()
+    .describe('Optional view mode for the opened leaf'),
+};
+
+const setActiveLeafSchema = {
+  leafId: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe('Leaf id returned by workspace_list_leaves'),
+};
+
+interface WorkspaceHandlers {
+  getActiveLeaf: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  openFile: (params: InferredParams<typeof openFileSchema>) => Promise<CallToolResult>;
+  listLeaves: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+  setActiveLeaf: (params: InferredParams<typeof setActiveLeafSchema>) => Promise<CallToolResult>;
+  getLayout: (params: InferredParams<typeof readOnlySchema>) => Promise<CallToolResult>;
+}
+
+function createHandlers(adapter: ObsidianAdapter): WorkspaceHandlers {
   const vaultPath = adapter.getVaultPath();
   return {
     getActiveLeaf: (params): Promise<CallToolResult> => {
@@ -36,8 +70,8 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
     },
     async openFile(params): Promise<CallToolResult> {
       try {
-        const path = validateVaultPath(params.path as string, vaultPath);
-        await adapter.openFile(path, params.mode as string | undefined);
+        const path = validateVaultPath(params.path, vaultPath);
+        await adapter.openFile(path, params.mode);
         return text(`Opened: ${path}`);
       } catch (error) {
         return err(error instanceof Error ? error.message : String(error));
@@ -57,7 +91,7 @@ function createHandlers(adapter: ObsidianAdapter): Record<string, Handler> {
       );
     },
     setActiveLeaf: (params): Promise<CallToolResult> => {
-      const ok = adapter.setActiveLeaf(params.leafId as string);
+      const ok = adapter.setActiveLeaf(params.leafId);
       return Promise.resolve(ok ? text('Active leaf set') : err('Leaf not found'));
     },
     getLayout: (params): Promise<CallToolResult> => {
@@ -79,18 +113,18 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
     metadata: { id: 'workspace', name: 'Workspace and Navigation', description: 'Manage panes, open files, and navigate the workspace' },
     tools(): ToolDefinition[] {
       return [
-        {
+        defineTool({
           name: 'workspace_get_active_leaf',
           description: describeTool({
             summary: 'Get info about the currently-focused leaf (pane).',
             returns: 'JSON: { id, type, ... } describing the active leaf.',
             errors: ['"No active leaf" if no leaf is focused.'],
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getActiveLeaf,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'workspace_open_file',
           description: describeTool({
             summary: 'Open a file in a leaf, optionally requesting a view mode.',
@@ -101,31 +135,21 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text "Opened: <path>".',
             errors: ['"Path must not traverse outside the vault" on traversal attempts.'],
           }),
-          schema: {
-            path: z
-              .string()
-              .min(1)
-              .max(4096)
-              .describe('Vault-relative file path to open'),
-            mode: z
-              .enum(['source', 'preview', 'live'])
-              .optional()
-              .describe('Optional view mode for the opened leaf'),
-          },
+          schema: openFileSchema,
           handler: h.openFile,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'workspace_list_leaves',
           description: describeTool({
             summary: 'List every open leaf and the file it holds.',
             returns: 'JSON: [{ path, leafId }].',
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.listLeaves,
           annotations: annotations.read,
-        },
-        {
+        }),
+        defineTool({
           name: 'workspace_set_active_leaf',
           description: describeTool({
             summary: 'Focus a specific leaf by id.',
@@ -133,26 +157,20 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'Plain text "Active leaf set" on success.',
             errors: ['"Leaf not found" if the id does not match any leaf.'],
           }),
-          schema: {
-            leafId: z
-              .string()
-              .min(1)
-              .max(200)
-              .describe('Leaf id returned by workspace_list_leaves'),
-          },
+          schema: setActiveLeafSchema,
           handler: h.setActiveLeaf,
           annotations: annotations.additive,
-        },
-        {
+        }),
+        defineTool({
           name: 'workspace_get_layout',
           description: describeTool({
             summary: 'Get a summary of the current workspace layout.',
             returns: 'JSON: Obsidian\'s layout descriptor (nested splits and leaves).',
           }),
-          schema: { ...responseFormatField },
+          schema: readOnlySchema,
           handler: h.getLayout,
           annotations: annotations.read,
-        },
+        }),
       ];
     },
   };

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
-import { createSearchHandlers } from '../../../src/tools/search/handlers';
+import { createSearchHandlers, type SearchHandlers } from '../../../src/tools/search/handlers';
 import { createSearchModule } from '../../../src/tools/search/index';
 
 function getText(result: CallToolResult): string {
@@ -33,7 +33,7 @@ describe('search module', () => {
 
 describe('search handlers', () => {
   let adapter: MockObsidianAdapter;
-  let handlers: Record<string, (params: Record<string, unknown>) => Promise<CallToolResult>>;
+  let handlers: SearchHandlers;
 
   beforeEach(() => {
     adapter = new MockObsidianAdapter();


### PR DESCRIPTION
## Summary

Completes the per-module migration started by PR #221. Every handler in every tool module now has a **schema-inferred param type** via `InferredParams<typeof schema>` — no more `as string | number | boolean` casts inside handler bodies.

## Mechanism

- Each module declares its schemas as module-level consts (already the pattern in `vault` / `search`; extended to `editor` / `workspace` / `templates` / `plugin-interop` / `ui` / `extras`).
- `createHandlers()` now returns a named interface (`VaultHandlers`, `SearchHandlers`, etc.) where each method's `params` is typed from the matching schema.
- Every tool entry is wrapped in `defineTool({...})` so TS checks the `schema ↔ handler` pairing at the definition site.
- `InferredParams<Shape>` switched from `z.infer` (output) to **`z.input`** (input) so fields with `.default()` are optional in handler signatures. That matches how tests call handlers directly (without threading defaults). Handlers that read a default-bearing field nullish-coalesce it.

## Result

- **Zero** `as string | number | boolean` casts on `params.*` in `src/tools/` (the only remaining match is a comment string in `search/index.ts`).
- Renaming a schema field without updating the handler now fails at `tsc` — verified by temporarily renaming `path → filePath` in `vault/schemas.ts`, which produced the expected compile error.

## Test plan

- [x] `npm test` — 491 passing (no change)
- [x] `npm run lint` — no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — snapshot stable
- [x] Grep: `grep -rn "as string\|as number\|as boolean" src/tools/` returns only one hit in a comment

Closes #217