### PR TITLE
chore(tests/settings): add return types to local helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@
 - Run `npm run typecheck` for type-checking
 - Strict TypeScript ESLint rules are enforced: no `any` types, explicit return types, no unsafe returns/assignments
 - The mock file `tests/__mocks__/obsidian.ts` has eslint-disable for `any`-related rules since Obsidian API mocks require loose typing
-- The `tests/settings.test.ts` has pre-existing warnings for missing return types on local helpers — do not introduce new warnings
 
 ## Development Workflow
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -540,16 +540,15 @@ describe('McpSettingsTab MCP config display', () => {
 });
 
 describe('McpSettingsTab server controls', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockPlugin: Record<string, any>;
+  let mockPlugin: Record<string, unknown>;
 
-  function createMockPlugin(isRunning: boolean, clients = 0) {
+  function createMockPlugin(isRunning: boolean, clients = 0): Record<string, unknown> {
     return {
       settings: { ...DEFAULT_SETTINGS, accessKey: 'test-key', authEnabled: true },
       httpServer: isRunning
         ? { isRunning: true, connectedClients: clients }
         : null,
-      registry: { getModules: () => [] },
+      registry: { getModules: (): unknown[] => [] },
       startServer: vi.fn().mockResolvedValue(undefined),
       stopServer: vi.fn().mockResolvedValue(undefined),
       restartServer: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

Closes #224.

CI run `24627190298` had two ESLint annotations pointing at `tests/settings.test.ts` — both `@typescript-eslint/explicit-function-return-type` warnings on local mock helpers. This PR clears them so the file lints cleanly.

## Changes

- `tests/settings.test.ts`
  - `createMockPlugin(...)` → `createMockPlugin(...): Record<string, unknown>`
  - inline `registry: { getModules: () => [] }` → `getModules: (): unknown[] => []`
  - `mockPlugin` retyped from `Record<string, any>` to `Record<string, unknown>`, adjacent `// eslint-disable-next-line @typescript-eslint/no-explicit-any` dropped
- `CLAUDE.md` — removed the stale "pre-existing warnings" caveat; the file is now warning-free

## Verification

- `npm run lint` → 0 errors, 0 warnings
- `npm run typecheck` → clean
- `npm test` → 491/491 passing

No runtime behaviour change; only type annotations on test helpers.