### PR TITLE
feat(ci/release): attach plugin zip to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,25 @@ jobs:
             fs.writeFileSync('versions.json', JSON.stringify(versions, null, '\t') + '\n');
           "
 
+      - name: Build plugin zip
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          PLUGIN_ID: obsidian-mcp
+          VERSION: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+        run: |
+          mkdir -p "dist/${PLUGIN_ID}"
+          cp main.js manifest.json styles.css "dist/${PLUGIN_ID}/"
+          (cd dist && zip -r "../${PLUGIN_ID}-${VERSION}.zip" "${PLUGIN_ID}")
+
       - name: Upload plugin release assets
         if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
         run: |
           gh release upload ${{ steps.release.outputs.tag_name }} \
             main.js \
             manifest.json \
             styles.css \
-            versions.json
+            versions.json \
+            "obsidian-mcp-${VERSION}.zip"

--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -56,12 +56,22 @@ automatically.
 
 ### Option B — Manual install
 
-1. Download `main.js`, `manifest.json`, and `styles.css` from the
-   [latest release](https://github.com/KingOfKalk/obisdian-plugin-mcp/releases).
-2. Create the folder `<your-vault>/.obsidian/plugins/obsidian-mcp/`.
-3. Copy the three files into that folder.
-4. Reload Obsidian (`Ctrl/Cmd+R` or restart) and enable **MCP Server** under
+The simplest manual install uses the prebuilt zip attached to each release.
+The zip contains an `obsidian-mcp/` folder with `main.js`, `manifest.json`,
+and `styles.css` inside, ready to drop into your vault.
+
+1. Open the [latest release](https://github.com/KingOfKalk/obisdian-plugin-mcp/releases)
+   and download `obsidian-mcp-<version>.zip` from the **Assets** section.
+2. Extract the zip into `<your-vault>/.obsidian/plugins/`. You should end up
+   with the folder `<your-vault>/.obsidian/plugins/obsidian-mcp/` containing
+   the three plugin files.
+3. Reload Obsidian (`Ctrl/Cmd+R` or restart) and enable **MCP Server** under
    **Settings → Community plugins**.
+
+If you'd rather grab the files individually, download `main.js`,
+`manifest.json`, and `styles.css` from the same release, create the folder
+`<your-vault>/.obsidian/plugins/obsidian-mcp/` yourself, and drop the three
+files into it.
 
 ---
 


### PR DESCRIPTION
Closes #234

## Summary

- `release.yml` now builds `obsidian-mcp-<version>.zip` and attaches it to the GitHub release alongside the existing per-file assets.
- The zip contains a nested `obsidian-mcp/` folder with `main.js`, `manifest.json`, and `styles.css` — extract straight into `<vault>/.obsidian/plugins/`, no manual folder creation.
- `docs/help/en.md` "Manual install" section updated to point at the zip first, with the per-file flow kept as a fallback.
- Workflow only — older releases are not backfilled.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (491 tests pass)
- [x] `npm run docs:check`
- [x] Simulated the workflow zip step locally — `unzip -l` confirms the archive contains exactly `obsidian-mcp/`, `obsidian-mcp/main.js`, `obsidian-mcp/manifest.json`, `obsidian-mcp/styles.css`.
- [ ] Real validation happens on the next release-please release: confirm the zip appears on the release page and extracts into `.obsidian/plugins/` cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mNx35QMMQ47s3ckwAEdcD)_