### PR TITLE
ci(release): pin release-please-action to v5.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@v5.0.0
         id: release
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #239

## Summary

- Replace floating major tag `googleapis/release-please-action@v5` with the exact `@v5.0.0` release in `.github/workflows/release.yml`.
- Makes release runs reproducible: `@v5` would silently track future v5.x.y pushes from upstream; `@v5.0.0` resolves to the exact release notes at https://github.com/googleapis/release-please-action/releases/tag/v5.0.0.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm test` — 491 passed
- [ ] Next push to `main` triggers the Release workflow successfully (verifiable post-merge in the Actions tab)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvvqGfjizZe8fUV7xjqsis)_