### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
Closes #242

## Summary

- New workflow `.github/workflows/codeql.yml` runs CodeQL analysis on JavaScript/TypeScript
- Triggers: push to `main`, PRs against `main`, weekly schedule (Mondays 06:00 UTC)
- Query suite: `security-and-quality`
- Build mode: `none` (CodeQL extracts JS/TS without a build)
- Uses CodeQL Action v4 (latest supported)

## Test plan

- [ ] CI passes (existing `build-and-test` job)
- [ ] CodeQL job runs and completes without errors
- [ ] Any findings show up under repo Security → Code scanning
- [ ] After merge: add the CodeQL job as a required status check on the default-branch ruleset