### PR TITLE
ci: harden Dependabot setup for public release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,19 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      production-deps:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-deps:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
@@ -13,3 +26,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve dev-dep or github-actions minor/patch updates
+        if: |
+          (steps.metadata.outputs.dependency-type == 'direct:development' ||
+           steps.metadata.outputs.package-ecosystem == 'github_actions') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for dev-dep or github-actions minor/patch updates
+        if: |
+          (steps.metadata.outputs.dependency-type == 'direct:development' ||
+           steps.metadata.outputs.package-ecosystem == 'github_actions') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #259

## Summary

- Group npm minor/patch bumps by `production` vs `development` so a broken dev tool can't block a runtime dependency bump
- Group github-actions minor/patch bumps into a single PR
- Add `dependencies` label to npm updates for consistency
- Add auto-merge workflow that approves and enables auto-merge on Dependabot PRs that are minor/patch bumps in dev-deps or github-actions; major bumps and production-dep bumps still require manual review
- Repo settings (out-of-band, applied via API): Dependabot alerts enabled, repo-level auto-merge feature enabled

## Why

Branch ruleset now requires one approving review. Dependabot can't approve its own PRs, so without the auto-merge workflow, low-risk dependency bumps would queue indefinitely. Splitting prod and dev dependency groups isolates risk: a flaky devDependency bump can't hold up a security-relevant runtime bump.

## Test plan

- [ ] CI passes (`build-and-test`)
- [ ] After merge: wait for the next weekly Dependabot run; verify it produces grouped PRs (one per group) instead of one PR per dependency
- [ ] Verify the auto-merge workflow approves and enables auto-merge on a dev-dep minor/patch PR
- [ ] Verify a (synthetic or future) production-dep PR is **not** auto-approved
- [ ] Verify a major version bump is **not** auto-approved