### PR TITLE
fix(server/auth): use crypto.timingSafeEqual for bearer compare and rate-limit failures

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -260,6 +260,20 @@ the right header. Check:
 - Re-copy the **MCP Client Configuration** snippet after generating a new
   key; the snippet is rebuilt from the live key.
 
+### My client says "429 Too Many Requests"
+
+After 5 failed authentication attempts within 60 seconds from the same
+client IP, the server temporarily blocks that IP for 30 seconds and
+returns HTTP 429 with a `Retry-After` header. This is anti-brute-force
+protection and isn't configurable.
+
+- Wait the indicated number of seconds (the `Retry-After` header tells
+  you how long), then retry with the correct token.
+- A successful authentication clears the failure counter for that IP
+  immediately, so once you fix the token, the next request succeeds.
+- If you keep hitting this after fixing the token, an old client or
+  background process is probably still using the wrong key — close it.
+
 ### The server won't auto-start
 
 Auto-start is gated by auth. If **Require Bearer authentication** is on but

--- a/docs/superpowers/plans/245-timing-safe-bearer-compare.md
+++ b/docs/superpowers/plans/245-timing-safe-bearer-compare.md
@@ -1,0 +1,149 @@
+# Plan: timing-safe bearer compare + rate-limit failures (Issue #245)
+
+## Goal
+
+Eliminate the timing-attack surface in `authenticateRequest` and stop
+brute-force attempts on the bearer token by adding a per-IP failure
+rate limiter.
+
+## Approach
+
+### 1. Constant-time token comparison (`src/server/auth.ts`)
+
+- Replace `token !== accessKey` with a constant-time compare.
+- Algorithm:
+  1. Allocate two equal-length buffers (length = `max(token.length, accessKey.length)`)
+     filled from the UTF-8 bytes of each input (zero-padded).
+  2. Always run `crypto.timingSafeEqual` on those buffers — never
+     short-circuit on length mismatch, because branching on length
+     leaks information.
+  3. AND the `timingSafeEqual` result with `token.length === accessKey.length`.
+- This means the costly compare runs whether or not the lengths match,
+  so an attacker cannot distinguish "wrong length" from "wrong content"
+  by timing.
+
+### 2. Per-IP failure rate limiter (new `src/server/rate-limiter.ts`)
+
+- New class `FailureRateLimiter` with config:
+  - `maxFailures` (default 5)
+  - `windowMs` (default 60_000)
+  - `blockMs` (default 30_000)
+  - `maxEntries` (default 1000) — bound table size
+  - `clock` — injectable `() => number`, defaults to `Date.now`
+- Methods:
+  - `check(ip)` → `{ blocked: boolean; retryAfterMs?: number }`
+    - If currently in block window for this IP → blocked.
+    - Otherwise → not blocked.
+  - `recordFailure(ip)` → updates the rolling failure window.
+    - When failure count within window reaches `maxFailures`, set
+      `blockedUntil = now + blockMs`.
+    - Drops failures older than `windowMs` so the counter is rolling.
+  - `recordSuccess(ip)` → deletes the entry entirely. (Per issue:
+    "Reset the counter on first successful auth from that IP.")
+- Eviction: when adding a brand-new IP entry would push the table over
+  `maxEntries`, evict the oldest entry (insertion-order via `Map`).
+  Insertion-order Map iteration in JS preserves insertion order, so
+  `map.keys().next().value` gives the oldest. Re-insert on update to
+  refresh order? — No: keep oldest = "first added" so a flood of new
+  IPs doesn't push out an active attacker. Evict the **first** entry.
+
+### 3. IP normalization
+
+- `req.socket.remoteAddress` may yield `::ffff:127.0.0.1` for IPv4 over
+  IPv6 sockets. Strip the `::ffff:` prefix so the limiter has a single
+  key per logical IP. Implement as `normalizeIp(addr)` helper in
+  `rate-limiter.ts` (exported for tests).
+- If `remoteAddress` is undefined, treat as `unknown` — still rate-limit
+  under that synthetic key.
+
+### 4. Wiring (`src/server/http-server.ts`)
+
+- Add `rateLimiter` field to `HttpMcpServer`, instantiated in the
+  constructor with the same `clock` so tests can advance time.
+- In `handleRequest`, before `authenticateRequest`:
+  - If `authEnabled` is true, derive `clientIp` and call
+    `rateLimiter.check(clientIp)`.
+  - If blocked → respond 429 with `Retry-After` header (seconds,
+    rounded up) and a JSON body `{ error: "Too many failed attempts" }`.
+- After `authenticateRequest`:
+  - If `!authResult.authenticated` and `authEnabled` → `recordFailure(ip)`.
+  - If `authResult.authenticated` and `authEnabled` → `recordSuccess(ip)`.
+- The bypass when `authEnabled` is false stays as-is (no rate
+  limiting needed — auth is intentionally off).
+
+### 5. AuthResult shape
+
+- Don't change `AuthResult` — it stays `{ authenticated, error }`.
+- 429 vs 401 is decided in `http-server.ts` (the limiter says "blocked");
+  `authenticateRequest` itself never returns 429 because it doesn't know
+  about IPs. This is the cleanest split.
+
+### 6. Logging
+
+- Confirm no token is logged. Current `this.logger.warn('Authentication failed', { error: authResult.error })` only emits the generic error string, which never contains the token. Keep that.
+- For 429: log a single warn line with the IP (truncated/redacted? No — same logging behaviour as the existing 401 path; IPs aren't secret).
+
+## Files touched
+
+- `src/server/auth.ts` — constant-time compare.
+- `src/server/rate-limiter.ts` — new file.
+- `src/server/http-server.ts` — wire limiter, send 429.
+- `tests/server/auth.test.ts` — add timing-safe cases.
+- `tests/server/rate-limiter.test.ts` — new file, unit tests.
+- `tests/server/dispatcher.test.ts` — no change; rate limiter not wired through dispatcher.
+- `docs/superpowers/plans/245-timing-safe-bearer-compare.md` — this plan.
+
+## Test list
+
+### `tests/server/auth.test.ts`
+
+1. equal tokens of equal length → authenticated (already covered, keep).
+2. unequal tokens of equal length → rejected.
+3. unequal tokens of different length → rejected.
+4. (existing) reject empty token.
+
+### `tests/server/rate-limiter.test.ts`
+
+1. allows requests under threshold.
+2. blocks after 5 failures within 60s.
+3. unblocks after 30s block window.
+4. resets counter on success.
+5. failures older than `windowMs` are forgotten (rolling window).
+6. blocks per IP independently — failures on one IP don't block another.
+7. evicts oldest entry at `maxEntries`.
+8. `normalizeIp` strips `::ffff:` prefix.
+9. `check` returns `retryAfterMs` while blocked.
+
+### Integration sanity
+
+- The dispatcher / HTTP layer test would require spinning a real
+  socket; existing tests don't do that. We'll rely on a focused
+  limiter+wiring test rather than introducing a new HTTP harness.
+- (Optional) Extend `auth.test.ts` to cover that the function itself
+  is unaware of rate limiting — already implicit; not adding.
+
+## Risks
+
+- **Breaking constant-time semantics**: easy to accidentally
+  short-circuit. Mitigation: write the compare as buffer-fill +
+  unconditional `timingSafeEqual` + final AND.
+- **OOM via unique-IP flood**: mitigated by `maxEntries` cap with
+  oldest-eviction.
+- **IP spoofing through proxies**: out of scope — we use the socket
+  peer address, not `X-Forwarded-For`. Matches issue scope.
+- **Rate-limiting localhost during dev**: a local user fat-fingering
+  the token 5 times gets a 30s lockout. Acceptable for security
+  posture; documented in PR body.
+
+## Verification
+
+- `npm run lint`
+- `npx vitest run`
+- `npm run typecheck`
+
+## Out of scope
+
+- Replacing `console.log`-style debug instrumentation; logger is
+  already structured.
+- Per-token (vs per-IP) limiting; issue explicitly asks per-IP.
+- Trusting `X-Forwarded-For` — would need explicit proxy config.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage, ServerResponse } from 'http';
+import { timingSafeEqual } from 'crypto';
 
 export interface AuthResult {
   authenticated: boolean;
@@ -29,11 +30,32 @@ export function authenticateRequest(
   }
 
   const token = parts[1];
-  if (token !== accessKey) {
+  if (!constantTimeEqual(token, accessKey)) {
     return { authenticated: false, error: 'Invalid access key' };
   }
 
   return { authenticated: true };
+}
+
+/**
+ * Constant-time string compare designed to avoid leaking information
+ * about either operand via timing.
+ *
+ * Both inputs are zero-padded to a common length so `timingSafeEqual`
+ * always runs over equal-sized buffers. The length-equality check is
+ * AND-ed into the result *after* the timing-safe compare so a length
+ * mismatch never short-circuits the work.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  const length = Math.max(aBuf.length, bBuf.length, 1);
+  const aPadded = Buffer.alloc(length);
+  const bPadded = Buffer.alloc(length);
+  aBuf.copy(aPadded);
+  bBuf.copy(bPadded);
+  const equal = timingSafeEqual(aPadded, bPadded);
+  return equal && aBuf.length === bBuf.length;
 }
 
 export function sendAuthError(res: ServerResponse, error: string): void {
@@ -42,4 +64,16 @@ export function sendAuthError(res: ServerResponse, error: string): void {
     'WWW-Authenticate': 'Bearer',
   });
   res.end(JSON.stringify({ error }));
+}
+
+export function sendRateLimitError(
+  res: ServerResponse,
+  retryAfterMs: number,
+): void {
+  const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  res.writeHead(429, {
+    'Content-Type': 'application/json',
+    'Retry-After': String(retryAfterSeconds),
+  });
+  res.end(JSON.stringify({ error: 'Too many failed authentication attempts' }));
 }

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -5,8 +5,9 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '../utils/logger';
-import { authenticateRequest, sendAuthError } from './auth';
+import { authenticateRequest, sendAuthError, sendRateLimitError } from './auth';
 import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } from './cors';
+import { FailureRateLimiter, normalizeIp } from './rate-limiter';
 
 export interface HttpServerOptions {
   host: string;
@@ -50,6 +51,7 @@ export class HttpMcpServer {
   private sessions = new Map<string, Session>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   private clock: () => number;
+  private rateLimiter: FailureRateLimiter;
 
   constructor(
     serverFactory: McpServerFactory,
@@ -61,6 +63,7 @@ export class HttpMcpServer {
     this.logger = logger;
     this.options = options;
     this.clock = clock;
+    this.rateLimiter = new FailureRateLimiter({ clock });
   }
 
   get connectedClients(): number {
@@ -187,15 +190,36 @@ export class HttpMcpServer {
 
     applyCorsHeaders(res, corsOptions);
 
+    const clientIp = normalizeIp(req.socket.remoteAddress);
+
+    if (this.options.authEnabled) {
+      const limit = this.rateLimiter.check(clientIp);
+      if (limit.blocked) {
+        this.logger.warn('Authentication rate-limited', {
+          ip: clientIp,
+          retryAfterMs: limit.retryAfterMs,
+        });
+        sendRateLimitError(res, limit.retryAfterMs ?? 1000);
+        return;
+      }
+    }
+
     const authResult = authenticateRequest(
       req,
       this.options.accessKey,
       this.options.authEnabled,
     );
     if (!authResult.authenticated) {
+      if (this.options.authEnabled) {
+        this.rateLimiter.recordFailure(clientIp);
+      }
       this.logger.warn('Authentication failed', { error: authResult.error });
       sendAuthError(res, authResult.error ?? 'Authentication failed');
       return;
+    }
+
+    if (this.options.authEnabled) {
+      this.rateLimiter.recordSuccess(clientIp);
     }
 
     this.logger.debug(`${req.method ?? 'UNKNOWN'} ${req.url ?? '/'}`);

--- a/src/server/rate-limiter.ts
+++ b/src/server/rate-limiter.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-IP failure rate limiter for bearer-auth attempts.
+ *
+ * Tracks consecutive failed authentications per remote address. After
+ * `maxFailures` failures inside a `windowMs` rolling window, the IP is
+ * blocked for `blockMs` milliseconds. A successful authentication clears
+ * the IP's record.
+ *
+ * The internal table is bounded by `maxEntries`; once full, the
+ * insertion-oldest entry is evicted to keep memory usage bounded under a
+ * flood of unique source IPs.
+ */
+
+export interface FailureRateLimiterOptions {
+  /** Maximum failures within `windowMs` before the IP is blocked. */
+  maxFailures?: number;
+  /** Sliding window for counting failures, in milliseconds. */
+  windowMs?: number;
+  /** How long to block an IP after the threshold trips, in milliseconds. */
+  blockMs?: number;
+  /** Maximum number of IP entries to retain; oldest are evicted past this. */
+  maxEntries?: number;
+  /** Clock function; defaults to `Date.now`. Injectable for tests. */
+  clock?: () => number;
+}
+
+export interface CheckResult {
+  blocked: boolean;
+  /** Milliseconds until the block expires, only set when `blocked` is true. */
+  retryAfterMs?: number;
+}
+
+interface Entry {
+  /** Failure timestamps inside the rolling window. */
+  failures: number[];
+  /** Absolute timestamp at which the block lifts; 0 when not blocked. */
+  blockedUntil: number;
+}
+
+const DEFAULTS = {
+  maxFailures: 5,
+  windowMs: 60_000,
+  blockMs: 30_000,
+  maxEntries: 1000,
+} as const;
+
+export class FailureRateLimiter {
+  private readonly maxFailures: number;
+  private readonly windowMs: number;
+  private readonly blockMs: number;
+  private readonly maxEntries: number;
+  private readonly clock: () => number;
+  private readonly entries = new Map<string, Entry>();
+
+  constructor(options: FailureRateLimiterOptions = {}) {
+    this.maxFailures = options.maxFailures ?? DEFAULTS.maxFailures;
+    this.windowMs = options.windowMs ?? DEFAULTS.windowMs;
+    this.blockMs = options.blockMs ?? DEFAULTS.blockMs;
+    this.maxEntries = options.maxEntries ?? DEFAULTS.maxEntries;
+    this.clock = options.clock ?? Date.now;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  has(ip: string): boolean {
+    return this.entries.has(ip);
+  }
+
+  check(ip: string): CheckResult {
+    const entry = this.entries.get(ip);
+    if (!entry) {
+      return { blocked: false };
+    }
+    const now = this.clock();
+    if (entry.blockedUntil > now) {
+      return { blocked: true, retryAfterMs: entry.blockedUntil - now };
+    }
+    return { blocked: false };
+  }
+
+  recordFailure(ip: string): void {
+    const now = this.clock();
+    let entry = this.entries.get(ip);
+    if (!entry) {
+      this.evictIfNeeded();
+      entry = { failures: [], blockedUntil: 0 };
+      this.entries.set(ip, entry);
+    }
+
+    // Drop failures that fell out of the rolling window.
+    const cutoff = now - this.windowMs;
+    while (entry.failures.length > 0 && entry.failures[0] <= cutoff) {
+      entry.failures.shift();
+    }
+
+    entry.failures.push(now);
+
+    if (entry.failures.length >= this.maxFailures) {
+      entry.blockedUntil = now + this.blockMs;
+    }
+  }
+
+  recordSuccess(ip: string): void {
+    this.entries.delete(ip);
+  }
+
+  private evictIfNeeded(): void {
+    if (this.entries.size < this.maxEntries) {
+      return;
+    }
+    // Map preserves insertion order; the first key is the oldest entry.
+    const oldest = this.entries.keys().next();
+    if (!oldest.done) {
+      this.entries.delete(oldest.value);
+    }
+  }
+}
+
+/**
+ * Normalize a peer-socket remote address so the limiter treats logical
+ * IPs as a single key. Strips the IPv6-mapped-IPv4 prefix `::ffff:` and
+ * falls back to a stable `"unknown"` token when the address is missing.
+ */
+export function normalizeIp(addr: string | undefined): string {
+  if (!addr) {
+    return 'unknown';
+  }
+  if (addr.startsWith('::ffff:')) {
+    return addr.slice('::ffff:'.length);
+  }
+  return addr;
+}

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -38,6 +38,42 @@ describe('authenticateRequest', () => {
       expect(result.error).toContain('Invalid access key');
     });
 
+    it('authenticates with equal tokens of equal length (timing-safe path)', () => {
+      const key = 'a'.repeat(32);
+      const req = createMockRequest({ authorization: `Bearer ${key}` });
+      const result = authenticateRequest(req, key, true);
+      expect(result.authenticated).toBe(true);
+    });
+
+    it('rejects unequal tokens of equal length (timing-safe path)', () => {
+      const key = 'a'.repeat(32);
+      const wrong = 'b'.repeat(32);
+      const req = createMockRequest({ authorization: `Bearer ${wrong}` });
+      const result = authenticateRequest(req, key, true);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Invalid access key');
+    });
+
+    it('rejects tokens of different length without leaking via short-circuit', () => {
+      const key = 'a'.repeat(32);
+      const shorter = 'a'.repeat(16);
+      const longer = 'a'.repeat(48);
+      expect(
+        authenticateRequest(
+          createMockRequest({ authorization: `Bearer ${shorter}` }),
+          key,
+          true,
+        ).authenticated,
+      ).toBe(false);
+      expect(
+        authenticateRequest(
+          createMockRequest({ authorization: `Bearer ${longer}` }),
+          key,
+          true,
+        ).authenticated,
+      ).toBe(false);
+    });
+
     it('should reject when access key is empty', () => {
       const req = createMockRequest({ authorization: 'Bearer something' });
       const result = authenticateRequest(req, '', true);

--- a/tests/server/rate-limiter.test.ts
+++ b/tests/server/rate-limiter.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { FailureRateLimiter, normalizeIp } from '../../src/server/rate-limiter';
+
+function makeClock(): { now: () => number; advance: (ms: number) => void } {
+  let t = 1_000_000;
+  return {
+    now: (): number => t,
+    advance: (ms: number): void => {
+      t += ms;
+    },
+  };
+}
+
+describe('normalizeIp', (): void => {
+  it('strips IPv6-mapped IPv4 prefix', (): void => {
+    expect(normalizeIp('::ffff:127.0.0.1')).toBe('127.0.0.1');
+    expect(normalizeIp('::ffff:10.0.0.5')).toBe('10.0.0.5');
+  });
+
+  it('passes through plain IPv4 unchanged', (): void => {
+    expect(normalizeIp('127.0.0.1')).toBe('127.0.0.1');
+  });
+
+  it('passes through plain IPv6 unchanged', (): void => {
+    expect(normalizeIp('::1')).toBe('::1');
+    expect(normalizeIp('fe80::1')).toBe('fe80::1');
+  });
+
+  it('falls back to "unknown" for undefined', (): void => {
+    expect(normalizeIp(undefined)).toBe('unknown');
+  });
+});
+
+describe('FailureRateLimiter', (): void => {
+  it('does not block when under the failure threshold', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    expect(limiter.check('1.1.1.1').blocked).toBe(false);
+  });
+
+  it('blocks after 5 failures within the window', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    const result = limiter.check('1.1.1.1');
+    expect(result.blocked).toBe(true);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(30_000);
+  });
+
+  it('unblocks once the block window expires', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    expect(limiter.check('1.1.1.1').blocked).toBe(true);
+
+    clock.advance(30_001);
+    expect(limiter.check('1.1.1.1').blocked).toBe(false);
+  });
+
+  it('resets the counter on success', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    limiter.recordSuccess('1.1.1.1');
+    // After reset, the next 4 failures should NOT trip the block.
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    expect(limiter.check('1.1.1.1').blocked).toBe(false);
+  });
+
+  it('forgets failures older than windowMs (rolling window)', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    // 4 failures, then wait past window, then 1 more failure: should NOT block.
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    clock.advance(60_001);
+    limiter.recordFailure('1.1.1.1');
+    expect(limiter.check('1.1.1.1').blocked).toBe(false);
+  });
+
+  it('rate-limits per IP independently', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 1000,
+      clock: clock.now,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    expect(limiter.check('1.1.1.1').blocked).toBe(true);
+    expect(limiter.check('2.2.2.2').blocked).toBe(false);
+  });
+
+  it('evicts the oldest entry once maxEntries is exceeded', (): void => {
+    const clock = makeClock();
+    const limiter = new FailureRateLimiter({
+      maxFailures: 5,
+      windowMs: 60_000,
+      blockMs: 30_000,
+      maxEntries: 3,
+      clock: clock.now,
+    });
+
+    limiter.recordFailure('a');
+    limiter.recordFailure('b');
+    limiter.recordFailure('c');
+    expect(limiter.size).toBe(3);
+
+    // Adding a 4th unique IP must evict the oldest ('a').
+    limiter.recordFailure('d');
+    expect(limiter.size).toBe(3);
+    expect(limiter.has('a')).toBe(false);
+    expect(limiter.has('b')).toBe(true);
+    expect(limiter.has('c')).toBe(true);
+    expect(limiter.has('d')).toBe(true);
+  });
+
+  it('uses sensible defaults when no config is supplied', (): void => {
+    const limiter = new FailureRateLimiter();
+    for (let i = 0; i < 5; i++) {
+      limiter.recordFailure('1.1.1.1');
+    }
+    expect(limiter.check('1.1.1.1').blocked).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #245

## Summary

- Replace the per-byte-comparing `token !== accessKey` with a constant-time compare built on `crypto.timingSafeEqual`. Both inputs are zero-padded to a common length so the timing-safe call always runs on equal-sized buffers, and the length-equality check is AND-ed into the result *after* the compare so a length mismatch cannot short-circuit the work.
- Add a per-IP `FailureRateLimiter`: 5 failures within a 60 s rolling window trigger a 30 s block; a successful auth clears the IP. The table is bounded to 1000 entries with oldest-eviction so a unique-IP flood cannot OOM the server. IPv6-mapped IPv4 addresses are normalized so a single client maps to one key.
- Wire the limiter into `HttpMcpServer` and respond with HTTP 429 + `Retry-After` while blocked. Bearer tokens and full Authorization headers stay out of the logs.

## Test plan

- [x] `npx vitest run tests/server/auth.test.ts tests/server/rate-limiter.test.ts` — 25 tests pass (equal-length match, equal-length mismatch, different-length mismatch, threshold block, block expiry, success reset, rolling window, per-IP isolation, oldest-entry eviction, default config, IP normalization).
- [x] `npm test` — full suite passes (40 files, 506 tests).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `docs/help/en.md` updated with a new FAQ entry covering the 429 response.

## Notes / deviations

- `AuthResult` is unchanged. The 429 path is decided in `http-server.ts` from the limiter result rather than threading a new field through the auth function — `authenticateRequest` has no access to the IP, so this keeps the split clean.
- Rate limiting is skipped entirely when `authEnabled` is false, matching the existing "auth off bypasses everything" semantics.
- `X-Forwarded-For` is intentionally NOT trusted; the limiter keys on `req.socket.remoteAddress` only.