### PR TITLE
ci: drop node-version matrix so required status check name matches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,13 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20]
-
     steps:
       - uses: actions/checkout@v6
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 20
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/docs/superpowers/plans/267-ci-required-check-name.md
+++ b/docs/superpowers/plans/267-ci-required-check-name.md
@@ -1,0 +1,40 @@
+# Plan: fix CI required-check name mismatch (Issue #267)
+
+## Problem
+
+The repo's default ruleset requires a status check named `build-and-test`,
+but `.github/workflows/ci.yml` uses a `strategy.matrix` with
+`node-version: [20]`. GitHub appends the matrix value to the reported
+check name, so the actual check on every PR is `build-and-test (20)`.
+The required check `build-and-test` never fires, silently bypassing
+branch protection.
+
+## Approach (Option A from the issue)
+
+Drop `strategy.matrix` from `ci.yml`. The job name `build-and-test`
+will then match the ruleset's required context exactly, with no
+parenthesised suffix.
+
+## Changes
+
+- `.github/workflows/ci.yml`:
+  - Remove the `strategy.matrix.node-version` block.
+  - Replace `${{ matrix.node-version }}` with the literal `20` in the
+    `node-version` field of `actions/setup-node@v6`.
+  - Update the step name from `Use Node.js ${{ matrix.node-version }}`
+    to `Use Node.js 20`.
+  - Leave every other step untouched: lint, typecheck, docs:check,
+    test:coverage, build, `test -f main.js`.
+
+## Verification
+
+- The change is workflow-only; no `src/` or `tests/` change.
+- Still run `npm run lint`, `npm run typecheck`, `npm test` for hygiene.
+- Real verification is on the PR itself: GitHub must report the check as
+  exactly `build-and-test` (no `(20)` suffix), and the required-status-check
+  rule must enforce.
+
+## Out of scope
+
+- Adding more Node versions to CI.
+- Touching other workflows (`codeql.yml`, `release.yml`, etc.).


### PR DESCRIPTION
Closes #267

## Summary

- Drop `strategy.matrix` from `.github/workflows/ci.yml`. The single Node version (`20`) is inlined.
- The job now reports as exactly `build-and-test` (no `(20)` suffix), so the ruleset's required status check actually enforces.
- No behaviour change in lint, typecheck, docs:check, test, or build steps.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 506 tests pass
- [ ] Real verification on this PR: GitHub reports the check as exactly `build-and-test` (no parenthesised suffix), and merging is gated on it.