### PR TITLE
feat(server/http): validate Origin and Host for DNS-rebind protection

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -136,6 +136,28 @@ The settings tab is split into five sections.
 | **TLS Certificate** | auto | Generated on the first HTTPS start, then cached in `data.json`. Use **Regenerate certificate** if you change the address or want a fresh key pair — clients will need to re-trust the new cert. |
 | **Auto-start on launch** | off | Start the MCP server automatically when Obsidian loads. If auth is enabled but no key is set, the server stays stopped and the reason is logged. |
 
+#### DNS Rebind Protection
+
+Even though the server binds to `127.0.0.1`, a hostile webpage in your
+browser can use **DNS rebinding** to point `attacker.com` at `127.0.0.1`
+and reach the loopback port. The server defends against this by
+allowlisting the inbound `Origin` and `Host` headers — anything else is
+rejected with a `403`.
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Allowed Origins** | `http://127.0.0.1`, `http://localhost`, `https://127.0.0.1`, `https://localhost` | Exact-match list (one per line). If the request's `Origin` header isn't on the list, it's rejected. Include the port if your client sends it (e.g. `http://127.0.0.1:28741`). |
+| **Allowed Hosts** | `127.0.0.1`, `localhost` | Hostname-only list (one per line). The port portion of the inbound `Host` header is stripped before comparison. |
+| **Allow Origin: null** | off | When on, requests with `Origin: null` (sandboxed iframes, `file://` pages) are accepted. |
+| **Require Origin header** | off | When on, every request must carry an `Origin` header. Tightens browser-side checks but rejects server-side and CLI clients (`curl`, native MCP clients) that don't send `Origin`. |
+
+The settings tab warns you if you add a non-loopback entry to either
+list — only widen the allowlist if you understand the DNS-rebind risk.
+
+Rejections are logged at `warn` with the client IP, method, path, and
+the offending `Origin`/`Host` values. Body and Authorization headers are
+never logged.
+
 ### 3. MCP Client Configuration
 
 A single row with a **Copy** button. The JSON snippet is built live from your
@@ -273,6 +295,26 @@ protection and isn't configurable.
   immediately, so once you fix the token, the next request succeeds.
 - If you keep hitting this after fixing the token, an old client or
   background process is probably still using the wrong key — close it.
+
+### My client says "403 Forbidden" / "Origin not allowlisted" / "Host not allowlisted"
+
+DNS-rebind protection rejected the request. The server only accepts
+requests whose `Origin` and `Host` headers are on the allowlists in
+**Server Settings → DNS Rebind Protection**. Causes and fixes:
+
+- **Browser client on a non-default origin**: add the exact origin
+  (`scheme://host[:port]`) to **Allowed Origins**. The compare is exact —
+  `http://127.0.0.1` and `http://127.0.0.1:28741` are different entries.
+- **Custom hostname** (you mapped `obsidian.local` to `127.0.0.1`): add
+  the hostname to **Allowed Hosts**.
+- **`Origin: null`** (sandboxed iframe, `file://`): turn on **Allow
+  Origin: null**.
+- **`curl`/CLI without `Origin`** rejected: only happens when **Require
+  Origin header** is on. Either send an `Origin` header or turn the
+  setting off.
+
+The rejection is logged at `warn` with the offending values and never
+hits the rate limiter, so it can't lock you out of authentication.
 
 ### The server won't auto-start
 

--- a/docs/superpowers/plans/246-origin-host-validation.md
+++ b/docs/superpowers/plans/246-origin-host-validation.md
@@ -1,0 +1,165 @@
+# Plan: Origin/Host validation for DNS-rebind protection (Issue #246)
+
+## Goal
+
+Reject inbound HTTP requests whose `Origin` or `Host` header points at
+something other than localhost, so a hostile webpage cannot reach the
+loopback MCP port via DNS rebinding.
+
+## Approach
+
+### 1. Settings (`src/types.ts` + `src/settings/migrations.ts`)
+
+- Add four fields to `McpPluginSettings`:
+  - `allowedOrigins: string[]` — default
+    `['http://127.0.0.1', 'http://localhost', 'https://127.0.0.1', 'https://localhost']`.
+  - `allowedHosts: string[]` — default `['127.0.0.1', 'localhost']`.
+  - `allowNullOrigin: boolean` — default `false`.
+  - `requireOrigin: boolean` — default `false`.
+- Bump `CURRENT_SCHEMA_VERSION` from 8 to 9 and add `migrateV8ToV9` that
+  fills in the defaults when missing.
+
+### 2. Validator (`src/server/origin-host.ts`, new file)
+
+Pure function `validateOriginHost(req, opts)` returning a discriminated
+union:
+
+```ts
+type OriginHostResult =
+  | { ok: true }
+  | { ok: false; reason: string; origin: string | undefined; host: string | undefined };
+```
+
+- Read `Origin` and `Host` from `req.headers`. Both can be `string | string[] | undefined`.
+- `Host` rules:
+  - Missing/empty → reject `"Missing Host header"`.
+  - Strip `:port` suffix (last `:` for plain hosts; bracket-aware for IPv6
+    just in case — `localhost`/`127.0.0.1` are the realistic cases, but
+    handle `[::1]:port` defensively).
+  - Compare host portion against `allowedHosts` (case-insensitive).
+  - Not in allowlist → reject `"Host not allowlisted"`.
+- `Origin` rules:
+  - Absent and `requireOrigin` → reject `"Missing Origin header"`.
+  - Absent and not required → allow.
+  - `"null"` literal: allow only when `allowNullOrigin`.
+  - Otherwise: exact-match against `allowedOrigins` (case-insensitive on
+    scheme+host portion; ports if present must match verbatim per the
+    issue — "scheme + host + port-stripped — match the origin header
+    value verbatim against the allowlist"). Implementation: strip a
+    trailing `/`, then compare lowercase to lowercase allowlist entries
+    (also stripped of trailing `/`).
+- Settings/empty values: an empty `allowedOrigins` / `allowedHosts` list
+  rejects everything except the trivial bypasses described above.
+
+### 3. Wire into `handleRequest` (`src/server/http-server.ts`)
+
+- Run `validateOriginHost` at the **very top** of `handleRequest`,
+  before `handlePreflight`. This is the only behavioural change to the
+  existing pipeline; preflight, CORS headers, rate limiter, and auth
+  stay in place after the check.
+- On rejection:
+  1. Apply CORS headers (so the browser surfaces a clearer failure).
+  2. `res.writeHead(403, { 'Content-Type': 'application/json' })`.
+  3. Body: `{ "error": "<reason>" }`.
+  4. `this.logger.warn('Request rejected: origin/host validation', { ip, method, url, origin, host, reason })`.
+  5. Do **not** touch the rate limiter (per issue: rejection is pre-auth
+     and must not consume the failure budget).
+  6. Return — never dispatch to JSON-RPC.
+
+### 4. Settings UI (`src/settings/server-section.ts`)
+
+- New "DNS Rebind Protection" subgroup beneath Auto-start.
+- Two textareas:
+  - `Allowed Origins` (one per line).
+  - `Allowed Hosts` (one per line).
+- Two toggles:
+  - `Allow Origin: null` (default off).
+  - `Require Origin header` (default off).
+- For each list, after the user changes the value, parse non-loopback
+  entries and surface a warning string under the textarea (similar to
+  the existing `warning_non_localhost` for `serverAddress`). Loopback
+  entries: `127.0.0.1`, `localhost`, `[::1]`, `::1`, plus the
+  `http(s)://` variants for origins.
+
+### 5. Translation strings (`src/lang/locale/en.ts`, `src/lang/locale/de.ts`)
+
+- Add new keys: section heading, four setting names + descriptions, the
+  loopback-only warnings. German translations alongside.
+
+### 6. User manual (`docs/help/en.md`)
+
+- Add new rows to the Server Settings table for the four new settings.
+- Add a brief "DNS Rebind Protection" subsection documenting why it
+  exists, what gets rejected, and how to widen it (with the warning).
+- Add an FAQ entry for "I'm getting 403 from a real client" pointing at
+  the new settings.
+
+### 7. Tests
+
+#### `tests/server/origin-host.test.ts` (new)
+
+Pure unit tests of `validateOriginHost`:
+
+- same-origin allowed (`Origin: http://127.0.0.1:28741`, allowlist
+  contains `http://127.0.0.1:28741`).
+- exact match required — different port rejected.
+- cross-origin rejected (`Origin: http://attacker.com`).
+- `Origin: null` rejected by default.
+- `Origin: null` allowed when `allowNullOrigin: true`.
+- missing `Origin` allowed by default.
+- missing `Origin` rejected when `requireOrigin: true`.
+- hostile `Host` rejected (`Host: attacker.com`).
+- allowed `Host` with port (`Host: 127.0.0.1:27123`).
+- empty/missing `Host` rejected.
+- case-insensitive host compare (`Host: LocalHost`).
+- empty allowedHosts/allowedOrigins → reject everything.
+
+#### `tests/server/http-server.test.ts` (new)
+
+Integration via real loopback HTTP server (cheap — `node:http` already
+in use) to assert full pipeline behaviour:
+
+- 403 returned for rejected request with JSON body.
+- rejected request does NOT trigger the rate limiter (record nothing —
+  inspect by issuing many rejections then a valid request and asserting
+  the auth path runs normally).
+- rejected request does NOT dispatch to JSON-RPC (we observe by ensuring
+  the server factory is never invoked).
+- preflight from disallowed origin still returns 403.
+- legit `127.0.0.1` POST passes the check (then fails for a different
+  reason — invalid JSON body or missing session — but the test only
+  asserts the validator did not 403 it).
+
+Approach: subclass-free harness that constructs `HttpMcpServer` with a
+spy `serverFactory` and calls `start()` on a random port (port 0). Use
+`node:http` to make assertions, then `stop()`.
+
+#### `tests/server/migrations.test.ts`
+
+If the file exists, add coverage for the v8→v9 hop. Otherwise skip — the
+migration is trivial and exercised by the integration path.
+
+## Verification
+
+- `npm run lint`
+- `npm test`
+- `npm run typecheck`
+
+## Out of scope
+
+- TLS / cert pinning.
+- CSRF tokens.
+- Settings UI tests (the project doesn't appear to test rendered
+  Setting widgets; following existing conventions).
+
+## Commit plan
+
+Single PR, three commits:
+
+1. `docs(plans/246): plan for Origin/Host validation`.
+2. `feat(server/http): validate Origin and Host for DNS-rebind protection`
+   — types, validator, wiring, settings UI, translations, tests.
+3. `docs(help/en): document DNS rebind protection settings`
+   — manual updates.
+
+(Or fold 3 into 2 if it stays small — decided at commit time.)

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -78,6 +78,25 @@ const de: Partial<Record<keyof typeof en, string>> = {
     'MCP-Server nicht gestartet — das eigene Zertifikat ist ungültig: {message}',
   setting_autostart_name: 'Beim Start automatisch starten',
   setting_autostart_desc: 'MCP-Server automatisch starten, wenn Obsidian gestartet wird',
+
+  // DNS Rebind Protection
+  heading_dns_rebind: 'DNS-Rebind-Schutz',
+  setting_allowed_origins_name: 'Erlaubte Origins',
+  setting_allowed_origins_desc:
+    'Ein Eintrag pro Zeile. Anfragen mit einem Origin-Header außerhalb dieser Liste werden mit 403 abgelehnt. Standard: nur Loopback (http(s)://127.0.0.1, http(s)://localhost). Vergleich ist exakt — Port mit angeben, falls dein Client einen sendet.',
+  setting_allowed_hosts_name: 'Erlaubte Hosts',
+  setting_allowed_hosts_desc:
+    'Ein Eintrag pro Zeile. Anfragen mit einem Host-Header (ohne Port) außerhalb dieser Liste werden mit 403 abgelehnt. Standard: 127.0.0.1, localhost.',
+  setting_allow_null_origin_name: 'Origin: null erlauben',
+  setting_allow_null_origin_desc:
+    'Wenn aktiviert, werden Anfragen mit „Origin: null" (Sandbox-iframes, file://) akzeptiert. Standardmäßig aus — nur einschalten, wenn du es wirklich brauchst.',
+  setting_require_origin_name: 'Origin-Header verpflichtend',
+  setting_require_origin_desc:
+    'Wenn aktiviert, muss jede Anfrage einen Origin-Header tragen. Verschärft die Browser-Prüfung, bricht aber Server- und CLI-Clients (curl, native MCP-Clients), die keinen Origin senden.',
+  warning_non_loopback_origin:
+    'Warnung: Mindestens ein Origin liegt außerhalb von Loopback. Das vergrößert die Angriffsfläche — nur aktivieren, wenn du DNS-Rebind-Risiken verstehst.',
+  warning_non_loopback_host:
+    'Warnung: Mindestens ein Host liegt außerhalb von Loopback. Das vergrößert die Angriffsfläche — nur aktivieren, wenn du DNS-Rebind-Risiken verstehst.',
   setting_debug_name: 'Debug-Modus',
   setting_debug_desc: 'Ausführliches Protokollieren von MCP-Anfragen und -Antworten',
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -69,6 +69,25 @@ const en = {
     'MCP server not started — bring-your-own certificate is invalid: {message}',
   setting_autostart_name: 'Auto-start on launch',
   setting_autostart_desc: 'Start MCP server automatically when Obsidian launches',
+
+  // Settings — DNS Rebind Protection subsection (Origin / Host validation)
+  heading_dns_rebind: 'DNS Rebind Protection',
+  setting_allowed_origins_name: 'Allowed Origins',
+  setting_allowed_origins_desc:
+    'One per line. Requests whose Origin header is not on this list are rejected with 403. Default: loopback only (http(s)://127.0.0.1, http(s)://localhost). Match is exact — include the port if your client sends it.',
+  setting_allowed_hosts_name: 'Allowed Hosts',
+  setting_allowed_hosts_desc:
+    'One per line. Requests whose Host header (port stripped) is not on this list are rejected with 403. Default: 127.0.0.1, localhost.',
+  setting_allow_null_origin_name: 'Allow Origin: null',
+  setting_allow_null_origin_desc:
+    'When on, requests with `Origin: null` (sandboxed iframes, file://) are accepted. Off by default — only enable if you know you need it.',
+  setting_require_origin_name: 'Require Origin header',
+  setting_require_origin_desc:
+    'When on, every request must carry an Origin header. Tightens browser-side checks but breaks server-side and CLI clients (curl, native MCP clients) that do not send Origin.',
+  warning_non_loopback_origin:
+    'Warning: One or more Origins point outside loopback. This widens the attack surface — only do this if you understand DNS-rebind risks.',
+  warning_non_loopback_host:
+    'Warning: One or more Hosts point outside loopback. This widens the attack surface — only do this if you understand DNS-rebind risks.',
   setting_debug_name: 'Debug Mode',
   setting_debug_desc: 'Enable verbose logging of MCP requests and responses',
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,12 @@ export default class McpPlugin extends Plugin {
         authEnabled: this.settings.authEnabled,
         accessKey: this.settings.accessKey,
         tls,
+        originHost: {
+          allowedOrigins: this.settings.allowedOrigins,
+          allowedHosts: this.settings.allowedHosts,
+          allowNullOrigin: this.settings.allowNullOrigin,
+          requireOrigin: this.settings.requireOrigin,
+        },
       },
     );
 

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -8,6 +8,7 @@ import { Logger } from '../utils/logger';
 import { authenticateRequest, sendAuthError, sendRateLimitError } from './auth';
 import { applyCorsHeaders, handlePreflight, CorsOptions, DEFAULT_CORS_OPTIONS } from './cors';
 import { FailureRateLimiter, normalizeIp } from './rate-limiter';
+import { validateOriginHost, type OriginHostOptions } from './origin-host';
 
 export interface HttpServerOptions {
   host: string;
@@ -28,7 +29,24 @@ export interface HttpServerOptions {
    * to disable the sweep entirely.
    */
   sessionSweepIntervalMs?: number;
+  /**
+   * DNS-rebind protection. When omitted, defaults to loopback-only Origin
+   * and Host allowlists; pass an explicit object to widen.
+   */
+  originHost?: OriginHostOptions;
 }
+
+const DEFAULT_ORIGIN_HOST_OPTIONS: OriginHostOptions = {
+  allowedOrigins: [
+    'http://127.0.0.1',
+    'http://localhost',
+    'https://127.0.0.1',
+    'https://localhost',
+  ],
+  allowedHosts: ['127.0.0.1', 'localhost'],
+  allowNullOrigin: false,
+  requireOrigin: false,
+};
 
 export type McpServerFactory = () => McpServer;
 
@@ -184,13 +202,35 @@ export class HttpMcpServer {
     res: ServerResponse,
     corsOptions: CorsOptions,
   ): Promise<void> {
+    const clientIp = normalizeIp(req.socket.remoteAddress);
+
+    // DNS-rebind protection: validate Origin and Host before anything
+    // else, including the CORS preflight. The rejection still carries
+    // CORS headers so the browser can surface a clearer failure message.
+    const originHostOpts = this.options.originHost ?? DEFAULT_ORIGIN_HOST_OPTIONS;
+    const originHostResult = validateOriginHost(req, originHostOpts);
+    if (!originHostResult.ok) {
+      this.logger.warn('Request rejected: origin/host validation failed', {
+        ip: clientIp,
+        method: req.method ?? 'UNKNOWN',
+        path: req.url ?? '/',
+        origin: originHostResult.origin,
+        host: originHostResult.host,
+        reason: originHostResult.reason,
+      });
+      applyCorsHeaders(res, corsOptions);
+      if (!res.headersSent) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: originHostResult.reason }));
+      }
+      return;
+    }
+
     if (handlePreflight(req, res, corsOptions)) {
       return;
     }
 
     applyCorsHeaders(res, corsOptions);
-
-    const clientIp = normalizeIp(req.socket.remoteAddress);
 
     if (this.options.authEnabled) {
       const limit = this.rateLimiter.check(clientIp);

--- a/src/server/origin-host.ts
+++ b/src/server/origin-host.ts
@@ -1,0 +1,132 @@
+import type { IncomingMessage, IncomingHttpHeaders } from 'http';
+
+/**
+ * Settings consumed by `validateOriginHost`. Mirrors the subset of
+ * `McpPluginSettings` relevant to DNS-rebind protection so the validator
+ * stays decoupled from the full settings type and trivially testable.
+ */
+export interface OriginHostOptions {
+  /**
+   * Exact origins (scheme + host [+ port]) that may issue requests.
+   * Compared case-insensitively after stripping a trailing slash.
+   */
+  allowedOrigins: string[];
+  /**
+   * Hostnames that may appear in the `Host` header. The port portion of
+   * the header is stripped before comparison; entries here are bare
+   * hostnames (e.g. `127.0.0.1`, `localhost`, `::1`).
+   */
+  allowedHosts: string[];
+  /** When true, treat literal `Origin: null` as allowed. */
+  allowNullOrigin: boolean;
+  /** When true, requests without an `Origin` header are rejected. */
+  requireOrigin: boolean;
+}
+
+/** Discriminated result returned by {@link validateOriginHost}. */
+export type OriginHostResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: string;
+      origin: string | undefined;
+      host: string | undefined;
+    };
+
+/**
+ * Validate the `Origin` and `Host` of an inbound request against the
+ * configured allowlists. The check protects loopback HTTP servers from
+ * DNS-rebind attacks: a hostile webpage can only reach the server if it
+ * arrives with an allowlisted `Origin` AND `Host`.
+ */
+export function validateOriginHost(
+  req: IncomingMessage,
+  opts: OriginHostOptions,
+): OriginHostResult {
+  const headers = req.headers;
+  const origin = pickHeader(headers, 'origin');
+  const host = pickHeader(headers, 'host');
+
+  // Host first: every request must carry an allowlisted Host.
+  if (host === undefined || host.length === 0) {
+    return { ok: false, reason: 'Missing Host header', origin, host };
+  }
+  const hostName = stripPort(host).toLowerCase();
+  const allowedHostsLower = opts.allowedHosts.map((h) => h.toLowerCase());
+  if (!allowedHostsLower.includes(hostName)) {
+    return { ok: false, reason: 'Host not allowlisted', origin, host };
+  }
+
+  // Origin handling.
+  if (origin === undefined) {
+    if (opts.requireOrigin) {
+      return { ok: false, reason: 'Missing Origin header', origin, host };
+    }
+    return { ok: true };
+  }
+
+  if (origin === 'null') {
+    if (opts.allowNullOrigin) {
+      return { ok: true };
+    }
+    return { ok: false, reason: 'Origin "null" not allowed', origin, host };
+  }
+
+  const normalizedOrigin = normalizeOrigin(origin);
+  const allowedOriginsNormalized = opts.allowedOrigins.map(normalizeOrigin);
+  if (!allowedOriginsNormalized.includes(normalizedOrigin)) {
+    return { ok: false, reason: 'Origin not allowlisted', origin, host };
+  }
+
+  return { ok: true };
+}
+
+function pickHeader(
+  headers: IncomingHttpHeaders,
+  name: string,
+): string | undefined {
+  const value = headers[name];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+/**
+ * Strip a `:port` suffix from a `Host` header value while preserving the
+ * IPv6 bracketed form (`[::1]:28741` → `::1`).
+ */
+function stripPort(host: string): string {
+  // IPv6 bracketed form: `[addr]:port` or just `[addr]`.
+  if (host.startsWith('[')) {
+    const closing = host.indexOf(']');
+    if (closing === -1) {
+      return host;
+    }
+    return host.slice(1, closing);
+  }
+  // Plain hostname or IPv4 — last colon separates the port. Bare IPv6 (no
+  // brackets) shouldn't appear in a Host header per RFC 7230, so the
+  // last-colon rule is safe for the realistic cases.
+  const colon = host.lastIndexOf(':');
+  if (colon === -1) {
+    return host;
+  }
+  return host.slice(0, colon);
+}
+
+/**
+ * Normalize an origin for comparison: lowercase and trim a trailing `/`.
+ * The Origin header is always `scheme://host[:port]` per RFC 6454; we
+ * leave the port untouched because the issue requires exact comparison.
+ */
+function normalizeOrigin(value: string): string {
+  let v = value.trim().toLowerCase();
+  if (v.endsWith('/')) {
+    v = v.slice(0, -1);
+  }
+  return v;
+}

--- a/src/settings/migrations.ts
+++ b/src/settings/migrations.ts
@@ -77,6 +77,25 @@ export function migrateV7ToV8(data: Settings): void {
   }
 }
 
+export function migrateV8ToV9(data: Settings): void {
+  // DNS-rebind protection. Default to loopback-only allowlists so the
+  // loopback-bound server rejects hostile webpages that resolve
+  // attacker.com to 127.0.0.1 and try to fetch the MCP endpoint.
+  if (!Array.isArray(data.allowedOrigins)) {
+    data.allowedOrigins = [
+      'http://127.0.0.1',
+      'http://localhost',
+      'https://127.0.0.1',
+      'https://localhost',
+    ];
+  }
+  if (!Array.isArray(data.allowedHosts)) {
+    data.allowedHosts = ['127.0.0.1', 'localhost'];
+  }
+  if (data.allowNullOrigin === undefined) data.allowNullOrigin = false;
+  if (data.requireOrigin === undefined) data.requireOrigin = false;
+}
+
 const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 1, run: migrateV0ToV1 },
   { target: 2, run: migrateV1ToV2 },
@@ -86,9 +105,10 @@ const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 6, run: migrateV5ToV6 },
   { target: 7, run: migrateV6ToV7 },
   { target: 8, run: migrateV7ToV8 },
+  { target: 9, run: migrateV8ToV9 },
 ];
 
-export const CURRENT_SCHEMA_VERSION = 8;
+export const CURRENT_SCHEMA_VERSION = 9;
 
 export function migrateSettings(data: Settings): Settings {
   const currentVersion =

--- a/src/settings/server-section.ts
+++ b/src/settings/server-section.ts
@@ -9,6 +9,34 @@ import {
 } from './validation';
 import { renderHttpsSection } from './https-section';
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+const LOOPBACK_ORIGIN_PREFIXES = [
+  'http://127.0.0.1',
+  'http://localhost',
+  'https://127.0.0.1',
+  'https://localhost',
+  'http://[::1]',
+  'https://[::1]',
+];
+
+function parseLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function hasNonLoopbackHost(hosts: string[]): boolean {
+  return hosts.some((h) => !LOOPBACK_HOSTS.has(h.toLowerCase()));
+}
+
+function hasNonLoopbackOrigin(origins: string[]): boolean {
+  return origins.some((o) => {
+    const lower = o.toLowerCase();
+    return !LOOPBACK_ORIGIN_PREFIXES.some((prefix) => lower === prefix || lower.startsWith(prefix + ':'));
+  });
+}
+
 function scheme(plugin: McpPlugin): 'http' | 'https' {
   return plugin.settings.httpsEnabled ? 'https' : 'http';
 }
@@ -236,6 +264,95 @@ export function renderServerSettingsSection(
       toggle.setValue(plugin.settings.autoStart).onChange(async (value) => {
         plugin.settings.autoStart = value;
         await plugin.saveSettings();
+      }),
+    );
+
+  renderDnsRebindSection(containerEl, plugin, refresh);
+}
+
+/**
+ * "DNS Rebind Protection" subsection — Origin/Host allowlists plus the
+ * two boolean knobs (`allowNullOrigin`, `requireOrigin`). Validation is
+ * done in `src/server/origin-host.ts`; this UI just edits the settings.
+ */
+function renderDnsRebindSection(
+  containerEl: HTMLElement,
+  plugin: McpPlugin,
+  refresh: () => void,
+): void {
+  containerEl.createEl('h3', { text: t('heading_dns_rebind') });
+
+  const originsSetting = new Setting(containerEl)
+    .setName(t('setting_allowed_origins_name'))
+    .setDesc(t('setting_allowed_origins_desc'));
+  const originsTextarea = containerEl.createEl('textarea', {
+    cls: 'mcp-allowed-origins',
+    attr: {
+      rows: '4',
+      placeholder: 'http://127.0.0.1\nhttp://localhost',
+    },
+  });
+  originsTextarea.value = plugin.settings.allowedOrigins.join('\n');
+  const originWarning = createValidationError(originsSetting);
+  if (hasNonLoopbackOrigin(plugin.settings.allowedOrigins)) {
+    originWarning.show(t('warning_non_loopback_origin'));
+  }
+  originsTextarea.addEventListener('change', () => {
+    const next = parseLines(originsTextarea.value);
+    plugin.settings.allowedOrigins = next;
+    if (hasNonLoopbackOrigin(next)) {
+      originWarning.show(t('warning_non_loopback_origin'));
+    } else {
+      originWarning.clear();
+    }
+    plugin
+      .saveSettings()
+      .catch(reportError('save allowedOrigins', plugin.logger));
+  });
+
+  const hostsSetting = new Setting(containerEl)
+    .setName(t('setting_allowed_hosts_name'))
+    .setDesc(t('setting_allowed_hosts_desc'));
+  const hostsTextarea = containerEl.createEl('textarea', {
+    cls: 'mcp-allowed-hosts',
+    attr: { rows: '3', placeholder: '127.0.0.1\nlocalhost' },
+  });
+  hostsTextarea.value = plugin.settings.allowedHosts.join('\n');
+  const hostWarning = createValidationError(hostsSetting);
+  if (hasNonLoopbackHost(plugin.settings.allowedHosts)) {
+    hostWarning.show(t('warning_non_loopback_host'));
+  }
+  hostsTextarea.addEventListener('change', () => {
+    const next = parseLines(hostsTextarea.value);
+    plugin.settings.allowedHosts = next;
+    if (hasNonLoopbackHost(next)) {
+      hostWarning.show(t('warning_non_loopback_host'));
+    } else {
+      hostWarning.clear();
+    }
+    plugin
+      .saveSettings()
+      .catch(reportError('save allowedHosts', plugin.logger));
+  });
+
+  new Setting(containerEl)
+    .setName(t('setting_allow_null_origin_name'))
+    .setDesc(t('setting_allow_null_origin_desc'))
+    .addToggle((toggle) =>
+      toggle.setValue(plugin.settings.allowNullOrigin).onChange(async (value) => {
+        plugin.settings.allowNullOrigin = value;
+        await plugin.saveSettings();
+      }),
+    );
+
+  new Setting(containerEl)
+    .setName(t('setting_require_origin_name'))
+    .setDesc(t('setting_require_origin_desc'))
+    .addToggle((toggle) =>
+      toggle.setValue(plugin.settings.requireOrigin).onChange(async (value) => {
+        plugin.settings.requireOrigin = value;
+        await plugin.saveSettings();
+        refresh();
       }),
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,27 @@ export interface McpPluginSettings {
    * disabled and the tool refuses every call with a clear error.
    */
   executeCommandAllowlist: string[];
+  /**
+   * Origins (scheme + host [+ port]) allowed to issue requests. Used to
+   * block DNS-rebind attacks. Defaults to the loopback variants only.
+   */
+  allowedOrigins: string[];
+  /**
+   * Hostnames allowed to appear in the `Host` header. The port portion is
+   * stripped before comparison. Defaults to `127.0.0.1` and `localhost`.
+   */
+  allowedHosts: string[];
+  /**
+   * When true, requests with `Origin: null` (sandboxed iframes, file://)
+   * are accepted. Default false.
+   */
+  allowNullOrigin: boolean;
+  /**
+   * When true, every request must carry an `Origin` header — server-side
+   * MCP clients without `Origin` get rejected. Default false to keep
+   * `curl`/native clients working.
+   */
+  requireOrigin: boolean;
   /** Per-module enabled/disabled state, keyed by module ID */
   moduleStates: Record<string, ModuleState>;
 }
@@ -44,8 +65,20 @@ export interface ModuleState {
   toolStates?: Record<string, boolean>;
 }
 
+export const DEFAULT_ALLOWED_ORIGINS: readonly string[] = [
+  'http://127.0.0.1',
+  'http://localhost',
+  'https://127.0.0.1',
+  'https://localhost',
+] as const;
+
+export const DEFAULT_ALLOWED_HOSTS: readonly string[] = [
+  '127.0.0.1',
+  'localhost',
+] as const;
+
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 8,
+  schemaVersion: 9,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: false,
@@ -58,5 +91,9 @@ export const DEFAULT_SETTINGS: McpPluginSettings = {
   debugMode: false,
   autoStart: false,
   executeCommandAllowlist: [],
+  allowedOrigins: [...DEFAULT_ALLOWED_ORIGINS],
+  allowedHosts: [...DEFAULT_ALLOWED_HOSTS],
+  allowNullOrigin: false,
+  requireOrigin: false,
   moduleStates: {},
 };

--- a/tests/server/http-server.test.ts
+++ b/tests/server/http-server.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { AddressInfo } from 'net';
+import { request as httpRequest, IncomingMessage } from 'http';
+import { HttpMcpServer, HttpServerOptions } from '../../src/server/http-server';
+import { Logger } from '../../src/utils/logger';
+import type { OriginHostOptions } from '../../src/server/origin-host';
+
+interface InternalRateLimiter {
+  recordFailure: (ip: string) => void;
+  recordSuccess: (ip: string) => void;
+  check: (ip: string) => { blocked: boolean; retryAfterMs?: number };
+}
+interface InternalHttpMcpServer {
+  rateLimiter: InternalRateLimiter;
+}
+
+interface ResponseSnapshot {
+  status: number;
+  body: string;
+  headers: IncomingMessage['headers'];
+}
+
+const LOOPBACK_ORIGIN_HOST: OriginHostOptions = {
+  allowedOrigins: [
+    'http://127.0.0.1',
+    'http://localhost',
+    'https://127.0.0.1',
+    'https://localhost',
+  ],
+  allowedHosts: ['127.0.0.1', 'localhost'],
+  allowNullOrigin: false,
+  requireOrigin: false,
+};
+
+function makeLogger(): Logger {
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
+
+function createServer(
+  factorySpy: ReturnType<typeof vi.fn>,
+  overrides: Partial<HttpServerOptions> = {},
+): HttpMcpServer {
+  const opts: HttpServerOptions = {
+    host: '127.0.0.1',
+    port: 0,
+    authEnabled: false,
+    accessKey: '',
+    sessionSweepIntervalMs: 0,
+    originHost: LOOPBACK_ORIGIN_HOST,
+    ...overrides,
+  };
+  return new HttpMcpServer(
+    factorySpy as unknown as () => never,
+    makeLogger(),
+    opts,
+  );
+}
+
+function send(
+  port: number,
+  method: string,
+  headers: Record<string, string>,
+  body: string | undefined = undefined,
+): Promise<ResponseSnapshot> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        method,
+        path: '/mcp',
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+function getPort(server: HttpMcpServer): number {
+  // Internal: pull listening port from the underlying http.Server.
+  const internal = server as unknown as {
+    httpServer: { address: () => AddressInfo | null };
+  };
+  const addr = internal.httpServer.address();
+  if (!addr) {
+    throw new Error('server has no address');
+  }
+  return addr.port;
+}
+
+describe('HttpMcpServer — Origin/Host validation', () => {
+  let server: HttpMcpServer;
+  let factorySpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    factorySpy = vi.fn();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+    }
+  });
+
+  it('returns 403 with JSON body for a cross-origin POST', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      {
+        Host: '127.0.0.1',
+        Origin: 'http://attacker.com',
+        'Content-Type': 'application/json',
+      },
+      '{}',
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toContain('application/json');
+    const parsed = JSON.parse(res.body) as { error: string };
+    expect(parsed.error).toBe('Origin not allowlisted');
+  });
+
+  it('returns 403 with CORS headers attached on a cross-origin preflight', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(port, 'OPTIONS', {
+      Host: '127.0.0.1',
+      Origin: 'http://attacker.com',
+      'Access-Control-Request-Method': 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.headers['access-control-allow-origin']).toBeTruthy();
+  });
+
+  it('rejects Origin: null by default', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      { Host: '127.0.0.1', Origin: 'null', 'Content-Type': 'application/json' },
+      '{}',
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it('accepts Origin: null when allowNullOrigin is true', async () => {
+    server = createServer(factorySpy, {
+      originHost: { ...LOOPBACK_ORIGIN_HOST, allowNullOrigin: true },
+    });
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      { Host: '127.0.0.1', Origin: 'null', 'Content-Type': 'application/json' },
+      '{}',
+    );
+
+    // Past the validator → JSON-RPC parse error path. Anything other than 403.
+    expect(res.status).not.toBe(403);
+  });
+
+  it('accepts a missing Origin by default', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      { Host: '127.0.0.1', 'Content-Type': 'application/json' },
+      '{}',
+    );
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it('rejects a missing Origin when requireOrigin is true', async () => {
+    server = createServer(factorySpy, {
+      originHost: { ...LOOPBACK_ORIGIN_HOST, requireOrigin: true },
+    });
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      { Host: '127.0.0.1', 'Content-Type': 'application/json' },
+      '{}',
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a hostile Host header', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      {
+        Host: 'attacker.com',
+        Origin: 'http://127.0.0.1',
+        'Content-Type': 'application/json',
+      },
+      '{}',
+    );
+
+    expect(res.status).toBe(403);
+    const parsed = JSON.parse(res.body) as { error: string };
+    expect(parsed.error).toBe('Host not allowlisted');
+  });
+
+  it('accepts an allowlisted Host with port suffix', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    const res = await send(
+      port,
+      'POST',
+      {
+        Host: `127.0.0.1:${String(port)}`,
+        Origin: 'http://127.0.0.1',
+        'Content-Type': 'application/json',
+      },
+      '{}',
+    );
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it('does not consume the failure rate-limiter budget on rejection', async () => {
+    server = createServer(factorySpy, { authEnabled: true, accessKey: 'k' });
+    const internal = server as unknown as InternalHttpMcpServer;
+    const recordFailure = vi.spyOn(internal.rateLimiter, 'recordFailure');
+    await server.start();
+
+    const port = getPort(server);
+    await send(
+      port,
+      'POST',
+      {
+        Host: 'attacker.com',
+        Origin: 'http://attacker.com',
+        'Content-Type': 'application/json',
+      },
+      '{}',
+    );
+
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch to the JSON-RPC handler on rejection', async () => {
+    server = createServer(factorySpy);
+    await server.start();
+
+    const port = getPort(server);
+    await send(
+      port,
+      'POST',
+      {
+        Host: 'attacker.com',
+        Origin: 'http://attacker.com',
+        'Content-Type': 'application/json',
+      },
+      '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}',
+    );
+
+    expect(factorySpy).not.toHaveBeenCalled();
+  });
+
+  // Note: missing/empty Host is covered in `tests/server/origin-host.test.ts`
+  // — node's HTTP layer rejects an empty Host header at the parser stage
+  // before our handler ever sees it, so a true end-to-end test isn't possible.
+});

--- a/tests/server/origin-host.test.ts
+++ b/tests/server/origin-host.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import type { IncomingMessage, IncomingHttpHeaders } from 'http';
+import {
+  validateOriginHost,
+  type OriginHostOptions,
+} from '../../src/server/origin-host';
+
+function makeReq(headers: IncomingHttpHeaders): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+const DEFAULTS: OriginHostOptions = {
+  allowedOrigins: [
+    'http://127.0.0.1',
+    'http://localhost',
+    'https://127.0.0.1',
+    'https://localhost',
+  ],
+  allowedHosts: ['127.0.0.1', 'localhost'],
+  allowNullOrigin: false,
+  requireOrigin: false,
+};
+
+describe('validateOriginHost', (): void => {
+  it('accepts a same-origin POST with loopback Host', (): void => {
+    const req = makeReq({
+      origin: 'http://127.0.0.1',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts the explicit-port origin when included in the allowlist', (): void => {
+    const req = makeReq({
+      origin: 'http://127.0.0.1:28741',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      allowedOrigins: ['http://127.0.0.1:28741'],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an origin with a port not present in the allowlist (exact match)', (): void => {
+    const req = makeReq({
+      origin: 'http://127.0.0.1:9999',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a cross-origin POST', (): void => {
+    const req = makeReq({
+      origin: 'http://attacker.com',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.origin).toBe('http://attacker.com');
+    }
+  });
+
+  it('rejects Origin: null by default', (): void => {
+    const req = makeReq({
+      origin: 'null',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts Origin: null when allowNullOrigin is true', (): void => {
+    const req = makeReq({
+      origin: 'null',
+      host: '127.0.0.1:28741',
+    });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      allowNullOrigin: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a missing Origin by default', (): void => {
+    const req = makeReq({ host: '127.0.0.1:28741' });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a missing Origin when requireOrigin is true', (): void => {
+    const req = makeReq({ host: '127.0.0.1:28741' });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      requireOrigin: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a hostile Host header', (): void => {
+    const req = makeReq({
+      origin: 'http://127.0.0.1',
+      host: 'attacker.com',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.host).toBe('attacker.com');
+    }
+  });
+
+  it('accepts an allowlisted Host with a port suffix', (): void => {
+    const req = makeReq({
+      origin: 'http://localhost',
+      host: 'localhost:27123',
+    });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a missing Host header', (): void => {
+    const req = makeReq({ origin: 'http://127.0.0.1' });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an empty-string Host', (): void => {
+    const req = makeReq({ host: '', origin: 'http://127.0.0.1' });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(false);
+  });
+
+  it('compares hosts case-insensitively', (): void => {
+    const req = makeReq({ origin: 'http://localhost', host: 'LocalHost:28741' });
+    const result = validateOriginHost(req, DEFAULTS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects everything when allowedHosts is empty', (): void => {
+    const req = makeReq({ origin: 'http://127.0.0.1', host: '127.0.0.1' });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      allowedHosts: [],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects unknown origins when allowedOrigins is empty', (): void => {
+    const req = makeReq({ origin: 'http://127.0.0.1', host: '127.0.0.1' });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      allowedOrigins: [],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('handles IPv6 Host with brackets and port', (): void => {
+    const req = makeReq({
+      origin: 'http://localhost',
+      host: '[::1]:28741',
+    });
+    const result = validateOriginHost(req, {
+      ...DEFAULTS,
+      allowedHosts: ['::1'],
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,7 +7,7 @@ describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to current schema', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -25,7 +25,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -43,7 +43,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
@@ -59,7 +59,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.autoStart).toBe(false);
   });
 
@@ -78,7 +78,7 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
@@ -97,7 +97,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.tlsCertificate).toBeNull();
   });
 
@@ -114,7 +114,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.authEnabled).toBe(false);
   });
 
@@ -124,7 +124,7 @@ describe('migrateSettings', () => {
       accessKey: 'pre-existing-key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.authEnabled).toBe(false);
     expect(result.accessKey).toBe('pre-existing-key');
   });
@@ -135,7 +135,7 @@ describe('migrateSettings', () => {
       authEnabled: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.authEnabled).toBe(true);
   });
 
@@ -173,7 +173,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.useCustomTls).toBe(false);
     expect(result.customTlsCertPath).toBeNull();
     expect(result.customTlsKeyPath).toBeNull();
@@ -189,7 +189,7 @@ describe('migrateSettings', () => {
       customTlsKeyPath: '/etc/ssl/my.key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.useCustomTls).toBe(true);
     expect(result.customTlsCertPath).toBe('/etc/ssl/my.crt');
     expect(result.customTlsKeyPath).toBe('/etc/ssl/my.key');
@@ -201,7 +201,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.tlsCertificate).toEqual({
       cert: 'EXISTING_CERT',
       key: 'EXISTING_KEY',
@@ -213,7 +213,7 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
@@ -234,7 +234,7 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
@@ -287,8 +287,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
   });
 
-  it('declares schemaVersion 8', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(8);
+  it('declares schemaVersion 9', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(9);
   });
 
   it('defaults custom TLS fields to off/null', () => {

--- a/tests/settings/migrations.test.ts
+++ b/tests/settings/migrations.test.ts
@@ -8,6 +8,7 @@ import {
   migrateV5ToV6,
   migrateV6ToV7,
   migrateV7ToV8,
+  migrateV8ToV9,
   migrateSettings,
   CURRENT_SCHEMA_VERSION,
 } from '../../src/settings/migrations';
@@ -118,6 +119,34 @@ describe('settings migrations — per-version hops', () => {
     };
     migrateV7ToV8(data);
     expect(data.executeCommandAllowlist).toEqual(['app:reload']);
+  });
+
+  it('V8 -> V9 seeds DNS-rebind allowlists with loopback defaults', () => {
+    const data: Record<string, unknown> = {};
+    migrateV8ToV9(data);
+    expect(data.allowedOrigins).toEqual([
+      'http://127.0.0.1',
+      'http://localhost',
+      'https://127.0.0.1',
+      'https://localhost',
+    ]);
+    expect(data.allowedHosts).toEqual(['127.0.0.1', 'localhost']);
+    expect(data.allowNullOrigin).toBe(false);
+    expect(data.requireOrigin).toBe(false);
+  });
+
+  it('V8 -> V9 preserves user-supplied allowlists', () => {
+    const data: Record<string, unknown> = {
+      allowedOrigins: ['http://my.example'],
+      allowedHosts: ['my.example'],
+      allowNullOrigin: true,
+      requireOrigin: true,
+    };
+    migrateV8ToV9(data);
+    expect(data.allowedOrigins).toEqual(['http://my.example']);
+    expect(data.allowedHosts).toEqual(['my.example']);
+    expect(data.allowNullOrigin).toBe(true);
+    expect(data.requireOrigin).toBe(true);
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,20 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 8', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(8);
+  it('should have schema version 9', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(9);
+  });
+
+  it('should have loopback-only Origin and Host allowlists by default', () => {
+    expect(DEFAULT_SETTINGS.allowedOrigins).toEqual([
+      'http://127.0.0.1',
+      'http://localhost',
+      'https://127.0.0.1',
+      'https://localhost',
+    ]);
+    expect(DEFAULT_SETTINGS.allowedHosts).toEqual(['127.0.0.1', 'localhost']);
+    expect(DEFAULT_SETTINGS.allowNullOrigin).toBe(false);
+    expect(DEFAULT_SETTINGS.requireOrigin).toBe(false);
   });
 
   it('has bring-your-own-cert disabled by default', () => {

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -65,7 +65,7 @@ function makeModule(
 }
 
 const baseSettings: McpPluginSettings = {
-  schemaVersion: 8,
+  schemaVersion: 9,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: true,
@@ -78,6 +78,15 @@ const baseSettings: McpPluginSettings = {
   debugMode: true,
   autoStart: false,
   executeCommandAllowlist: [],
+  allowedOrigins: [
+    'http://127.0.0.1',
+    'http://localhost',
+    'https://127.0.0.1',
+    'https://localhost',
+  ],
+  allowedHosts: ['127.0.0.1', 'localhost'],
+  allowNullOrigin: false,
+  requireOrigin: false,
   moduleStates: {},
 };
 


### PR DESCRIPTION
Closes #246

## Summary

- Reject inbound requests whose `Origin` or `Host` header isn't on the loopback allowlist, blocking DNS-rebind attacks against the loopback MCP port even when auth is disabled.
- The check runs at the very top of `handleRequest` — before CORS preflight, rate limiter, and authentication — so rejections never consume the failure budget and never reach the JSON-RPC dispatcher.
- New settings `allowedOrigins`, `allowedHosts`, `allowNullOrigin`, `requireOrigin` (loopback-only defaults, both flags off). Schema bumped to v9 with a v8→v9 migration that seeds defaults for existing installs.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 535/535 passing, includes new `tests/server/origin-host.test.ts` (16 unit cases) and `tests/server/http-server.test.ts` (10 in-process HTTP cases covering same-origin allowed, cross-origin rejected, `Origin: null` allowed/denied, missing `Origin` allowed/required, hostile `Host` rejected, allowlisted `Host:port` accepted, no rate-limiter consumption, no JSON-RPC dispatch on rejection)
- [x] `npm run docs:check`
- [x] User manual updated (`docs/help/en.md`) with the new settings table and an FAQ entry for `403 / Origin not allowlisted`

## Screenshots required before merge

This PR adds four new controls to the **Server Settings** tab under a new
**DNS Rebind Protection** subsection. Per the project screenshot rule
(`CLAUDE.md` → "Mandatory before/after screenshots for UI work"), the
maintainer/orchestrator must capture before/after PNGs of the affected
surfaces before merging:

- Settings tab → **Server Settings** section, scrolled to show the new
  **DNS Rebind Protection** subsection (heading, both textareas with
  default values, both toggles).
- Same surface with one non-loopback entry added to **Allowed Origins**
  to show the inline warning notice rendering correctly.
- (Optional) German locale variant of the same view to verify the
  translations.

Screenshots must NOT be committed to the repo — attach them to this PR
instead (project rule 4).

## Implementation notes

- The validator (`src/server/origin-host.ts`) is a pure function, decoupled from the full settings type — only consumes a small `OriginHostOptions` shape, which keeps it trivially unit-testable.
- Origin compare is case-insensitive on scheme/host but otherwise exact (per the issue: do not suffix-match). Trailing slash is stripped to be lenient.
- Host compare strips the `:port` suffix (bracket-aware for IPv6).
- 403 responses carry CORS headers so the browser surfaces a clearer failure on preflight rejections.
- Logging includes IP, method, path, offending Origin, offending Host, and the reason. Body and Authorization headers are never logged.