### PR TITLE
fix(server/mcp): advertise as obsidian-mcp-server and read version from manifest

### DIFF
--- a/docs/superpowers/plans/247-mcp-server-name-and-version.md
+++ b/docs/superpowers/plans/247-mcp-server-name-and-version.md
@@ -1,0 +1,94 @@
+# Plan: MCP server name and version fix (Issue #247)
+
+## Goal
+
+Make the MCP `serverInfo` advertised on the protocol handshake match the
+`{service}-mcp-server` convention and reflect the real plugin version
+from `manifest.json` instead of the hardcoded `'0.0.0'`.
+
+## Approach
+
+### 1. Read `manifest.json` via static JSON import
+
+`tsconfig.json` already has `resolveJsonModule: true` and `esModuleInterop: true`,
+and esbuild bundles JSON imports natively. Use a default import:
+
+```ts
+import manifest from '../../manifest.json';
+```
+
+No `assert { type: 'json' }` needed — `module: ESNext` + `moduleResolution: bundler`
+plus esbuild handle this without import assertions, and the test runner
+(vitest) inherits the same TS config.
+
+The repo has no existing JSON imports in `src/`, so we are not deviating
+from a prior pattern; this is the simplest path that keeps the build infra
+untouched (Option A from the issue).
+
+### 2. Update the SDK constructor call (`src/server/mcp-server.ts`)
+
+```ts
+import manifest from '../../manifest.json';
+// ...
+new McpServer(
+  { name: 'obsidian-mcp-server', version: manifest.version },
+  { capabilities: { tools: {} } },
+);
+```
+
+Only the two literal strings change (`obsidian-mcp` → `obsidian-mcp-server`,
+`'0.0.0'` → `manifest.version`). No other behaviour, no other files.
+
+### 3. Test (`tests/server/mcp-server.test.ts`, new file)
+
+The MCP SDK's `McpServer` exposes the underlying `Server` via a public
+`server` property, but stores `_serverInfo` privately (`server/index.d.ts`)
+with no public accessor. We have two options:
+
+- **Option A:** cast through `unknown` to a narrow shape and read
+  `server._serverInfo`. Brittle if the SDK renames the field.
+- **Option B:** mock `@modelcontextprotocol/sdk/server/mcp.js` and capture
+  the constructor argument with `vi.fn()`.
+
+Pick **Option B** — it is robust against SDK internals and matches the
+test's intent (we want to verify what we hand the SDK, not what the SDK
+stores). Reuse the same `manifest.version` import in the test so the
+assertion stays correct on every release bump.
+
+Test cases:
+
+- `serverInfo.name === 'obsidian-mcp-server'` after `createMcpServer(...)`.
+- `serverInfo.version === manifest.version` (string-equal to the imported
+  manifest).
+- Sanity: capabilities include `tools`.
+
+Use `vi.mock('@modelcontextprotocol/sdk/server/mcp.js', ...)` with a stub
+class that records its constructor args and exposes `registerTool` /
+`server` so `createMcpServer` can finish without throwing.
+
+## Files touched
+
+- `src/server/mcp-server.ts` — JSON import + two literal changes.
+- `tests/server/mcp-server.test.ts` — new test file (does NOT replace
+  `tests/server/dispatcher.test.ts`, which covers `createToolDispatcher`).
+- `docs/superpowers/plans/247-mcp-server-name-and-version.md` — this plan.
+
+## Out of scope
+
+- `package.json#name`, `manifest.json#id`, repo name, branding, docs copy.
+- Any user-facing string. This is a protocol-handshake-only change.
+
+## Caveats
+
+- The MCP SDK `Server` does not expose a public `getServerInfo()`-style
+  accessor; that's why we mock at the constructor boundary instead.
+- If a future SDK version exposes `serverInfo` publicly, the test can be
+  simplified to read it from a real `McpServer`, but the production change
+  is unaffected.
+
+## Verification
+
+- `npm run lint`
+- `npm test`
+- `npm run typecheck`
+- `npm run build` (catches any JSON-import issue at bundle time)

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { Logger } from '../utils/logger';
 import { ModuleRegistry } from '../registry/module-registry';
 import { ToolDefinition } from '../registry/types';
+import manifest from '../../manifest.json';
 
 export function createMcpServer(
   registry: ModuleRegistry,
@@ -11,8 +12,11 @@ export function createMcpServer(
 ): McpServer {
   const server = new McpServer(
     {
-      name: 'obsidian-mcp',
-      version: '0.0.0',
+      // {service}-mcp-server naming convention for the MCP protocol
+      // handshake. This is internal to the protocol and intentionally
+      // distinct from the npm package name and Obsidian plugin id.
+      name: 'obsidian-mcp-server',
+      version: manifest.version,
     },
     {
       capabilities: {

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import manifest from '../../manifest.json';
+import { Logger } from '../../src/utils/logger';
+import { ModuleRegistry } from '../../src/registry/module-registry';
+
+interface CapturedServerInfo {
+  name: string;
+  version: string;
+}
+
+interface CapturedOptions {
+  capabilities?: { tools?: unknown };
+}
+
+const capturedConstructorArgs: Array<{
+  serverInfo: CapturedServerInfo;
+  options: CapturedOptions;
+}> = [];
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  class FakeMcpServer {
+    public server = {};
+    constructor(serverInfo: CapturedServerInfo, options: CapturedOptions) {
+      capturedConstructorArgs.push({ serverInfo, options });
+    }
+    registerTool(): void {
+      // no-op — createMcpServer registers active tools, but our test
+      // registry is empty.
+    }
+  }
+  return { McpServer: FakeMcpServer };
+});
+
+function makeLogger(): Logger {
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
+
+describe('createMcpServer', () => {
+  beforeEach(() => {
+    capturedConstructorArgs.length = 0;
+  });
+
+  it('advertises the server as "obsidian-mcp-server" per the {service}-mcp-server convention', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+    const registry = new ModuleRegistry(makeLogger());
+
+    createMcpServer(registry, makeLogger());
+
+    expect(capturedConstructorArgs).toHaveLength(1);
+    expect(capturedConstructorArgs[0].serverInfo.name).toBe('obsidian-mcp-server');
+  });
+
+  it('reports the version from manifest.json (not a hardcoded placeholder)', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+    const registry = new ModuleRegistry(makeLogger());
+
+    createMcpServer(registry, makeLogger());
+
+    expect(capturedConstructorArgs).toHaveLength(1);
+    expect(capturedConstructorArgs[0].serverInfo.version).toBe(manifest.version);
+    // Sanity: don't let a future regression silently re-introduce '0.0.0'
+    // by also asserting it isn't the historical placeholder.
+    expect(capturedConstructorArgs[0].serverInfo.version).not.toBe('0.0.0');
+  });
+
+  it('declares tool capabilities on the server', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+    const registry = new ModuleRegistry(makeLogger());
+
+    createMcpServer(registry, makeLogger());
+
+    expect(capturedConstructorArgs[0].options.capabilities?.tools).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #247

## Summary

- Rename the MCP `serverInfo.name` from `obsidian-mcp` to `obsidian-mcp-server` so the protocol handshake matches the `{service}-mcp-server` convention. The npm package name and the Obsidian plugin id are deliberately untouched.
- Replace the hardcoded `version: '0.0.0'` with `manifest.version`, read via a static `import manifest from '../../manifest.json'`. `resolveJsonModule` is already enabled in `tsconfig.json` and esbuild bundles JSON imports natively, so no build-infra change is required.

## Test plan

- New `tests/server/mcp-server.test.ts` mocks `@modelcontextprotocol/sdk/server/mcp.js` and asserts:
  - `serverInfo.name === 'obsidian-mcp-server'`
  - `serverInfo.version === manifest.version` (re-imports the same `manifest.json`, so it stays correct on every release bump)
  - capabilities include `tools`
- `npm run lint` — clean
- `npm test` — 538 tests across 43 files, all green
- `npm run typecheck` — clean
- `npm run build` — production bundle builds successfully; verified the bundled `main.js` contains `obsidian-mcp-server` and the manifest version