### PR TITLE
fix(tools/templates): stop swallowing all errors in template_list

### DIFF
--- a/docs/superpowers/plans/252-template-list-error-handling.md
+++ b/docs/superpowers/plans/252-template-list-error-handling.md
@@ -1,0 +1,126 @@
+# Plan: stop swallowing all errors in `template_list` (Issue #252)
+
+## Goal
+
+`template_list` currently returns `[]` on **any** failure inside the
+adapter call. That hides permission errors, adapter bugs, and config
+problems behind an indistinguishable "no templates" response. After
+this change, `[]` means exactly "the templates folder does not
+exist"; every other failure surfaces through `handleToolError`.
+
+## Typed-error decision
+
+- Add **`FolderNotFoundError extends NotFoundError`** to
+  `src/tools/shared/errors.ts`. This is what the issue actually asks
+  for and what the handler will catch.
+- Also add **`FileNotFoundError extends NotFoundError`** alongside
+  it for symmetry. We don't use it in this PR, but it makes the
+  typed-error pattern obvious to follow when other adapter throws
+  get tightened. Cheap to add; loud signal to future contributors.
+- Keep the message string `Folder not found: ${path}` byte-identical
+  to the current `new Error(...)` message so existing assertions
+  (`mock-adapter.test.ts` matches on the substring `'Folder not
+  found'`) keep passing.
+
+## Files touched
+
+1. `src/tools/shared/errors.ts`
+   - Add `class FolderNotFoundError extends NotFoundError`.
+   - Add `class FileNotFoundError extends NotFoundError`.
+   - `handleToolError` already routes `NotFoundError` correctly via
+     `errorFrom(error.message)`, so no change there.
+
+2. `src/obsidian/adapter.ts`
+   - `getFolder()` throws `FolderNotFoundError(path)` instead of
+     `new Error(\`Folder not found: ${path}\`)`. Message preserved.
+   - **Do NOT touch** `getFile()` or `getAbstractFile()` — out of
+     scope for #252; broader adapter typing is a future follow-up.
+
+3. `src/obsidian/mock-adapter.ts`
+   - `list()` and `listRecursive()` throw `FolderNotFoundError`
+     instead of `new Error('Folder not found: …')` so the handler's
+     `instanceof FolderNotFoundError` check passes in tests that
+     drive through the mock adapter. Message preserved.
+   - `deleteFolder()` likewise throws `FolderNotFoundError` for
+     consistency (also exercises the same string today).
+
+4. `src/tools/templates/index.ts`
+   - Replace the bare `catch {}` in `listTemplates` with:
+     ```ts
+     try {
+       const result = adapter.list(templatesFolder);
+       return Promise.resolve(text(JSON.stringify(result.files)));
+     } catch (err) {
+       if (err instanceof FolderNotFoundError) {
+         return Promise.resolve(text('[]'));
+       }
+       return Promise.resolve(handleToolError(err));
+     }
+     ```
+   - Import `FolderNotFoundError` from `../shared/errors`.
+
+## Tests
+
+### `tests/tools/templates/templates.test.ts`
+
+Add five regression tests (one per acceptance-criterion case):
+
+- (a) Folder missing → `template_list` returns `[]`.
+- (b) Folder present + empty → `template_list` returns `JSON.stringify([])`.
+- (c) Folder present + populated → returns the file list as JSON
+  (this case effectively already exists; keep the spirit, ensure
+  it stays).
+- (d) Permission denied → handler returns `handleToolError`-shaped
+  envelope: `isError: true`, message contains `Permission denied`.
+- (e) Unexpected error → adapter throws plain `new Error('boom')`
+  → handler returns `isError: true`, message contains `boom`.
+
+For (d) and (e) we'll subclass / wrap `MockObsidianAdapter` in the
+test file to override `list()` and throw the desired error. Keeps
+the production mock untouched.
+
+### `tests/obsidian/mock-adapter.test.ts`
+
+Add a single regression test:
+
+- Calling `adapter.list('missing')` throws `FolderNotFoundError`
+  (assert `toThrow(FolderNotFoundError)`). Pins the typed-error
+  contract so a future refactor can't silently regress to plain
+  `Error`.
+- The existing `toThrow('Folder not found')` test still passes
+  because the message is unchanged.
+
+## Scope-creep notes
+
+- **`getFile()` / `getAbstractFile()`** still throw plain `Error`.
+  Tightening those is a separate follow-up; #252 is scoped to the
+  templates handler. PR body will call this out.
+- The `templatesFolder` is hardcoded to `'templates'` in
+  `src/tools/templates/index.ts:72`. Not configurable today, so
+  tests use the same hardcoded value. Out of scope to change here.
+- No user-manual update needed: the only externally observable
+  change is "errors that used to be silently swallowed now surface
+  through the standard error envelope". Nothing to add to
+  `docs/help/en.md`. Tool registry is unchanged so no
+  `docs/tools.generated.md` regen.
+
+## Commit plan
+
+1. `docs(plans/252): plan for template_list error handling` — this file.
+2. `fix(tools/shared): add FolderNotFoundError and FileNotFoundError`
+   — typed errors + adapter wiring (`adapter.ts` + `mock-adapter.ts`)
+   + the adapter regression test. Keeps the typed-error addition
+   self-contained.
+3. `fix(tools/templates): stop swallowing all errors in template_list`
+   — narrow the catch in `index.ts` and add the five handler tests.
+
+All commit bodies include `Refs #252`. No AI attribution.
+
+## Verification
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- Confirm `mock-adapter.test.ts`'s existing `'Folder not found'`
+  string assertions still pass after the throw is swapped to a
+  typed error.

--- a/src/obsidian/adapter.ts
+++ b/src/obsidian/adapter.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion */
 import { App, Notice, TFile, TFolder, TAbstractFile, Vault } from 'obsidian';
+import { FolderNotFoundError } from '../tools/shared/errors';
 
 export interface FileStat {
   size: number;
@@ -434,7 +435,7 @@ export class RealObsidianAdapter implements ObsidianAdapter {
   private getFolder(path: string): TFolder {
     const folder = this.app.vault.getAbstractFileByPath(path);
     if (!(folder instanceof TFolder)) {
-      throw new Error(`Folder not found: ${path}`);
+      throw new FolderNotFoundError(path);
     }
     return folder;
   }

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -1,4 +1,5 @@
 import { FileStat, ListResult, ObsidianAdapter } from './adapter';
+import { FolderNotFoundError } from '../tools/shared/errors';
 
 interface MockFileMetadata {
   frontmatter?: Record<string, unknown>;
@@ -138,7 +139,7 @@ export class MockObsidianAdapter implements ObsidianAdapter {
 
   async deleteFolder(path: string, recursive: boolean): Promise<void> {
     if (!this.folders.has(path)) {
-      throw new Error(`Folder not found: ${path}`);
+      throw new FolderNotFoundError(path);
     }
     const children = this.getDirectChildren(path);
     if (!recursive && (children.files.length > 0 || children.folders.length > 0)) {
@@ -171,14 +172,14 @@ export class MockObsidianAdapter implements ObsidianAdapter {
 
   list(path: string): ListResult {
     if (!this.folders.has(path) && path !== '/') {
-      throw new Error(`Folder not found: ${path}`);
+      throw new FolderNotFoundError(path);
     }
     return this.getDirectChildren(path);
   }
 
   listRecursive(path: string): ListResult {
     if (!this.folders.has(path) && path !== '/') {
-      throw new Error(`Folder not found: ${path}`);
+      throw new FolderNotFoundError(path);
     }
     const prefix = path === '/' ? '' : path + '/';
     const files: string[] = [];

--- a/src/tools/shared/errors.ts
+++ b/src/tools/shared/errors.ts
@@ -14,6 +14,24 @@ export class NotFoundError extends Error {
   }
 }
 
+/**
+ * The vault path resolves to nothing — there is no file or folder there.
+ * Use `FolderNotFoundError` / `FileNotFoundError` when the type is known.
+ */
+export class FolderNotFoundError extends NotFoundError {
+  constructor(path: string) {
+    super(`Folder not found: ${path}`);
+    this.name = 'FolderNotFoundError';
+  }
+}
+
+export class FileNotFoundError extends NotFoundError {
+  constructor(path: string) {
+    super(`File not found: ${path}`);
+    this.name = 'FileNotFoundError';
+  }
+}
+
 export class PermissionError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
-import { handleToolError } from '../shared/errors';
+import { FolderNotFoundError, handleToolError } from '../shared/errors';
 import { describeTool } from '../shared/describe';
 
 function text(t: string): CallToolResult { return { content: [{ type: 'text', text: t }] }; }
@@ -76,8 +76,11 @@ function createHandlers(adapter: ObsidianAdapter): TemplatesHandlers {
       try {
         const result = adapter.list(templatesFolder);
         return Promise.resolve(text(JSON.stringify(result.files)));
-      } catch {
-        return Promise.resolve(text('[]'));
+      } catch (err) {
+        if (err instanceof FolderNotFoundError) {
+          return Promise.resolve(text('[]'));
+        }
+        return Promise.resolve(handleToolError(err));
       }
     },
     async createFromTemplate(params): Promise<CallToolResult> {

--- a/tests/obsidian/mock-adapter.test.ts
+++ b/tests/obsidian/mock-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { FolderNotFoundError } from '../../src/tools/shared/errors';
 
 describe('MockObsidianAdapter', () => {
   let adapter: MockObsidianAdapter;
@@ -171,6 +172,10 @@ describe('MockObsidianAdapter', () => {
 
     it('should throw when listing a nonexistent folder', () => {
       expect(() => adapter.list('missing')).toThrow('Folder not found');
+    });
+
+    it('should throw FolderNotFoundError (typed) when listing a nonexistent folder', () => {
+      expect(() => adapter.list('missing')).toThrow(FolderNotFoundError);
     });
   });
 

--- a/tests/tools/templates/templates.test.ts
+++ b/tests/tools/templates/templates.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { ListResult } from '../../../src/obsidian/adapter';
 import { createTemplatesModule } from '../../../src/tools/templates/index';
+import { PermissionError } from '../../../src/tools/shared/errors';
 
 function getText(r: CallToolResult): string {
   return r.content[0].type === 'text' ? r.content[0].text : '';
+}
+
+class ListThrowingAdapter extends MockObsidianAdapter {
+  constructor(private readonly toThrow: unknown) {
+    super();
+  }
+  override list(_path: string): ListResult {
+    throw this.toThrow;
+  }
 }
 
 describe('templates module', () => {
@@ -28,6 +39,60 @@ describe('templates module', () => {
     const result = await tool.handler({});
     const data = JSON.parse(getText(result)) as string[];
     expect(data).toHaveLength(2);
+  });
+
+  describe('template_list error handling', () => {
+    // (a) Folder missing → handler returns [].
+    it('returns [] when the templates folder is missing', async () => {
+      const module = createTemplatesModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'template_list')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect(getText(result)).toBe('[]');
+    });
+
+    // (b) Folder present + empty → handler returns [].
+    it('returns [] when the templates folder exists but is empty', async () => {
+      adapter.addFolder('templates');
+      const module = createTemplatesModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'template_list')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect(getText(result)).toBe(JSON.stringify([]));
+    });
+
+    // (c) Folder present + populated → returns the file list as JSON.
+    it('returns the file list as JSON when the folder is populated', async () => {
+      adapter.addFolder('templates');
+      adapter.addFile('templates/a.md', 'a');
+      adapter.addFile('templates/b.md', 'b');
+      const module = createTemplatesModule(adapter);
+      const tool = module.tools().find((t) => t.name === 'template_list')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(getText(result)) as string[];
+      expect(data).toEqual(['templates/a.md', 'templates/b.md']);
+    });
+
+    // (d) Permission denied → handleToolError envelope.
+    it('surfaces PermissionError through handleToolError', async () => {
+      const throwing = new ListThrowingAdapter(new PermissionError('templates'));
+      const module = createTemplatesModule(throwing);
+      const tool = module.tools().find((t) => t.name === 'template_list')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('Permission denied');
+    });
+
+    // (e) Unexpected error → handleToolError envelope.
+    it('surfaces unexpected errors through handleToolError', async () => {
+      const throwing = new ListThrowingAdapter(new Error('boom'));
+      const module = createTemplatesModule(throwing);
+      const tool = module.tools().find((t) => t.name === 'template_list')!;
+      const result = await tool.handler({});
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('boom');
+    });
   });
 
   it('should create from template with variable substitution', async () => {


### PR DESCRIPTION
Closes #252

## Summary

- `template_list` returned `[]` on any failure, hiding permission errors and adapter bugs behind an indistinguishable "no templates" response. Now `[]` means exactly "the templates folder is missing"; every other error surfaces through the standard `handleToolError` envelope so callers see an actionable message.
- Add typed `FolderNotFoundError` (and a sibling `FileNotFoundError` for symmetry) under `src/tools/shared/errors.ts`, and wire `ObsidianAdapter.getFolder()` plus `MockObsidianAdapter`'s `list()` / `listRecursive()` / `deleteFolder()` to throw the typed error. Message strings are preserved byte-for-byte so existing substring assertions keep passing.
- Five regression tests cover the acceptance criteria: folder missing -> `[]`, folder present + empty -> `[]`, folder populated -> JSON list, `PermissionError` -> error envelope, unexpected `Error` -> error envelope. An adapter-level regression test pins the typed-error contract.

## Deviations / scope notes

- Added `FileNotFoundError` alongside `FolderNotFoundError` even though no production code catches it yet. Cheap to add and makes the typed-error pattern obvious for the next contributor; mentioned upfront so reviewers can push back if they want it stripped.
- Did NOT touch `getFile()` or `getAbstractFile()` in `src/obsidian/adapter.ts` — they still throw plain `Error`. Out of scope for #252; tightening them is a future follow-up.
- The templates folder is hardcoded to `'templates'` in `src/tools/templates/index.ts` (line 72). Tests use the same hardcoded value. Making it configurable is a separate concern.
- No user-manual update needed: the only externally observable change is "errors that used to be silently swallowed now surface via the standard envelope". Tool registry is unchanged so `docs/tools.generated.md` does not need regenerating.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (544 tests, 43 files, all pass — up from 538 baseline)
- [x] Existing `mock-adapter.test.ts` substring assertion `toThrow('Folder not found')` still passes after the typed-error swap (message preserved).