### PR TITLE
fix(utils/logger): route all log levels to stderr for stdio transport compatibility

### DIFF
--- a/docs/superpowers/plans/256-logger-to-stderr.md
+++ b/docs/superpowers/plans/256-logger-to-stderr.md
@@ -1,0 +1,46 @@
+# Plan — #256 route all log levels to stderr
+
+## Why
+
+`src/utils/logger.ts` currently sends `debug`/`info` JSON lines to
+`console.log` (stdout). Stdio MCP transport reserves stdout for JSON-RPC
+frames; any other byte on stdout corrupts the stream. Even though the
+plugin runs over Streamable HTTP today, the rubric requires the logger to
+be safe for stdio swap. Solution: route every level through stderr.
+
+## Scope
+
+- `src/utils/logger.ts`: replace the `console.log(json)` call in the
+  `debug`/`info` branch of the `switch (level)` with `console.error(json)`.
+- Add one short comment above the switch explaining the WHY.
+- Keep the existing `// eslint-disable-next-line no-console` directives
+  (project allows `no-console` here intentionally).
+- Do NOT touch the `sink` path — it's a plain-text routing concern,
+  orthogonal to the stdout/stderr question.
+
+## Tests
+
+`tests/utils/logger.test.ts`:
+- Migrate every `console.log` spy that asserts a routing call for
+  `debug`/`info` to spy on `console.error` instead. JSON-shape assertions
+  stay the same.
+- Sink tests that mock `console.log` purely to silence output also move to
+  `console.error` so nothing leaks.
+- Add one focused regression test that asserts `console.log` is NEVER
+  called for any level, while `console.error` IS called for `debug`/`info`.
+
+## Verification
+
+- `npm run lint`
+- `npm test`
+- `npm run typecheck`
+
+All three must pass before push.
+
+## Commits
+
+1. `docs(plans/256): plan for logger stderr routing` — this file.
+2. `fix(utils/logger): route all log levels to stderr for stdio transport compatibility`
+   — code + test changes together so the suite stays green at every commit.
+
+Each commit body references `Refs #256`.

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -71,11 +71,13 @@ export class Logger {
 
     const json = JSON.stringify(entry);
 
+    // stdio MCP transports require stdout to carry only JSON-RPC frames.
+    // Route every level through stderr so swapping transport doesn't corrupt the stream.
     switch (level) {
       case 'debug':
       case 'info':
         // eslint-disable-next-line no-console
-        console.log(json);
+        console.error(json);
         break;
       case 'warn':
         // eslint-disable-next-line no-console

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -15,7 +15,7 @@ describe('Logger', () => {
     });
 
     it('should log debug messages when debug mode is on', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.debug('test debug message');
       expect(spy).toHaveBeenCalledTimes(1);
       const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
@@ -25,7 +25,7 @@ describe('Logger', () => {
     });
 
     it('should log info messages', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('test info');
       expect(spy).toHaveBeenCalledTimes(1);
       const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
@@ -49,7 +49,7 @@ describe('Logger', () => {
     });
 
     it('should include a timestamp in ISO format', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('timestamp test');
       const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(() => new Date(entry.timestamp)).not.toThrow();
@@ -57,14 +57,14 @@ describe('Logger', () => {
     });
 
     it('should include optional data when provided', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('with data', { foo: 'bar' });
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(entry.data).toEqual({ foo: 'bar' });
     });
 
     it('should not include data key when data is not provided', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('no data');
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(entry).not.toHaveProperty('data');
@@ -77,13 +77,13 @@ describe('Logger', () => {
     });
 
     it('should suppress debug messages', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.debug('this should not appear');
       expect(spy).not.toHaveBeenCalled();
     });
 
     it('should still log info messages', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('this should appear');
       expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -101,13 +101,31 @@ describe('Logger', () => {
     });
   });
 
+  describe('stdio transport compatibility', () => {
+    it('routes debug and info to console.error, never console.log', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const l = createLogger('m', { debugMode: true, accessKey: '' });
+      l.debug('d');
+      l.info('i');
+      l.warn('w');
+      l.error('e');
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalledTimes(3); // debug + info + error
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('access key redaction', () => {
     beforeEach(() => {
       logger = createLogger('test-module', { debugMode: true, accessKey });
     });
 
     it('should redact access key in message strings', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info(`Authorization header: Bearer ${accessKey}`);
       const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(entry.message).not.toContain(accessKey);
@@ -115,7 +133,7 @@ describe('Logger', () => {
     });
 
     it('should redact access key in data strings', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('request', { header: `Bearer ${accessKey}` });
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       const data = entry.data as Record<string, string>;
@@ -124,7 +142,7 @@ describe('Logger', () => {
     });
 
     it('should redact access key in nested data objects', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('nested', { req: { auth: accessKey } });
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       const data = entry.data as Record<string, Record<string, string>>;
@@ -132,7 +150,7 @@ describe('Logger', () => {
     });
 
     it('should redact access key in arrays', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('array', [accessKey, 'safe']);
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       const data = entry.data as string[];
@@ -142,14 +160,14 @@ describe('Logger', () => {
 
     it('should not redact when access key is empty', () => {
       const emptyLogger = createLogger('test', { debugMode: true, accessKey: '' });
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       emptyLogger.info('no redaction needed');
       const entry: LogEntry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(entry.message).toBe('no redaction needed');
     });
 
     it('should handle non-string, non-object data without redaction', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       logger.info('number data', 42);
       const entry = JSON.parse(spy.mock.calls[0][0] as string) as LogEntry;
       expect(entry.data).toBe(42);
@@ -159,7 +177,7 @@ describe('Logger', () => {
   describe('updateOptions', () => {
     it('should update debug mode dynamically', () => {
       logger = createLogger('test', { debugMode: false, accessKey: '' });
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       logger.debug('suppressed');
       expect(spy).not.toHaveBeenCalled();
@@ -173,7 +191,7 @@ describe('Logger', () => {
   describe('sink', () => {
     it('invokes the sink once per emitted line at info level', () => {
       const sink = vi.fn();
-      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const l = createLogger('m', { debugMode: false, accessKey: '', sink });
       l.info('first');
       l.info('second');
@@ -192,7 +210,7 @@ describe('Logger', () => {
 
     it('does not invoke the sink for messages filtered by level', () => {
       const sink = vi.fn();
-      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const l = createLogger('m', { debugMode: false, accessKey: '', sink });
       l.debug('suppressed');
       expect(sink).not.toHaveBeenCalled();
@@ -200,7 +218,7 @@ describe('Logger', () => {
 
     it('formats sink lines as human-readable plain text', () => {
       const sink = vi.fn();
-      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const l = createLogger('http-server', {
         debugMode: false,
         accessKey: '',
@@ -215,7 +233,7 @@ describe('Logger', () => {
 
     it('redacts the access key in sink output', () => {
       const sink = vi.fn();
-      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const l = createLogger('m', {
         debugMode: false,
         accessKey: 'sekrit',
@@ -231,7 +249,7 @@ describe('Logger', () => {
       const sink = vi.fn(() => {
         throw new Error('disk full');
       });
-      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const l = createLogger('m', { debugMode: false, accessKey: '', sink });
       expect(() => l.info('x')).not.toThrow();
     });


### PR DESCRIPTION
Closes #256

## Summary

- Route `debug` and `info` log entries through `console.error` instead of `console.log` so the logger never writes to stdout.
- Stdio MCP transports reserve stdout exclusively for JSON-RPC frames; this change makes the logger safe to use regardless of transport.
- Adds one short comment above the level switch explaining the WHY.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 545 passed (was 544; one new "stdio transport compatibility" regression test asserts `console.log` is never called for any level)
- [x] `npm run typecheck` clean
- [x] Existing `console.log` spy assertions for debug/info migrated to `console.error`; remaining `console.log` references in the test file confined to the new negative assertion