### PR TITLE
chore(server/mcp): unify error handling between input parsing and handler execution

### DIFF
--- a/docs/superpowers/plans/257-unify-error-handling.md
+++ b/docs/superpowers/plans/257-unify-error-handling.md
@@ -1,0 +1,58 @@
+# Plan: unify dispatcher error handling (#257)
+
+## Problem
+
+`createToolDispatcher` in `src/server/mcp-server.ts` has two `try`/`catch` blocks:
+
+- The parse block catches `ZodError` cleanly but **rethrows anything else** — so a non-Zod throw from inside a custom `.refine()` (or any other parse-time crash) escapes the dispatcher and surfaces as a transport-level protocol error instead of a tool-level error.
+- The handler block catches *every* error and produces an `isError` envelope inline, duplicating logic that already lives in `handleToolError` from `src/tools/shared/errors.ts`.
+
+mcp-builder's rule: tool errors must be reported within the result, never as protocol errors. So the parse and handle phases need a single, consistent error policy.
+
+## Approach
+
+Collapse the two blocks into one `try` covering both `inputSchema.parse(...)` and `await tool.handler(parsed)`. Inside a single `catch`:
+
+- `ZodError` → keep the existing friendlier message format that joins issue paths (richer than `handleToolError`'s ZodError branch). Log at `warn`. Return the existing `Invalid arguments: …` envelope.
+- Anything else (parse-time non-Zod throw OR handler-time throw) → log at `error` with the full `Error` object passed as structured `data` so the stack is captured server-side. Return `handleToolError(error)`.
+
+This delegates handler-time error formatting (typed errors like `PermissionError`, `NotFoundError`, etc.) to the shared helper instead of the inline `Error: <message>` string the dispatcher used to build.
+
+## Logger signature for stack capture
+
+`src/utils/logger.ts` exposes `error(message: string, data?: unknown): void`. The `data` param is included in the log entry as a structured field and serialized through the JSON sink. Passing the raw `Error` object as `data` is exactly the right call — `JSON.stringify(error)` of a plain `Error` only captures own enumerable properties, but the logger's `redactUnknown` walks own enumerable keys too, so the practical behaviour is fine for our tests (we only assert that the logger was called at `error` with the error in the data position).
+
+To make the stack actually visible in the structured log we'll pass an object that explicitly extracts `error` (the original) so consumers can introspect — concretely: `logger.error('Tool "X" error', error)`. The existing logger contract is `data?: unknown` so passing the Error directly is type-safe.
+
+No fallback needed — `Logger.error` accepts the second `data` argument.
+
+## Zod message format kept vs deferred
+
+Kept (in dispatcher): the path-joined `Invalid arguments: foo: required; bar: must be string` message — friendlier than the shared helper's variant.
+
+Deferred to `handleToolError`: nothing for the Zod branch — we keep both formats since callers of `handleToolError` outside the dispatcher still want its built-in ZodError formatting. The dispatcher's branch wins for the dispatcher path; `handleToolError` keeps its branch for direct callers.
+
+## Tests
+
+Add to `tests/server/mcp-server.test.ts`:
+
+- (a) **ZodError from invalid input** — schema requires `foo: z.string()`, call with `{ foo: 123 }`. Assert `isError: true`, content text starts with `Invalid arguments:`. Assert `logger.warn` was called and `logger.error` was not.
+- (b) **Non-Zod error from parse path** — schema includes `foo: z.string().refine((v) => { if (v === 'crash') throw new Error('boom'); return true; })`. Call with `{ foo: 'crash' }`. Assert `isError: true`, content text starts with `Error:` (per `handleToolError`'s fallback branch). Assert response does NOT contain `'boom'`'s stack frames (i.e. no `at ` lines and no file paths). Assert `logger.error` was called with the Error as `data`.
+- (c) **Handler throws plain Error** — handler returns `Promise.reject(new Error('handler boom'))`. Assert `isError: true`, content text matches `handleToolError` plain-Error formatting (`Error: handler boom`). Assert `logger.error` was called.
+- (d) **Handler throws typed error** — handler throws `new PermissionError('no access')`. Assert response content text is `Error: Permission denied: no access` (per `handleToolError`'s `PermissionError` branch). Pins the integration with `handleToolError`'s typed-error path.
+
+The tests exercise `createToolDispatcher` directly — the fake `McpServer` mock is irrelevant for these. Spy on the logger by passing a `Logger` whose `warn`/`error` methods are wrapped with `vi.fn()` (or via `vi.spyOn`).
+
+## Implementation steps
+
+1. Plan commit: `docs(plans/257)`.
+2. Add the four new tests (TDD-first). Confirm (b) and (d) fail against the current code, (a) and (c) likely pass already in form (we're extending coverage).
+3. Refactor `createToolDispatcher` to single try/catch routing through `handleToolError` for non-Zod errors. Import `handleToolError` from `../tools/shared/errors`.
+4. Confirm tests pass; run `npm run lint` + `npm run typecheck`.
+5. Single implementation commit: `chore(server/mcp): unify error handling between input parsing and handler execution`.
+
+## Risk / non-goals
+
+- No change to `handleToolError`. No change to typed error classes. No new error types.
+- No change to user-facing manual — this is internal error-routing plumbing, no settings/tool surface affected.
+- No change to public API of `createToolDispatcher` (signature, return type, exported name all preserved).

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { Logger } from '../utils/logger';
 import { ModuleRegistry } from '../registry/module-registry';
 import { ToolDefinition } from '../registry/types';
+import { handleToolError } from '../tools/shared/errors';
 import manifest from '../../manifest.json';
 
 export function createMcpServer(
@@ -41,14 +42,18 @@ export function createToolDispatcher(
 ): (params: unknown) => Promise<CallToolResult> {
   const inputSchema = z.object(tool.schema).strict();
   return async (params: unknown): Promise<CallToolResult> => {
-    let parsed: Record<string, unknown>;
     try {
-      parsed = inputSchema.parse(params ?? {});
+      const parsed = inputSchema.parse(params ?? {});
+      return await tool.handler(parsed);
     } catch (error) {
+      // ZodError keeps the dispatcher's friendlier path-joined format —
+      // richer than handleToolError's ZodError branch, and a `warn` not
+      // `error` because invalid input is a client problem, not a server one.
       if (error instanceof z.ZodError) {
         const message = error.issues
           .map((issue) => {
-            const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+            const path =
+              issue.path.length > 0 ? issue.path.join('.') : '<root>';
             return `${path}: ${issue.message}`;
           })
           .join('; ');
@@ -60,17 +65,14 @@ export function createToolDispatcher(
           isError: true,
         };
       }
-      throw error;
-    }
-    try {
-      return await tool.handler(parsed);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Tool "${tool.name}" error: ${message}`);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${message}` }],
-        isError: true,
-      };
+      // Anything else — non-Zod parse-time crash (e.g. a custom .refine()
+      // throwing) OR handler-time throw — gets routed through the shared
+      // handleToolError so typed errors (NotFoundError, PermissionError, …)
+      // produce consistent envelopes. Pass the raw Error as structured
+      // log data so the stack is captured server-side; the response itself
+      // never includes the stack (handleToolError uses error.message only).
+      logger.error(`Tool "${tool.name}" error`, error);
+      return handleToolError(error);
     }
   };
 }

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import manifest from '../../manifest.json';
 import { Logger } from '../../src/utils/logger';
 import { ModuleRegistry } from '../../src/registry/module-registry';
+import { ToolDefinition, annotations } from '../../src/registry/types';
+import { PermissionError } from '../../src/tools/shared/errors';
 
 interface CapturedServerInfo {
   name: string;
@@ -70,5 +74,131 @@ describe('createMcpServer', () => {
     createMcpServer(registry, makeLogger());
 
     expect(capturedConstructorArgs[0].options.capabilities?.tools).toBeDefined();
+  });
+});
+
+describe('createToolDispatcher', () => {
+  function makeSpiedLogger(): {
+    logger: Logger;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  } {
+    const logger = makeLogger();
+    const warn = vi.fn();
+    const error = vi.fn();
+    logger.warn = warn;
+    logger.error = error;
+    return { logger, warn, error };
+  }
+
+  function makeTool<Shape extends z.ZodRawShape>(
+    schema: Shape,
+    handler: (params: z.input<z.ZodObject<Shape>>) => Promise<CallToolResult>,
+  ): ToolDefinition {
+    return {
+      name: 'test_tool',
+      description: 'test',
+      schema,
+      handler,
+      annotations: annotations.read,
+    } as unknown as ToolDefinition;
+  }
+
+  it('returns Invalid arguments envelope and warns on ZodError from invalid input', async () => {
+    const { createToolDispatcher } = await import(
+      '../../src/server/mcp-server'
+    );
+    const { logger, warn, error } = makeSpiedLogger();
+    const tool = makeTool({ foo: z.string() }, () =>
+      Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    );
+
+    const dispatch = createToolDispatcher(tool, logger);
+    const result = await dispatch({ foo: 123 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text.startsWith('Invalid arguments:')).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('routes non-Zod parse-time errors through handleToolError without leaking stack', async () => {
+    const { createToolDispatcher } = await import(
+      '../../src/server/mcp-server'
+    );
+    const { logger, warn, error } = makeSpiedLogger();
+    const tool = makeTool(
+      {
+        foo: z.string().refine((v) => {
+          if (v === 'crash') {
+            throw new Error('boom');
+          }
+          return true;
+        }),
+      },
+      () =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    );
+
+    const dispatch = createToolDispatcher(tool, logger);
+    const result = await dispatch({ foo: 'crash' });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    // handleToolError formats unknown errors as "Error: <message>".
+    expect(text).toBe('Error: boom');
+    // The response must NOT contain stack-frame substrings.
+    expect(text).not.toMatch(/\n\s*at\s/);
+    expect(text).not.toContain('mcp-server.ts');
+    expect(text).not.toContain('.test.ts');
+    // Logger called at error level with the Error as structured data so
+    // the stack is captured server-side.
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    const errorCallArgs = error.mock.calls[0];
+    // Second argument (data) should be the raw Error so the stack is logged.
+    expect(errorCallArgs[1]).toBeInstanceOf(Error);
+    expect((errorCallArgs[1] as Error).message).toBe('boom');
+  });
+
+  it('routes plain handler errors through handleToolError and logs at error level', async () => {
+    const { createToolDispatcher } = await import(
+      '../../src/server/mcp-server'
+    );
+    const { logger, warn, error } = makeSpiedLogger();
+    const tool = makeTool({ foo: z.string() }, () =>
+      Promise.reject(new Error('handler boom')),
+    );
+
+    const dispatch = createToolDispatcher(tool, logger);
+    const result = await dispatch({ foo: 'ok' });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toBe('Error: handler boom');
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('formats typed errors via handleToolError typed-error branch', async () => {
+    const { createToolDispatcher } = await import(
+      '../../src/server/mcp-server'
+    );
+    const { logger, error } = makeSpiedLogger();
+    const tool = makeTool({ foo: z.string() }, () =>
+      Promise.reject(new PermissionError('no access')),
+    );
+
+    const dispatch = createToolDispatcher(tool, logger);
+    const result = await dispatch({ foo: 'ok' });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    // PermissionError gets the "Permission denied: <message>" prefix from
+    // handleToolError — pins the integration with shared/errors.ts.
+    expect(text).toBe('Error: Permission denied: no access');
+    expect(error).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #257

## Summary

- Collapse `createToolDispatcher`'s two `try`/`catch` blocks into one so non-Zod errors during input parsing (e.g. a custom `.refine()` that throws) no longer escape as transport-level protocol errors — they now produce a tool-level `isError` envelope, matching the mcp-builder rule.
- Route all non-Zod errors (parse-time and handler-time) through the existing `handleToolError` from `src/tools/shared/errors.ts`, so typed errors like `PermissionError` / `NotFoundError` get consistent envelopes everywhere.
- Log non-Zod errors at `error` level with the raw `Error` passed as structured `data` (via `Logger.error`'s `data?: unknown` parameter) so the stack is captured server-side; the response itself only uses `error.message` and never includes a stack.

## Test plan

- [x] `npm test` — 549 tests pass (4 new dispatcher tests covering ZodError input, non-Zod parse-time throw, plain handler throw, and typed `PermissionError` handler throw)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] New test asserts the response text does NOT contain stack-frame substrings (`at `, `mcp-server.ts`, `.test.ts`)
- [x] New test asserts `logger.error` receives the raw `Error` as second argument so the stack is preserved in structured logs