### PR TITLE
feat(registry): declare outputSchema on tools and forward to registerTool

### DIFF
--- a/docs/superpowers/plans/248-output-schema.md
+++ b/docs/superpowers/plans/248-output-schema.md
@@ -1,0 +1,150 @@
+# Issue #248 — declare `outputSchema` on tools and forward to `registerTool`
+
+Refs #248. Builds on #216 (`structuredContent` rollout to read tools).
+
+## Goal
+
+1. Extend the registry's `ToolDefinition` with an optional `outputSchema`.
+2. Forward it through `registerTools()` into the MCP SDK's `server.registerTool` call.
+3. Declare `outputSchema` for the **Batch A** vault read tools so modern clients can validate / discover the shape of `structuredContent`.
+4. File follow-up issues for Batches B, C, D before opening the PR.
+
+## Design choices
+
+### `outputSchema` typing
+
+Use the **simpler single-generic shape** with `outputSchema?: z.ZodRawShape` (mirrors how `schema` is typed). Reasons:
+
+- `defineTool` already erases the generic via `as unknown as ToolDefinition`, so adding an optional field with `z.ZodRawShape` does not propagate type-inference churn through every call site.
+- The MCP SDK's `registerTool` accepts a `ZodRawShape`-shaped object for `outputSchema` — same shape as `inputSchema`.
+- The two-generic form `<Shape, Out>` is nicer in theory but forces every existing `defineTool({...})` invocation to either declare both generics or rely on inference for `Out`, which TypeScript struggles with when the field is omitted. Not worth the churn for a framework-level change.
+
+If `z.ZodRawShape` doesn't compile cleanly we fall back to `z.ZodTypeAny` — but it should compile, because `schema: Shape` already uses the same kind of typing.
+
+### Forwarding pattern in `registerTools`
+
+The SDK already accepts `outputSchema: undefined` and treats it as "no output schema declared". So the forward is a single field addition:
+
+```ts
+server.registerTool(
+  tool.name,
+  {
+    description: tool.description,
+    inputSchema: tool.schema,
+    outputSchema: tool.outputSchema,  // undefined when not declared
+    annotations: tool.annotations,
+  },
+  createToolDispatcher(tool, logger),
+);
+```
+
+No conditional logic — unconditional pass-through keeps the registration site simple.
+
+## Batch A scope and shapes
+
+The five Batch A tools listed in the issue, with the exact `structuredContent` each handler emits today (read from `src/tools/vault/handlers.ts` + `src/tools/shared/response.ts`):
+
+### 1. `vault_read` — handler emits `{ path, content }`
+
+```ts
+outputSchema: {
+  path: z.string(),
+  content: z.string(),
+}
+```
+
+### 2. `vault_get_metadata` — handler emits `{ path, size, created, modified }`
+
+```ts
+outputSchema: {
+  path: z.string(),
+  size: z.number(),
+  created: z.string(),   // ISO-8601 timestamp
+  modified: z.string(),  // ISO-8601 timestamp
+}
+```
+
+### 3. `vault_list` — handler emits `{ files: string[], folders: string[] }` (the raw `adapter.list(path)` result)
+
+```ts
+outputSchema: {
+  files: z.array(z.string()),
+  folders: z.array(z.string()),
+}
+```
+
+### 4. `vault_list_recursive` — handler emits `{ folders: string[], ...PaginatedResponse<string> }`
+
+The `paginate()` helper produces `{ total, count, offset, items, has_more, next_offset? }`. The handler spreads that page in alongside `folders`:
+
+```ts
+outputSchema: {
+  folders: z.array(z.string()),
+  total: z.number(),
+  count: z.number(),
+  offset: z.number(),
+  items: z.array(z.string()),
+  has_more: z.boolean(),
+  next_offset: z.number().optional(),
+}
+```
+
+### 5. `vault_read_binary` — **deferred, NOT shipped in this PR**
+
+`vault_read_binary` returns `textResult(base64)` — it has **no** `structuredContent` slot. PR #216 deliberately left binary read out of the structured-content rollout. Declaring `outputSchema` on a tool that does not emit `structuredContent` would violate the MCP protocol (the SDK requires `structuredContent` whenever `outputSchema` is present).
+
+Rather than retrofit `structuredContent` into the binary handler (out of scope per issue: "Restructuring `structuredContent` payloads — keep the existing shapes, only describe them"), defer `vault_read_binary` to a follow-up issue alongside Batches B/C/D. Document this deviation in the PR body.
+
+## Tests
+
+### Framework-level (added to `tests/server/mcp-server.test.ts`)
+
+- Mock `McpServer.registerTool` to capture the second argument (the registration options) and assert:
+  - When the tool has `outputSchema` defined, the captured options carry it.
+  - When the tool has no `outputSchema`, the captured options' `outputSchema` is `undefined`.
+- Two tools driven through a tiny fake registry (or via a hand-built `ModuleRegistry` with a stub module).
+
+### Per-tool (added to `tests/tools/vault/handlers.test.ts` or a new sibling)
+
+For each Batch A tool:
+
+- Drive the handler with a representative input.
+- Assert `z.object(<outputSchema>).strict().parse(result.structuredContent)` succeeds.
+- Use existing `MockObsidianAdapter` fixtures.
+
+Concrete cases:
+
+- `vault_read` — read a small text file, parse `{ path, content }`.
+- `vault_get_metadata` — read `{ path, size, created, modified }`.
+- `vault_list` — list a folder with a mix of files and subfolders.
+- `vault_list_recursive` — listing with pagination metadata, exercise both `has_more=true` (asserts `next_offset`) and `has_more=false` (asserts `next_offset` absent).
+
+The Zod parse uses `.strict()` so the test fails loudly if the handler emits an extra unexpected field — this catches drift between renderer and structured payload (the original `mcp-builder` motivation).
+
+## Follow-up issues
+
+Filed before opening the PR for #248:
+
+- **Batch B (search)** — `feat(tools/search): declare outputSchema for search tools`. Scope: `search_fulltext`, `search_by_tag`, `search_by_frontmatter`, `search_resolved_links`, `search_unresolved_links`, `search_tags`, plus all the single-path getters (currently `search_get_*`, due to be renamed to `vault_get_*` by #255).
+- **Batch C (workspace + editor read)** — `feat(tools/workspace+editor): declare outputSchema for read tools`. Scope: `workspace_get_active_leaf`, `workspace_list_leaves`, `workspace_get_layout`, `editor_get_content`, `editor_get_active_file`, `editor_get_cursor`, `editor_get_selection`, `editor_get_line_count`.
+- **Batch D (extras + plugin-interop + templates + vault_read_binary)** — `feat(tools/extras+interop+templates): declare outputSchema for remaining read tools`. Includes `vault_read_binary` once the structured-payload retrofit decision is made.
+
+All three labelled `enhancement`. Bodies reference #248 ("Follow-up to #248; framework already landed") and #258 (campaign tracker) via `Refs #258`.
+
+## Commit plan
+
+1. `docs(plans/248): plan for outputSchema framework and vault read batch` — this file.
+2. `feat(registry): declare outputSchema on tools and forward to registerTool` — adds the optional field to `ToolDefinition`, forwards it from `registerTools`, plus framework-level test.
+3. `feat(tools/vault): declare outputSchema for vault read tools` — adds outputSchema to the four Batch A tools that already emit `structuredContent`, plus per-tool parse-validation tests.
+4. (Implicit in commit 3 if no diff) Regenerate `docs/tools.generated.md` via `npm run docs:tools`. The current generator only lists tool names, so output will be unchanged — but we run it so CI's `docs:check` passes.
+
+Each commit body ends with `Refs #248`.
+
+## Verification
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- `npm run docs:check`
+
+All four must pass before push.

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -33,6 +33,16 @@ export interface ToolDefinition<
   name: string;
   description: string;
   schema: Shape;
+  /**
+   * Optional Zod raw shape describing the `structuredContent` payload the
+   * handler emits. Forwarded to `McpServer.registerTool` so modern clients
+   * can validate / introspect the typed output. Tools that don't emit a
+   * `structuredContent` slot (e.g. plain-text confirmations or binary
+   * payloads) MUST leave this undefined — the MCP SDK requires that any
+   * call returning a tool with `outputSchema` declared also carry
+   * `structuredContent` matching that schema.
+   */
+  outputSchema?: z.ZodRawShape;
   handler: TypedHandler<Shape>;
   annotations: ToolAnnotations;
 }

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -90,6 +90,7 @@ function registerTools(
       {
         description: tool.description,
         inputSchema: tool.schema,
+        outputSchema: tool.outputSchema,
         annotations: tool.annotations,
       },
       createToolDispatcher(tool, logger),

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { ToolModule, ToolDefinition, annotations, defineTool } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createHandlers, WriteMutex } from './handlers';
@@ -20,6 +21,63 @@ import {
   readBinarySchema,
   writeBinarySchema,
 } from './schemas';
+
+/**
+ * Output schemas for the read tools that emit `structuredContent`. Each
+ * shape mirrors what the corresponding handler in `./handlers.ts` puts on
+ * `result.structuredContent` — declaring them here lets modern MCP clients
+ * validate / introspect the typed payload.
+ *
+ * `vault_read_binary` intentionally has no entry: its handler returns
+ * plain text (a base64 string), with no `structuredContent` slot. The MCP
+ * SDK requires `structuredContent` to be present whenever `outputSchema`
+ * is declared, so retrofitting this tool is deferred to a follow-up.
+ */
+const readFileOutputSchema = {
+  path: z.string().describe('Vault-relative path that was read.'),
+  content: z.string().describe('Full UTF-8 file content.'),
+};
+
+const getMetadataOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  size: z.number().describe('File size in bytes.'),
+  created: z
+    .string()
+    .describe('Creation timestamp as an ISO-8601 string.'),
+  modified: z
+    .string()
+    .describe('Last-modification timestamp as an ISO-8601 string.'),
+};
+
+const listFolderOutputSchema = {
+  files: z
+    .array(z.string())
+    .describe('Direct file children of the listed folder (names only).'),
+  folders: z
+    .array(z.string())
+    .describe('Direct subfolders of the listed folder (names only).'),
+};
+
+const listRecursiveOutputSchema = {
+  folders: z
+    .array(z.string())
+    .describe('All folders found under the listed path (recursive).'),
+  total: z
+    .number()
+    .describe('Total number of files matched before pagination.'),
+  count: z.number().describe('Number of files in this page.'),
+  offset: z.number().describe('Offset of the first item in this page.'),
+  items: z
+    .array(z.string())
+    .describe('Files in this page (vault-relative paths).'),
+  has_more: z
+    .boolean()
+    .describe('True when there are more files past this page.'),
+  next_offset: z
+    .number()
+    .optional()
+    .describe('Offset to use in the next request when has_more is true.'),
+};
 
 export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
   const mutex = new WriteMutex();
@@ -72,6 +130,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             ],
           }),
           schema: readFileSchema,
+          outputSchema: readFileOutputSchema,
           handler: handlers.readFile,
           annotations: annotations.read,
         }),
@@ -133,6 +192,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }),
           schema: getMetadataSchema,
+          outputSchema: getMetadataOutputSchema,
           handler: handlers.getMetadata,
           annotations: annotations.read,
         }),
@@ -242,6 +302,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"Folder not found" if path does not exist.'],
           }),
           schema: listFolderSchema,
+          outputSchema: listFolderOutputSchema,
           handler: handlers.listFolder,
           annotations: annotations.read,
         }),
@@ -258,6 +319,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"Folder not found" if path does not exist.'],
           }),
           schema: listRecursiveSchema,
+          outputSchema: listRecursiveOutputSchema,
           handler: handlers.listRecursive,
           annotations: annotations.read,
         }),

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -4,7 +4,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import manifest from '../../manifest.json';
 import { Logger } from '../../src/utils/logger';
 import { ModuleRegistry } from '../../src/registry/module-registry';
-import { ToolDefinition, annotations } from '../../src/registry/types';
+import { ToolDefinition, ToolModule, annotations } from '../../src/registry/types';
 import { PermissionError } from '../../src/tools/shared/errors';
 
 interface CapturedServerInfo {
@@ -16,10 +16,22 @@ interface CapturedOptions {
   capabilities?: { tools?: unknown };
 }
 
+interface CapturedRegisterToolCall {
+  name: string;
+  config: {
+    description?: string;
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+    annotations?: unknown;
+  };
+}
+
 const capturedConstructorArgs: Array<{
   serverInfo: CapturedServerInfo;
   options: CapturedOptions;
 }> = [];
+
+const capturedRegisterToolCalls: CapturedRegisterToolCall[] = [];
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
   class FakeMcpServer {
@@ -27,9 +39,11 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
     constructor(serverInfo: CapturedServerInfo, options: CapturedOptions) {
       capturedConstructorArgs.push({ serverInfo, options });
     }
-    registerTool(): void {
-      // no-op — createMcpServer registers active tools, but our test
-      // registry is empty.
+    registerTool(
+      name: string,
+      config: CapturedRegisterToolCall['config'],
+    ): void {
+      capturedRegisterToolCalls.push({ name, config });
     }
   }
   return { McpServer: FakeMcpServer };
@@ -42,6 +56,7 @@ function makeLogger(): Logger {
 describe('createMcpServer', () => {
   beforeEach(() => {
     capturedConstructorArgs.length = 0;
+    capturedRegisterToolCalls.length = 0;
   });
 
   it('advertises the server as "obsidian-mcp-server" per the {service}-mcp-server convention', async () => {
@@ -74,6 +89,64 @@ describe('createMcpServer', () => {
     createMcpServer(registry, makeLogger());
 
     expect(capturedConstructorArgs[0].options.capabilities?.tools).toBeDefined();
+  });
+
+  it('forwards outputSchema to registerTool when defined, and undefined when absent', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+
+    const inputSchema = { foo: z.string() };
+    const outputSchema = { result: z.string() };
+
+    const toolWithOutputSchema = {
+      name: 'tool_with_output',
+      description: 'has output schema',
+      schema: inputSchema,
+      outputSchema,
+      handler: () =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      annotations: annotations.read,
+    } as unknown as ToolDefinition;
+
+    const toolWithoutOutputSchema = {
+      name: 'tool_without_output',
+      description: 'no output schema',
+      schema: inputSchema,
+      handler: () =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      annotations: annotations.read,
+    } as unknown as ToolDefinition;
+
+    const stubModule: ToolModule = {
+      metadata: {
+        id: 'stub',
+        name: 'Stub',
+        description: 'test',
+      },
+      tools: () => [toolWithOutputSchema, toolWithoutOutputSchema],
+    };
+
+    const registry = new ModuleRegistry(makeLogger());
+    registry.registerModule(stubModule);
+
+    createMcpServer(registry, makeLogger());
+
+    expect(capturedRegisterToolCalls).toHaveLength(2);
+
+    const withOutput = capturedRegisterToolCalls.find(
+      (c) => c.name === 'tool_with_output',
+    );
+    expect(withOutput).toBeDefined();
+    expect(withOutput?.config.outputSchema).toBe(outputSchema);
+    expect(withOutput?.config.inputSchema).toBe(inputSchema);
+
+    const withoutOutput = capturedRegisterToolCalls.find(
+      (c) => c.name === 'tool_without_output',
+    );
+    expect(withoutOutput).toBeDefined();
+    expect(withoutOutput?.config.outputSchema).toBeUndefined();
+    // The field IS present in the config object (we forward it
+    // unconditionally) — but its value is undefined.
+    expect('outputSchema' in (withoutOutput?.config ?? {})).toBe(true);
   });
 });
 

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
 import { createVaultModule } from '../../../src/tools/vault/index';
+import { createHandlers, WriteMutex } from '../../../src/tools/vault/handlers';
 
 describe('vault module', () => {
   it('should have correct metadata', () => {
@@ -53,5 +55,142 @@ describe('vault module', () => {
       'vault_update',
       'vault_write_binary',
     ]);
+  });
+});
+
+/**
+ * Batch A of #248: every vault read tool that emits `structuredContent`
+ * must declare an `outputSchema`, and that schema must accurately describe
+ * the payload the handler actually produces. Drift between renderer and
+ * structured payload is the failure mode this guards against.
+ *
+ * `vault_read_binary` is excluded — its handler returns plain text (no
+ * `structuredContent`), so declaring an `outputSchema` would violate the
+ * MCP contract. Deferred to the Batch D follow-up (see plan).
+ */
+describe('vault read tools — outputSchema declarations', () => {
+  function getStructured(
+    tool: { outputSchema?: z.ZodRawShape },
+  ): z.ZodObject<z.ZodRawShape> {
+    if (!tool.outputSchema) {
+      throw new Error('expected outputSchema to be declared');
+    }
+    return z.object(tool.outputSchema).strict();
+  }
+
+  function findTool(
+    name: string,
+  ): { name: string; outputSchema?: z.ZodRawShape } {
+    const adapter = new MockObsidianAdapter();
+    const module = createVaultModule(adapter);
+    const tool = module.tools().find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found`);
+    return tool;
+  }
+
+  it('vault_read declares outputSchema and structuredContent parses against it', async () => {
+    const tool = findTool('vault_read');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('test.md', '# Hello');
+    const handlers = createHandlers(adapter, new WriteMutex());
+
+    const result = await handlers.readFile({
+      path: 'test.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed).toEqual({ path: 'test.md', content: '# Hello' });
+  });
+
+  it('vault_get_metadata declares outputSchema and structuredContent parses against it', async () => {
+    const tool = findTool('vault_get_metadata');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', 'hi', { ctime: 1000, mtime: 2000 });
+    const handlers = createHandlers(adapter, new WriteMutex());
+
+    const result = await handlers.getMetadata({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('note.md');
+    expect(parsed.size).toBe(2);
+    expect(typeof parsed.created).toBe('string');
+    expect(typeof parsed.modified).toBe('string');
+  });
+
+  it('vault_list declares outputSchema and structuredContent parses against it', async () => {
+    const tool = findTool('vault_list');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('notes/a.md', 'a');
+    adapter.addFolder('notes/sub');
+    const handlers = createHandlers(adapter, new WriteMutex());
+
+    const result = await handlers.listFolder({
+      path: 'notes',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.files).toEqual(expect.any(Array));
+    expect(parsed.folders).toEqual(expect.any(Array));
+  });
+
+  it('vault_list_recursive declares outputSchema and parses with next_offset present', async () => {
+    const tool = findTool('vault_list_recursive');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('lots');
+    for (let i = 0; i < 5; i++) {
+      adapter.addFile(`lots/f-${String(i)}.md`, 'x');
+    }
+    const handlers = createHandlers(adapter, new WriteMutex());
+
+    const result = await handlers.listRecursive({
+      path: 'lots',
+      limit: 2,
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(5);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
+    expect(parsed.items).toHaveLength(2);
+  });
+
+  it('vault_list_recursive parses cleanly when has_more is false (no next_offset)', async () => {
+    const tool = findTool('vault_list_recursive');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('few');
+    adapter.addFile('few/a.md', 'a');
+    adapter.addFile('few/b.md', 'b');
+    const handlers = createHandlers(adapter, new WriteMutex());
+
+    const result = await handlers.listRecursive({
+      path: 'few',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_offset).toBeUndefined();
+  });
+
+  it('vault_read_binary intentionally omits outputSchema (no structuredContent emitted)', () => {
+    const tool = findTool('vault_read_binary');
+    // Deferred to Batch D. Asserting the absence pins the deviation
+    // documented in docs/superpowers/plans/248-output-schema.md so a
+    // future change cannot silently add one without re-checking that the
+    // handler also emits a matching structuredContent slot.
+    expect(tool.outputSchema).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #248

## Summary

- Add an optional `outputSchema?: z.ZodRawShape` field to `ToolDefinition` and forward it from `registerTools()` into `McpServer.registerTool` so modern MCP clients can validate / introspect the typed `structuredContent` payload that read tools emit.
- Declare `outputSchema` for the four Batch A vault read tools that already emit `structuredContent` (via PR #216): `vault_read`, `vault_get_metadata`, `vault_list`, `vault_list_recursive`. Each shape mirrors exactly what the corresponding handler puts on `result.structuredContent`.
- Strict-mode (`z.object(shape).strict().parse(...)`) parse tests guard against future drift between the markdown renderer and the structured payload.

## Typing choice

Used the simpler single-generic `z.ZodRawShape` instead of the two-generic `<Shape, Out>` form suggested in the issue. The existing `defineTool` already erases the generic via `as unknown as ToolDefinition`, so adding an optional field does not propagate type-inference churn through every call site. `npm run typecheck` stays clean across the whole codebase without touching any other tool definition.

## `vault_read_binary` deferral

The issue lists `vault_read_binary` in Batch A, but its handler returns plain text (a base64 string) with **no** `structuredContent` slot — PR #216 deliberately left it out of the structured-content rollout. The MCP SDK requires `structuredContent` to be present whenever `outputSchema` is declared, so retrofitting this tool would be a payload change (out of scope per the issue: "Restructuring `structuredContent` payloads — keep the existing shapes, only describe them"). Deferred to the Batch D follow-up #278, with a pinned test asserting the absence so a future change cannot silently add one without re-checking the structured slot.

## Test plan

- [x] `npm test` — 556 tests passing (was 549 baseline, +7 new).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run docs:check` — clean (no diff; the generator only lists tool names so the regenerated file is unchanged).
- [x] Framework test in `tests/server/mcp-server.test.ts` confirms `registerTool` is called with `outputSchema` when defined and with `outputSchema: undefined` when absent (the field is forwarded unconditionally).
- [x] Per-tool tests in `tests/tools/vault/module.test.ts` parse-validate `result.structuredContent` against each Batch A tool's declared schema, including both `has_more=true` (asserts `next_offset`) and `has_more=false` (asserts `next_offset` absent) cases for `vault_list_recursive`.

## Follow-ups

Batches B, C, D filed before opening this PR:

- #276 — `feat(tools/search): declare outputSchema for search tools` (Batch B)
- #277 — `feat(tools/workspace+editor): declare outputSchema for read tools` (Batch C)
- #278 — `feat(tools/extras+interop+templates): declare outputSchema for remaining read tools` (Batch D, includes the `vault_read_binary` retrofit decision)