### PR TITLE
fix(tools/ui): remove ui_confirm and ui_prompt stubs

### DIFF
--- a/docs/superpowers/plans/254-remove-ui-stubs.md
+++ b/docs/superpowers/plans/254-remove-ui-stubs.md
@@ -1,0 +1,60 @@
+# Plan: remove `ui_confirm` and `ui_prompt` stubs (#254)
+
+## Decision
+
+Option B from the campaign spec (#258): delete the stubs. They never opened
+an Obsidian modal — they only returned a JSON envelope that *looks* like
+data — so the honest move is to take them off the MCP tool surface.
+
+`ui_notice` stays untouched; it has a real implementation.
+
+## Files touched
+
+- `src/tools/ui/index.ts`
+  - Remove `showConfirmSchema` and `showPromptSchema` constants.
+  - Remove `showConfirm` and `showPrompt` from `UiHandlers` interface.
+  - Remove `showConfirm` and `showPrompt` from `createHandlers`.
+  - Remove the `defineTool({ name: 'ui_confirm', … })` and
+    `defineTool({ name: 'ui_prompt', … })` blocks in `tools()`.
+  - Drop the obsolete comment about confirmation modals / prompts being
+    stubs that need UI interaction.
+- `tests/tools/ui/ui.test.ts`
+  - Drop the `ui_confirm` and `ui_prompt` `it` blocks.
+  - Update the registration count test from 3 to 1.
+  - Keep the `ui_notice` test intact.
+- `docs/tools.generated.md`
+  - Regenerated via `npm run docs:tools`. The `ui` row's tool count drops
+    from 3 to 1 and the tool list becomes just `ui_notice`. The two
+    detailed sections for `ui_confirm` and `ui_prompt` disappear.
+
+## Files NOT touched
+
+- `docs/help/en.md` — confirmed via grep that neither `ui_confirm` nor
+  `ui_prompt` is mentioned. No user-facing manual update needed.
+- No `docs/help/de.md` exists yet.
+- No screenshot capture — no settings/modal/ribbon UI changes.
+
+## Surface change callout
+
+This removes two tools from the MCP tool list. Agents that currently call
+`ui_confirm` or `ui_prompt` will receive a "tool not found" error after
+this lands. The campaign spec (#258) classifies this as Phase 4
+(non-breaking-bundle) because the stubs never returned real data — a
+caller that was relying on them was already broken in practice. Therefore
+the commit uses `fix:` (matching the issue title) instead of `feat!:` /
+`BREAKING CHANGE:`. The PR body will spell the surface change out in plain
+English so reviewers can sanity-check.
+
+## Verification
+
+- `npm run lint`
+- `npm test`
+- `npm run typecheck`
+- `npm run docs:check`
+
+## Commits
+
+1. `docs(plans/254): plan for removing ui_confirm and ui_prompt stubs` —
+   this file. `Refs #254`.
+2. `fix(tools/ui): remove ui_confirm and ui_prompt stubs` — the deletions
+   plus the regenerated `docs/tools.generated.md`. `Refs #254`.

--- a/docs/tools.generated.md
+++ b/docs/tools.generated.md
@@ -10,9 +10,9 @@ This file is regenerated from the tool registry and committed so CI can detect d
 | `editor` | Editor Operations | 10 | editor_get_content, editor_get_active_file, editor_insert, editor_replace, editor_delete, editor_get_cursor, editor_set_cursor, editor_get_selection, editor_set_selection, editor_get_line_count |
 | `search` | Search and Metadata | 12 | search_fulltext, search_frontmatter, search_tags, search_headings, search_outgoing_links, search_embeds, search_backlinks, search_resolved_links, search_unresolved_links, search_block_references, search_by_tag, search_by_frontmatter |
 | `workspace` | Workspace and Navigation | 5 | workspace_get_active_leaf, workspace_open_file, workspace_list_leaves, workspace_set_active_leaf, workspace_get_layout |
-| `ui` | UI Interactions | 3 | ui_notice, ui_confirm, ui_prompt |
+| `ui` | UI Interactions | 1 | ui_notice |
 | `templates` | Templates and Content Generation | 3 | template_list, template_create_from, template_expand |
 | `plugin-interop` | Plugin Interop | 5 | plugin_list, plugin_check, plugin_dataview_query, plugin_templater_execute, plugin_execute_command |
 | `extras` | Extras | 1 | get_date |
 
-**Total tools:** 55 across 8 modules.
+**Total tools:** 53 across 8 modules.

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -27,31 +27,8 @@ const showNoticeSchema = {
     .describe('Milliseconds before the notice auto-dismisses (0 = sticky)'),
 };
 
-const showConfirmSchema = {
-  message: z
-    .string()
-    .min(1)
-    .max(1000)
-    .describe('Question to present in the confirmation modal'),
-};
-
-const showPromptSchema = {
-  message: z
-    .string()
-    .min(1)
-    .max(1000)
-    .describe('Prompt label to show in the input modal'),
-  defaultValue: z
-    .string()
-    .max(1000)
-    .optional()
-    .describe('Pre-filled value for the input field'),
-};
-
 interface UiHandlers {
   showNotice: (params: InferredParams<typeof showNoticeSchema>) => Promise<CallToolResult>;
-  showConfirm: (params: InferredParams<typeof showConfirmSchema>) => Promise<CallToolResult>;
-  showPrompt: (params: InferredParams<typeof showPromptSchema>) => Promise<CallToolResult>;
 }
 
 function createHandlers(adapter: ObsidianAdapter): UiHandlers {
@@ -59,24 +36,6 @@ function createHandlers(adapter: ObsidianAdapter): UiHandlers {
     showNotice: (params): Promise<CallToolResult> => {
       adapter.showNotice(params.message, params.duration);
       return Promise.resolve(text('Notice shown'));
-    },
-    // Confirmation modals and input prompts require Obsidian UI interaction
-    // that can't be easily automated via MCP. We implement them as stubs
-    // that return a structured response indicating they need user interaction.
-    showConfirm: (params): Promise<CallToolResult> => {
-      return Promise.resolve(text(JSON.stringify({
-        type: 'confirm',
-        message: params.message,
-        note: 'Confirmation modals require user interaction in the Obsidian UI',
-      })));
-    },
-    showPrompt: (params): Promise<CallToolResult> => {
-      return Promise.resolve(text(JSON.stringify({
-        type: 'prompt',
-        message: params.message,
-        defaultValue: params.defaultValue ?? '',
-        note: 'Input prompts require user interaction in the Obsidian UI',
-      })));
     },
   };
 }
@@ -99,31 +58,6 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
           }),
           schema: showNoticeSchema,
           handler: h.showNotice,
-          annotations: annotations.additive,
-        }),
-        defineTool({
-          name: 'ui_confirm',
-          description: describeTool({
-            summary: 'Stub for a confirmation modal — user interaction cannot be captured via MCP.',
-            args: ['message (string, 1..1000): Question text.'],
-            returns: 'JSON envelope noting that confirmation modals need UI interaction.',
-          }),
-          schema: showConfirmSchema,
-          handler: h.showConfirm,
-          annotations: annotations.additive,
-        }),
-        defineTool({
-          name: 'ui_prompt',
-          description: describeTool({
-            summary: 'Stub for an input prompt modal — user input cannot be captured via MCP.',
-            args: [
-              'message (string, 1..1000): Prompt label.',
-              'defaultValue (string, ≤1000, optional): Pre-filled value.',
-            ],
-            returns: 'JSON envelope noting that prompts need UI interaction.',
-          }),
-          schema: showPromptSchema,
-          handler: h.showPrompt,
           annotations: annotations.additive,
         }),
       ];

--- a/tests/tools/ui/ui.test.ts
+++ b/tests/tools/ui/ui.test.ts
@@ -3,10 +3,10 @@ import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
 import { createUiModule } from '../../../src/tools/ui/index';
 
 describe('UI module', () => {
-  it('should register 3 tools', () => {
+  it('should register 1 tool', () => {
     const adapter = new MockObsidianAdapter();
     const module = createUiModule(adapter);
-    expect(module.tools()).toHaveLength(3);
+    expect(module.tools()).toHaveLength(1);
   });
 
   it('should show notice without error', async () => {
@@ -14,22 +14,6 @@ describe('UI module', () => {
     const module = createUiModule(adapter);
     const tool = module.tools().find((t) => t.name === 'ui_notice')!;
     const result = await tool.handler({ message: 'Test notice' });
-    expect(result.isError).toBeUndefined();
-  });
-
-  it('should return confirm response', async () => {
-    const adapter = new MockObsidianAdapter();
-    const module = createUiModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'ui_confirm')!;
-    const result = await tool.handler({ message: 'Are you sure?' });
-    expect(result.isError).toBeUndefined();
-  });
-
-  it('should return prompt response', async () => {
-    const adapter = new MockObsidianAdapter();
-    const module = createUiModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'ui_prompt')!;
-    const result = await tool.handler({ message: 'Enter name' });
     expect(result.isError).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #254

## Summary

- Removes the `ui_confirm` and `ui_prompt` MCP tools, which were stubs that never opened an Obsidian modal — they only returned a JSON envelope describing the intent, which misled callers.
- Drops the matching schemas, handler entries, `UiHandlers` interface members, the obsolete stub-explanation comment, and the test cases for the two stubs.
- Regenerates `docs/tools.generated.md` (`ui` module 3 → 1 tool, registry total 55 → 53).
- `ui_notice` is unaffected — it has a real implementation and stays exactly as it was.

## Surface change

Two tools (`ui_confirm`, `ui_prompt`) are removed from the MCP tool list. Agents that currently call them will receive a tool-not-found error. They never returned real user input anyway, so any caller relying on them was already broken in practice. This PR follows the campaign decision in #258 (Phase 4, Option B): `fix:` rather than `feat!:` because the removed tools never actually worked.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 44 files, 575 passing (down 2 from baseline; the two dropped UI tests)
- [x] `npm run typecheck` — clean
- [x] `npm run docs:check` — clean (regenerated `docs/tools.generated.md` matches)