### PR TITLE
feat!: enforce naming convention and secure-by-default auth

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -94,7 +94,7 @@ Each category is a toggleable module. Modules self-register. The settings UI aut
 
 Utility tools that do not mirror an Obsidian API. Modules in this group render under a separate "Extras" heading in the settings UI (not under "Feature Modules"). Unlike core feature modules, Extras modules are not toggled as a single unit: the settings UI renders one toggle **per tool** within the Extras group, and the registry stores per-tool enable state on the module. All Extras tools are disabled by default — users opt in one tool at a time.
 
-- **R55** — `get_date` tool returns the current local datetime as a plain ISO-8601 string with timezone offset (e.g. `2026-04-16T14:32:05.123+02:00`). The offset is already encoded in the string, so no additional fields are returned. Disabled by default. Belongs to the "Extras" module group.
+- **R55** — `extras_get_date` tool returns the current local datetime as a plain ISO-8601 string with timezone offset (e.g. `2026-04-16T14:32:05.123+02:00`). The offset is already encoded in the string, so no additional fields are returned. Disabled by default. Belongs to the "Extras" module group.
 
 ### Internationalization (I18N)
 

--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -192,7 +192,7 @@ There is also an **Extras** group for utility tools that don't mirror an
 Obsidian API. Extras are toggled **per tool**, not per module, and are off by
 default. Today this contains:
 
-- `get_date` — returns the current local time as ISO-8601 with offset.
+- `extras_get_date` — returns the current local time as ISO-8601 with offset.
 
 ### Execute Command Allowlist
 
@@ -344,7 +344,7 @@ again retries the start.
 
 - The module that ships the tool is disabled. Enable it under **Feature
   Modules**.
-- For Extras tools (e.g. `get_date`), the per-tool toggle is off by default.
+- For Extras tools (e.g. `extras_get_date`), the per-tool toggle is off by default.
 - The client cached the previous `tools/list` response. Reconnect.
 
 ### How do I expose the server to another machine on my LAN?

--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -78,15 +78,17 @@ files into it.
 ## Basic setup (5 minutes)
 
 The shipping defaults are intentionally conservative: the server is **off**,
-auth is **off**, and binding is restricted to `127.0.0.1`. Walk through these
+**auth is on**, and binding is restricted to `127.0.0.1`. The plugin
+auto-generates a 32-byte access key on first load. Walk through these
 steps once after install:
 
 1. **Open the settings tab**: **Settings → MCP Server**.
-2. **Decide if you need authentication**:
-   - Local-only, single-user machine → leave **Require Bearer authentication**
-     off.
-   - Anything else (shared host, non-localhost binding, paranoia) → turn it on
-     and click **Generate** next to **Access Key**.
+2. **Copy the auto-generated access key**. The plugin already populated
+   it on first load; click the **Copy** button next to **Access Key**.
+   - If you'd rather run unauthenticated (only safe on a trusted,
+     localhost-only setup), toggle **Require Bearer authentication**
+     off, then explicitly toggle **Accept insecure mode** on. The
+     server refuses to bind without that second toggle.
 3. **(Optional) Pick which feature modules you want**. By default all core
    modules are enabled. Disable anything you don't need (principle of least
    privilege).
@@ -130,11 +132,12 @@ The settings tab is split into five sections.
 | **Server Address** | `127.0.0.1` | IPv4 address the server binds to. `127.0.0.1` is local-only. Setting this to `0.0.0.0` exposes the server on every network interface — only do that with auth enabled and a firewall in front. Requires a restart. |
 | **Port** | `28741` | TCP port to listen on. Any integer 1–65535. Restart required. |
 | **Server URL** | (read-only) | Full `http(s)://address:port/mcp` URL. The copy button puts it on your clipboard. |
-| **Require Bearer authentication** | off | Master switch for auth. When off, every request is accepted (only safe on `127.0.0.1`). When on, every request must carry `Authorization: Bearer <key>`. |
-| **Access Key** | (empty) | Visible only when auth is on. Use **Generate** to create a 64-char hex key (256 bits of entropy from `crypto.randomBytes`). The **Copy** button copies it without revealing it. |
+| **Require Bearer authentication** | **on** | Master switch for auth. When on, every request must carry `Authorization: Bearer <key>`. When off, the server **refuses to bind** unless you also turn on **Accept insecure mode** (see below). |
+| **Access Key** | (auto-generated) | Visible only when auth is on. On a fresh install with auth on, the plugin auto-generates a 32-byte base64url key on first load and persists it. Use **Generate** to rotate it. The **Copy** button copies it to the clipboard. |
+| **Accept insecure mode** | off | Visible only when auth is off. The server refuses to bind without this toggle, so you can't accidentally expose an unauthenticated MCP endpoint. Only safe on a trusted, localhost-only setup. |
 | **HTTPS** | off | Switch to HTTPS using a locally generated self-signed certificate. Restart required. See the FAQ for client-side trust. |
 | **TLS Certificate** | auto | Generated on the first HTTPS start, then cached in `data.json`. Use **Regenerate certificate** if you change the address or want a fresh key pair — clients will need to re-trust the new cert. |
-| **Auto-start on launch** | off | Start the MCP server automatically when Obsidian loads. If auth is enabled but no key is set, the server stays stopped and the reason is logged. |
+| **Auto-start on launch** | off | Start the MCP server automatically when Obsidian loads. The server still applies the auth/insecure-mode guard on auto-start, so a misconfigured install stays stopped and the reason is logged. |
 
 #### DNS Rebind Protection
 
@@ -318,9 +321,18 @@ hits the rate limiter, so it can't lock you out of authentication.
 
 ### The server won't auto-start
 
-Auto-start is gated by auth. If **Require Bearer authentication** is on but
-**Access Key** is empty, the server intentionally stays stopped and writes an
-`info` log entry explaining why. Either generate a key or disable auth.
+Auto-start is gated by the same checks as the manual start button.
+Two configurations cause an auto-start to fail silently with an `info`
+log entry:
+
+- **Require Bearer authentication** is on but **Access Key** is empty
+  (rare — the plugin auto-generates a key on first load, so this
+  usually only happens if you cleared the field manually).
+- **Require Bearer authentication** is off and **Accept insecure
+  mode** is also off. The server refuses to bind in this state so
+  unauthenticated traffic is never started by accident. Open the
+  settings tab to turn auth back on (and let the plugin generate a
+  key) or to explicitly accept insecure mode.
 
 ### "EADDRINUSE" / port conflict on start
 

--- a/docs/superpowers/plans/258-phase5-breaking-bundle.md
+++ b/docs/superpowers/plans/258-phase5-breaking-bundle.md
@@ -1,0 +1,289 @@
+# Plan — Phase 5 breaking bundle (#258)
+
+- **Tracker:** [#258](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/258)
+- **Closes:** #250, #251, #253, #255
+- **Branch:** `feat/issue-258-phase5-breaking-bundle`
+- **PR title:** `feat!: enforce naming convention and secure-by-default auth`
+
+This plan implements the four breaking issues that ship together as one
+PR. Decisions are locked from the campaign spec
+(`docs/superpowers/specs/2026-05-02-mcp-builder-review-followup-design.md`,
+§2 and §3 Phase 5). No deprecation aliases — clean break.
+
+---
+
+## #251 — Rename `get_date` → `extras_get_date`
+
+### Approach
+
+- Single source-line change: `name: 'get_date'` → `'extras_get_date'`.
+- No alias. PR ships a major version, so an alias would be one-release-old
+  immediately.
+- `migrations.ts` references `{ get_date: true }` in the V3→V4 hop —
+  already-migrated installs persist that key, so we leave the V3→V4 hop
+  alone (rewriting historical migrations is out of scope) but add a
+  V9→V10 hop that renames `extras.toolStates.get_date` →
+  `extras.toolStates.extras_get_date` so the toggle keeps working after
+  upgrade.
+
+### Files touched
+
+- `src/tools/extras/index.ts` — rename the tool name.
+- `src/settings/migrations.ts` — V9→V10 hop renames the toolStates key.
+- `tests/tools/extras/extras.test.ts` — every assertion that mentions
+  `get_date`.
+- `tests/settings.test.ts` — the four call sites that mention `get_date`
+  in toolStates / discovery output.
+- `tests/utils/debug-info.test.ts` — `get_date` in the debug bundle
+  fixture.
+- `tests/registry/module-registry.test.ts` — `get_date` mock-tool calls.
+- `docs/help/en.md` — line 195 and 347 reference `get_date`.
+
+### Tests to add / update
+
+- All existing `get_date` references rewritten to `extras_get_date`.
+- New migrations test: V9 → V10 renames `extras.toolStates.get_date` →
+  `extras_get_date`, leaves other tool keys alone.
+
+---
+
+## #255 — Rename six `search_*` getters to `vault_get_*`
+
+### Approach
+
+The six tools (`search_frontmatter`, `search_headings`,
+`search_outgoing_links`, `search_embeds`, `search_backlinks`,
+`search_block_references`) do single-path field access — they are not
+vault-wide search and conceptually belong with `vault_read` /
+`vault_get_metadata`.
+
+**Chosen path:** move the six tools out of the search module and into
+`src/tools/vault/index.ts`. The handler logic stays where it currently
+lives (the search handlers operate on the same adapter the vault module
+already holds, so the move is purely a registry change — keep importing
+`createSearchHandlers` from `src/tools/search/handlers.ts` for now and
+let the handler module continue to live there). This keeps the vault
+module's existing `handlers.ts` untouched and avoids a giant churn.
+
+The `search` module is left with the genuine vault-search tools:
+`search_fulltext`, `search_by_tag`, `search_by_frontmatter`,
+`search_resolved_links`, `search_unresolved_links`, `search_tags`.
+
+### Files touched
+
+- `src/tools/search/index.ts` — remove the six getters.
+- `src/tools/search/handlers.ts` — unchanged structurally (handlers
+  exported and still used).
+- `src/tools/vault/index.ts` — register the six new `vault_get_*` tools
+  using the existing search handlers + schemas. Import them from
+  `../search/handlers` and `../search/schemas`.
+- `tests/tools/search/search.test.ts` — drop the moved tools' module-
+  level tests; keep handler-level tests (handlers stay in place but the
+  tool count drops to 6).
+- `tests/tools/vault/module.test.ts` — assert the six new tools register.
+- `docs/help/en.md` — update any references; the help doesn't currently
+  list the affected tools by name (verify with grep).
+- `docs/tools.generated.md` — regenerated.
+
+### Renamed tools (old → new)
+
+| Old | New |
+|---|---|
+| `search_frontmatter` | `vault_get_frontmatter` |
+| `search_headings` | `vault_get_headings` |
+| `search_outgoing_links` | `vault_get_outgoing_links` |
+| `search_embeds` | `vault_get_embeds` |
+| `search_backlinks` | `vault_get_backlinks` |
+| `search_block_references` | `vault_get_block_references` |
+
+### Tests to update
+
+- `search.test.ts`: tool count drops from 12 → 6; `descriptionFor` /
+  registration tests move to vault module.
+- `vault/module.test.ts`: assert tool count after the move; assert each
+  new `vault_get_*` name is registered with read annotations.
+
+---
+
+## #250 — Plugin-interop: execute DQL; rename JS / Templater stubs
+
+### Approach (locked decisions)
+
+- **`plugin_dataview_query`:** Option A — actually execute when the user
+  passes a DQL query. Use the Dataview API's
+  `app.plugins.plugins.dataview?.api.queryMarkdown(query)` (read-only,
+  no JS evaluation). Return the rendered markdown along with the raw
+  query in `structuredContent`.
+- **dataview-js mode:** since the existing schema has a single `query`
+  field with no mode discriminator, **do not** add JS support to the
+  same tool. Add a separate tool
+  `plugin_dataview_describe_js_query` that echoes the JS source verbatim
+  with a note that the host must run it. Cleaner than a discriminated
+  union in the schema for this size of change.
+- **`plugin_templater_execute`:** rename to
+  `plugin_templater_describe_template`. Schema unchanged. Description
+  flips to "Echo a Templater template path for client-side execution.
+  Returns the path and a note that the host must run it via Templater."
+- **Adapter exposure:** add a typed `getDataviewApi()` method to
+  `ObsidianAdapter` that returns `{ queryMarkdown(query: string):
+  Promise<{ successful: boolean; value?: string; error?: string }> } |
+  null`. Reading via the adapter keeps `RealObsidianAdapter` the only
+  place that touches `app.plugins.plugins.<id>` and lets the mock stub
+  it cleanly.
+- **Error class:** add `PluginNotInstalledError` and
+  `PluginApiUnavailableError` to `src/tools/shared/errors.ts`. Map them
+  in `handleToolError` so they render as a normal MCP error envelope.
+
+### Files touched
+
+- `src/tools/shared/errors.ts` — two new error classes; map them in
+  `handleToolError`.
+- `src/obsidian/adapter.ts` — add `getDataviewApi()` to interface and
+  `RealObsidianAdapter`.
+- `src/obsidian/mock-adapter.ts` — add `getDataviewApi()` returning
+  `null` by default + a setter `setDataviewApi(...)` for tests.
+- `src/tools/plugin-interop/index.ts` — implement DQL execution; rename
+  `plugin_templater_execute` → `plugin_templater_describe_template`;
+  add new `plugin_dataview_describe_js_query` tool.
+- `tests/tools/plugin-interop/plugin-interop.test.ts` — add tests for
+  the renamed and the new tool; assert error classes for absent
+  dataview; assert successful queryMarkdown round-trip.
+- `docs/help/en.md` — only an indirect mention; update any references.
+- `docs/tools.generated.md` — regenerated.
+
+### Tests to add
+
+- `plugin_dataview_query` with `getDataviewApi()` mocked to a successful
+  `queryMarkdown` returns the rendered markdown and structured content.
+- `plugin_dataview_query` when `getDataviewApi()` returns `null` →
+  `PluginNotInstalledError` (or appropriate envelope).
+- `plugin_dataview_describe_js_query` echoes the JS verbatim.
+- `plugin_templater_describe_template` echoes the template path
+  verbatim; old `plugin_templater_execute` no longer registers.
+
+---
+
+## #253 — Auth default flip + insecure-mode flag
+
+### Approach (locked decisions)
+
+- **Default flip:** `authEnabled: true`, `accessKey: ''`,
+  `iAcceptInsecureMode: false` in `DEFAULT_SETTINGS`. Schema bumps to
+  v10.
+- **First-run behaviour:** if `authEnabled === true && accessKey === ''`
+  on plugin load, auto-generate a 32-byte key
+  (`randomBytes(32).toString('base64url')`), persist it, and surface it
+  in the settings tab.
+- **Insecure mode:** if `authEnabled === false &&
+  iAcceptInsecureMode !== true`, the server refuses to start. A
+  `Notice` directs the user to settings.
+- **Grandfather migration:** in V9→V10:
+  - Add `iAcceptInsecureMode: false` to all migrated objects.
+  - If migrated object has `authEnabled === false && accessKey === ''`
+    (the default-insecure historical state), set
+    `iAcceptInsecureMode: true` so existing installs don't suddenly
+    refuse to bind. Also rename `extras.toolStates.get_date` → ...
+    (combined with #251's migration).
+  - Show a one-time notice on next plugin load: "Auth is disabled.
+    Click here to enable and generate a key." Track via a transient
+    `seenInsecureWarning` flag (set true after the notice is dismissed
+    or after first display).
+- **Settings UI:**
+  - Auth toggle becomes "Require Bearer authentication" — copy
+    unchanged but the description is updated to mention insecure mode.
+  - Add an "Accept insecure mode" toggle that is shown only when
+    `authEnabled === false`. When toggled on, an `iAcceptInsecureMode`
+    setting persists. When `authEnabled === true`, the toggle is
+    hidden.
+  - The access-key field still has Generate / Copy buttons (already
+    present); add a small note that the key was auto-generated on
+    first run.
+
+### Files touched
+
+- `src/types.ts` — bump `schemaVersion` to 10; add
+  `iAcceptInsecureMode: boolean` and `seenInsecureWarning: boolean` to
+  `McpPluginSettings`. Update `DEFAULT_SETTINGS`.
+- `src/settings/migrations.ts` — V9→V10 hop covering the grandfather
+  case + the `extras_get_date` rename.
+- `src/main.ts` —
+  - On `loadSettings`, if `authEnabled === true && accessKey === ''`,
+    generate a fresh key and persist.
+  - In `startServer()`, refuse to bind if `authEnabled === false &&
+    iAcceptInsecureMode !== true`. Emit a `Notice` and a log line.
+  - On first load after grandfather migration (detected via
+    `seenInsecureWarning === false`), show the one-time notice
+    pointing the user to settings; flip
+    `seenInsecureWarning = true` on the same load.
+- `src/settings/server-section.ts` — add the "Accept insecure mode"
+  toggle when auth is off; otherwise unchanged. The Generate / Copy
+  controls already exist.
+- `src/lang/locale/en.ts` — new strings:
+  `setting_insecure_mode_name`,
+  `setting_insecure_mode_desc`,
+  `notice_insecure_mode_refused`,
+  `notice_grandfather_warning`,
+  `notice_access_key_generated`.
+- `tests/settings/migrations.test.ts` — V9→V10 hop tests
+  (grandfather case, fresh-default case, explicit-auth-off-without-key
+  case, also check `extras_get_date` rename).
+- `tests/types.test.ts` — bump expected schemaVersion to 10; add
+  assertions for the two new fields.
+- `tests/main.test.ts` — update tests at lines 92 and 361 to reflect
+  the new "no-bind without iAcceptInsecureMode" rule. Add positive
+  test: `authEnabled === true && accessKey === ''` triggers
+  auto-generation + persistence on load.
+- `docs/help/en.md` — auth section: new default, the flag, grandfather
+  behaviour.
+
+### Tests to add
+
+- Auto-generation: `loadSettings` with `authEnabled: true,
+  accessKey: ''` produces a non-empty 32-byte base64url string and
+  calls `saveData`.
+- Refusal: `startServer()` with `authEnabled: false,
+  iAcceptInsecureMode: false` does not call `httpServer.start()` and
+  shows a Notice.
+- Migration grandfather: V9 input with `authEnabled === false &&
+  accessKey === ''` produces `iAcceptInsecureMode: true` after V9→V10.
+- Migration non-grandfather: V9 input with `authEnabled === true &&
+  accessKey === 'real-key'` produces `iAcceptInsecureMode: false`.
+
+---
+
+## Cross-cutting
+
+- Run `npm run docs:tools` once at the end after all renames have
+  landed to regenerate `docs/tools.generated.md`.
+- Don't edit `CHANGELOG.md` manually (release-please is in charge).
+
+## Ordering of commits
+
+1. `docs(plans/258-phase5): plan for breaking bundle` — this file.
+2. `fix(tools/extras)!: rename get_date to extras_get_date` — #251.
+3. `refactor(tools)!: rename search_*_field getters to vault_get_*` —
+   #255.
+4. `feat(tools/plugin-interop)!: execute DQL queries; rename
+   Templater/dataview-js to *_describe_*` — #250.
+5. `feat(settings)!: enable auth by default and require explicit
+   insecure-mode flag` — #253.
+6. `docs: regenerate tools.generated.md and update help for breaking
+   renames` — final commit. Cross-cutting docs.
+
+Each `!:` commit triggers a major bump on its own. release-please
+collapses them into a single major release.
+
+## Deviations
+
+- **#250:** New tool `plugin_dataview_describe_js_query` introduced
+  rather than overloading the existing `plugin_dataview_query` schema
+  with a `mode` field. Cleaner than mode-dispatch for a stub.
+- **#251 V9→V10:** Adds a forward-looking rename for the tool-state
+  key inside `extras.toolStates` (`get_date` → `extras_get_date`).
+  This is an extra carry-along not explicitly listed in the spec but
+  necessary so existing per-tool toggles keep working after the tool
+  rename.
+- **#253:** Two new persisted fields rather than one
+  (`iAcceptInsecureMode` plus `seenInsecureWarning`). The latter is a
+  one-shot "we showed the grandfather notice" flag. Used internally
+  only — not exposed in UI.

--- a/docs/tools.generated.md
+++ b/docs/tools.generated.md
@@ -6,13 +6,13 @@ This file is regenerated from the tool registry and committed so CI can detect d
 
 | Module ID | Module Name | Count | Tools |
 |---|---|---|---|
-| `vault` | Vault and File Operations | 16 | vault_create, vault_read, vault_update, vault_delete, vault_append, vault_get_metadata, vault_rename, vault_move, vault_copy, vault_create_folder, vault_delete_folder, vault_rename_folder, vault_list, vault_list_recursive, vault_read_binary, vault_write_binary |
+| `vault` | Vault and File Operations | 22 | vault_create, vault_read, vault_update, vault_delete, vault_append, vault_get_metadata, vault_rename, vault_move, vault_copy, vault_create_folder, vault_delete_folder, vault_rename_folder, vault_list, vault_list_recursive, vault_read_binary, vault_write_binary, vault_get_frontmatter, vault_get_headings, vault_get_outgoing_links, vault_get_embeds, vault_get_backlinks, vault_get_block_references |
 | `editor` | Editor Operations | 10 | editor_get_content, editor_get_active_file, editor_insert, editor_replace, editor_delete, editor_get_cursor, editor_set_cursor, editor_get_selection, editor_set_selection, editor_get_line_count |
-| `search` | Search and Metadata | 12 | search_fulltext, search_frontmatter, search_tags, search_headings, search_outgoing_links, search_embeds, search_backlinks, search_resolved_links, search_unresolved_links, search_block_references, search_by_tag, search_by_frontmatter |
+| `search` | Search and Metadata | 6 | search_fulltext, search_tags, search_resolved_links, search_unresolved_links, search_by_tag, search_by_frontmatter |
 | `workspace` | Workspace and Navigation | 5 | workspace_get_active_leaf, workspace_open_file, workspace_list_leaves, workspace_set_active_leaf, workspace_get_layout |
 | `ui` | UI Interactions | 1 | ui_notice |
 | `templates` | Templates and Content Generation | 3 | template_list, template_create_from, template_expand |
-| `plugin-interop` | Plugin Interop | 5 | plugin_list, plugin_check, plugin_dataview_query, plugin_templater_execute, plugin_execute_command |
-| `extras` | Extras | 1 | get_date |
+| `plugin-interop` | Plugin Interop | 6 | plugin_list, plugin_check, plugin_dataview_query, plugin_dataview_describe_js_query, plugin_templater_describe_template, plugin_execute_command |
+| `extras` | Extras | 1 | extras_get_date |
 
-**Total tools:** 53 across 8 modules.
+**Total tools:** 54 across 8 modules.

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -29,12 +29,22 @@ const en = {
   notice_server_url_copied: 'MCP server URL copied to clipboard',
   setting_auth_enabled_name: 'Require Bearer authentication',
   setting_auth_enabled_desc:
-    'When on, the server requires a valid Bearer access key on every MCP request. When off, requests are accepted without authentication — only safe on a trusted, localhost-only setup.',
+    'When on, the server requires a valid Bearer access key on every MCP request. When off, the server refuses to bind unless "Accept insecure mode" is also on — so unauthenticated traffic is never started by accident.',
   setting_access_key_name: 'Access Key',
-  setting_access_key_desc: 'Bearer token for authenticating MCP clients',
+  setting_access_key_desc:
+    'Bearer token for authenticating MCP clients. Auto-generated on first load (32 bytes, base64url) if this field is empty when auth is on.',
   placeholder_access_key: 'Enter access key',
   tooltip_copy_access_key: 'Copy access key',
   notice_access_key_copied: 'Access key copied to clipboard',
+  notice_access_key_generated:
+    'Generated a fresh 32-byte access key. Open MCP settings to copy it.',
+  setting_insecure_mode_name: 'Accept insecure mode',
+  setting_insecure_mode_desc:
+    'Acknowledge that you want the server to bind with authentication disabled. Required (in addition to turning auth off) for the server to start. Only safe on a trusted, localhost-only setup.',
+  notice_insecure_mode_refused:
+    'MCP server refused to start: authentication is disabled but "Accept insecure mode" is not on. Open MCP settings to enable auth or accept insecure mode.',
+  notice_grandfather_warning:
+    'MCP authentication is disabled. The plugin used to default to that, but new installs are secure-by-default. Open MCP settings to turn auth on (recommended) or to keep insecure mode explicitly.',
   tooltip_generate: 'Generate',
   setting_https_name: 'HTTPS',
   setting_https_desc:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Notice, Plugin, setIcon } from 'obsidian';
+import { randomBytes } from 'crypto';
 import { DEFAULT_SETTINGS, McpPluginSettings, TlsCertificateData } from './types';
 import { createLogger, Logger } from './utils/logger';
 import { ModuleRegistry } from './registry/module-registry';
@@ -29,6 +30,8 @@ export default class McpPlugin extends Plugin {
 
   async onload(): Promise<void> {
     await this.loadSettings();
+    await this.ensureAccessKey();
+    await this.maybeShowInsecureModeWarning();
 
     this.logger = createLogger('mcp-plugin', {
       debugMode: this.settings.debugMode,
@@ -106,23 +109,73 @@ export default class McpPlugin extends Plugin {
       },
     });
 
-    // Start server only when explicitly opted in. If auth is enabled, require
-    // a configured access key — otherwise every request would be rejected.
+    // Start server only when explicitly opted in. Gate on the same
+    // conditions startServer() itself checks so we never auto-start
+    // into a configuration the bind path will refuse anyway.
     const canAutoStart =
       this.settings.autoStart &&
-      (!this.settings.authEnabled || this.settings.accessKey.length > 0);
+      this.canBindServer();
     if (canAutoStart) {
       await this.startServer();
     } else {
       if (!this.settings.autoStart) {
         this.logger.info('MCP server not started: auto-start is disabled');
-      } else {
+      } else if (this.settings.authEnabled && this.settings.accessKey.length === 0) {
         this.logger.info(
           'MCP server not started: Bearer auth is on but no access key is configured',
+        );
+      } else if (!this.settings.authEnabled && !this.settings.iAcceptInsecureMode) {
+        this.logger.info(
+          'MCP server not started: auth is disabled and iAcceptInsecureMode is not set',
         );
       }
       this.updateStatusDisplay();
     }
+  }
+
+  /**
+   * On first load with the new secure-by-default posture, generate a
+   * fresh 32-byte access key if auth is enabled but the key is empty.
+   * Persist immediately so the user sees the value in settings without
+   * having to click Generate.
+   */
+  private async ensureAccessKey(): Promise<void> {
+    if (this.settings.authEnabled && this.settings.accessKey.length === 0) {
+      this.settings.accessKey = randomBytes(32).toString('base64url');
+      await this.saveSettings();
+    }
+  }
+
+  /**
+   * Show a one-time notice when the v9 → v10 migration grandfathered
+   * the user into insecure mode. Tracked via `seenInsecureWarning` so
+   * the notice fires exactly once.
+   */
+  private async maybeShowInsecureModeWarning(): Promise<void> {
+    if (
+      !this.settings.authEnabled &&
+      this.settings.iAcceptInsecureMode &&
+      !this.settings.seenInsecureWarning
+    ) {
+      new Notice(
+        t('notice_grandfather_warning'),
+        15000,
+      );
+      this.settings.seenInsecureWarning = true;
+      await this.saveSettings();
+    }
+  }
+
+  /**
+   * Predicate for both the auto-start path and the manual start path.
+   * Returns false if auth is off but the user has not explicitly
+   * opted into insecure mode, or if auth is on but no key is set yet.
+   */
+  private canBindServer(): boolean {
+    if (this.settings.authEnabled) {
+      return this.settings.accessKey.length > 0;
+    }
+    return this.settings.iAcceptInsecureMode === true;
   }
 
   onunload(): void {
@@ -130,6 +183,12 @@ export default class McpPlugin extends Plugin {
   }
 
   async startServer(): Promise<void> {
+    if (!this.settings.authEnabled && !this.settings.iAcceptInsecureMode) {
+      const message = t('notice_insecure_mode_refused');
+      this.logger.error(`Failed to start MCP server: ${message}`);
+      new Notice(message, 12000);
+      return;
+    }
     const attemptedPort = this.settings.port;
     let tls: TlsCertificateData | undefined;
     if (this.settings.httpsEnabled) {

--- a/src/obsidian/adapter.ts
+++ b/src/obsidian/adapter.ts
@@ -77,7 +77,30 @@ export interface ObsidianAdapter {
   getInstalledPlugins(): Array<{ id: string; name: string; enabled: boolean }>;
   isPluginEnabled(pluginId: string): boolean;
   executeCommand(commandId: string): boolean;
+  /**
+   * Return a thin, read-only wrapper over the Dataview plugin API so we
+   * can run DQL queries (`queryMarkdown`) without leaking
+   * `app.plugins.plugins.dataview` to the rest of the codebase.
+   * Returns `null` if Dataview is not installed/enabled or the API is
+   * not exposed at all (e.g. the plugin is mid-load).
+   */
+  getDataviewApi(): DataviewApi | null;
 }
+
+/**
+ * Minimal, read-only slice of Dataview's runtime API. Intentionally
+ * narrowed to just `queryMarkdown(query)` — the only surface we expose
+ * via `plugin_dataview_query`. Dataview's actual API has many more
+ * methods; we deliberately ignore them so we don't accidentally surface
+ * write-capable or JS-evaluating entry points.
+ */
+export interface DataviewApi {
+  queryMarkdown(query: string): Promise<DataviewQueryResult>;
+}
+
+export type DataviewQueryResult =
+  | { successful: true; value: string }
+  | { successful: false; error: string };
 
 export class RealObsidianAdapter implements ObsidianAdapter {
   constructor(private app: App) {}
@@ -422,6 +445,29 @@ export class RealObsidianAdapter implements ObsidianAdapter {
   executeCommand(commandId: string): boolean {
     const appAny = this.app as any;
     return !!appAny.commands?.executeCommandById(commandId);
+  }
+
+  getDataviewApi(): DataviewApi | null {
+    const appAny = this.app as any;
+    const plugin = appAny.plugins?.plugins?.dataview;
+    const api = plugin?.api;
+    if (!api || typeof api.queryMarkdown !== 'function') {
+      return null;
+    }
+    return {
+      queryMarkdown: async (query: string): Promise<DataviewQueryResult> => {
+        // Dataview's queryMarkdown returns a Result<string, string>-style
+        // object with { successful, value | error }. Pass it through.
+        const out = await api.queryMarkdown(query);
+        if (out?.successful === true) {
+          return { successful: true, value: String(out.value ?? '') };
+        }
+        return {
+          successful: false,
+          error: String(out?.error ?? 'Dataview query failed'),
+        };
+      },
+    };
   }
 
   private getFile(path: string): TFile {

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -1,4 +1,9 @@
-import { FileStat, ListResult, ObsidianAdapter } from './adapter';
+import {
+  DataviewApi,
+  FileStat,
+  ListResult,
+  ObsidianAdapter,
+} from './adapter';
 import { FolderNotFoundError } from '../tools/shared/errors';
 
 interface MockFileMetadata {
@@ -441,6 +446,16 @@ export class MockObsidianAdapter implements ObsidianAdapter {
   executeCommand(commandId: string): boolean {
     this.executedCommands.push(commandId);
     return true;
+  }
+
+  private dataviewApi: DataviewApi | null = null;
+
+  getDataviewApi(): DataviewApi | null {
+    return this.dataviewApi;
+  }
+
+  setDataviewApi(api: DataviewApi | null): void {
+    this.dataviewApi = api;
   }
 
   // Test helpers

--- a/src/settings/migrations.ts
+++ b/src/settings/migrations.ts
@@ -96,6 +96,41 @@ export function migrateV8ToV9(data: Settings): void {
   if (data.requireOrigin === undefined) data.requireOrigin = false;
 }
 
+export function migrateV9ToV10(data: Settings): void {
+  // Auth flips secure-by-default. Two carry-along concerns:
+  //   1. Existing installs that were running default-insecure
+  //      (authEnabled === false && accessKey === '') must keep
+  //      working after upgrade. Grandfather them by setting
+  //      iAcceptInsecureMode: true. The plugin will surface a
+  //      one-time notice on next load (tracked via
+  //      seenInsecureWarning) so they know about the new posture.
+  //   2. The `extras_get_date` tool was renamed from `get_date`. The
+  //      per-tool toolStates key needs the same rename so the user's
+  //      enabled/disabled choice carries over.
+  if (data.iAcceptInsecureMode === undefined) {
+    const wasDefaultInsecure =
+      data.authEnabled === false && data.accessKey === '';
+    data.iAcceptInsecureMode = wasDefaultInsecure;
+  }
+  if (data.seenInsecureWarning === undefined) {
+    data.seenInsecureWarning = false;
+  }
+
+  const moduleStates = (data.moduleStates ?? {}) as Record<
+    string,
+    { enabled?: boolean; toolStates?: Record<string, boolean> }
+  >;
+  const extras = moduleStates.extras;
+  if (extras && extras.toolStates && 'get_date' in extras.toolStates) {
+    const value = extras.toolStates.get_date;
+    delete extras.toolStates.get_date;
+    if (!('extras_get_date' in extras.toolStates)) {
+      extras.toolStates.extras_get_date = value;
+    }
+  }
+  data.moduleStates = moduleStates;
+}
+
 const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 1, run: migrateV0ToV1 },
   { target: 2, run: migrateV1ToV2 },
@@ -106,9 +141,10 @@ const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 7, run: migrateV6ToV7 },
   { target: 8, run: migrateV7ToV8 },
   { target: 9, run: migrateV8ToV9 },
+  { target: 10, run: migrateV9ToV10 },
 ];
 
-export const CURRENT_SCHEMA_VERSION = 9;
+export const CURRENT_SCHEMA_VERSION = 10;
 
 export function migrateSettings(data: Settings): Settings {
   const currentVersion =

--- a/src/settings/server-section.ts
+++ b/src/settings/server-section.ts
@@ -195,10 +195,30 @@ export function renderServerSettingsSection(
     .addToggle((toggle) =>
       toggle.setValue(plugin.settings.authEnabled).onChange(async (value) => {
         plugin.settings.authEnabled = value;
+        // Turning auth on clears the explicit insecure-mode flag so the
+        // user has to opt into it again if they later turn auth back off.
+        if (value && plugin.settings.iAcceptInsecureMode) {
+          plugin.settings.iAcceptInsecureMode = false;
+        }
         await plugin.saveSettings();
         refresh();
       }),
     );
+
+  if (!plugin.settings.authEnabled) {
+    new Setting(containerEl)
+      .setName(t('setting_insecure_mode_name'))
+      .setDesc(t('setting_insecure_mode_desc'))
+      .addToggle((toggle) =>
+        toggle
+          .setValue(plugin.settings.iAcceptInsecureMode)
+          .onChange(async (value) => {
+            plugin.settings.iAcceptInsecureMode = value;
+            await plugin.saveSettings();
+            refresh();
+          }),
+      );
+  }
 
   if (plugin.settings.authEnabled) {
     new Setting(containerEl)

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -70,7 +70,7 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
     tools(): ToolDefinition[] {
       return [
         defineTool({
-          name: 'get_date',
+          name: 'extras_get_date',
           description: describeTool({
             summary: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
             returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -8,7 +8,11 @@ import {
   type InferredParams,
 } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
-import { handleToolError } from '../shared/errors';
+import {
+  PluginApiUnavailableError,
+  PluginNotInstalledError,
+  handleToolError,
+} from '../shared/errors';
 import { describeTool } from '../shared/describe';
 import {
   makeResponse,
@@ -36,7 +40,16 @@ const dataviewSchema = {
     .string()
     .min(1)
     .max(10_000)
-    .describe('Dataview query (DQL or Dataview-js)'),
+    .describe('Dataview DQL query text. JavaScript queries are not executed by this tool — see plugin_dataview_describe_js_query.'),
+  ...responseFormatField,
+};
+
+const dataviewJsSchema = {
+  query: z
+    .string()
+    .min(1)
+    .max(10_000)
+    .describe('Dataview-JS source. Returned verbatim — execution is the host client\'s responsibility.'),
   ...responseFormatField,
 };
 
@@ -46,6 +59,7 @@ const templaterSchema = {
     .min(1)
     .max(4096)
     .describe('Vault-relative path to the Templater template'),
+  ...responseFormatField,
 };
 
 const executeCommandSchema = {
@@ -60,7 +74,12 @@ interface PluginInteropHandlers {
   listPlugins: (params: InferredParams<typeof listSchema>) => Promise<CallToolResult>;
   checkPlugin: (params: InferredParams<typeof checkSchema>) => Promise<CallToolResult>;
   dataviewQuery: (params: InferredParams<typeof dataviewSchema>) => Promise<CallToolResult>;
-  templaterExecute: (params: InferredParams<typeof templaterSchema>) => Promise<CallToolResult>;
+  dataviewDescribeJsQuery: (
+    params: InferredParams<typeof dataviewJsSchema>,
+  ) => Promise<CallToolResult>;
+  templaterDescribeTemplate: (
+    params: InferredParams<typeof templaterSchema>,
+  ) => Promise<CallToolResult>;
   executeCommand: (params: InferredParams<typeof executeCommandSchema>) => Promise<CallToolResult>;
 }
 
@@ -100,30 +119,62 @@ function createHandlers(
         ),
       );
     },
-    dataviewQuery: (params): Promise<CallToolResult> => {
-      if (!adapter.isPluginEnabled('dataview')) {
-        return Promise.resolve(err('Dataview plugin is not installed or enabled'));
+    dataviewQuery: async (params): Promise<CallToolResult> => {
+      try {
+        if (!adapter.isPluginEnabled('dataview')) {
+          throw new PluginNotInstalledError('dataview');
+        }
+        const api = adapter.getDataviewApi();
+        if (!api) {
+          throw new PluginApiUnavailableError(
+            'dataview',
+            'queryMarkdown is not exposed',
+          );
+        }
+        const result = await api.queryMarkdown(params.query);
+        if (!result.successful) {
+          return err(`Dataview query failed: ${result.error}`);
+        }
+        return makeResponse(
+          { query: params.query, markdown: result.value },
+          (v) => v.markdown,
+          readResponseFormat(params),
+        );
+      } catch (error) {
+        return handleToolError(error);
       }
+    },
+    dataviewDescribeJsQuery: (params): Promise<CallToolResult> => {
+      // Stub-only: return the JS source verbatim plus a note. We do NOT
+      // evaluate Dataview-JS — that would arbitrary-eval user input
+      // against the Obsidian app handle.
       const payload = {
-        note: 'Dataview query execution requires the Dataview plugin API at runtime',
         query: params.query,
+        note: 'Dataview JS execution is intentionally not performed by this server. Run the source against the Dataview API on the host that owns the vault.',
       };
       return Promise.resolve(
         makeResponse(
           payload,
-          (v) => `_${v.note}_\n\n\`\`\`dataview\n${v.query}\n\`\`\``,
+          (v) => `_${v.note}_\n\n\`\`\`dataviewjs\n${v.query}\n\`\`\``,
           readResponseFormat(params),
         ),
       );
     },
-    templaterExecute: (params): Promise<CallToolResult> => {
-      if (!adapter.isPluginEnabled('templater-obsidian')) {
-        return Promise.resolve(err('Templater plugin is not installed or enabled'));
-      }
-      return Promise.resolve(text(JSON.stringify({
-        note: 'Templater execution requires the Templater plugin API at runtime',
+    templaterDescribeTemplate: (params): Promise<CallToolResult> => {
+      // Stub-only: echo the template path. We do NOT call Templater's
+      // execution surface — Templater can run arbitrary user JS, so
+      // execution must stay client-side.
+      const payload = {
         templatePath: params.templatePath,
-      })));
+        note: 'Templater execution is intentionally not performed by this server. The host client must run the template via the Templater API.',
+      };
+      return Promise.resolve(
+        makeResponse(
+          payload,
+          (v) => `_${v.note}_\n\nTemplate path: \`${v.templatePath}\``,
+          readResponseFormat(params),
+        ),
+      );
     },
     executeCommand: (params): Promise<CallToolResult> => {
       const allowlist = getExecuteCommandAllowlist();
@@ -187,26 +238,40 @@ export function createPluginInteropModule(
         defineTool({
           name: 'plugin_dataview_query',
           description: describeTool({
-            summary: 'Execute a Dataview (DQL / dataview-js) query.',
-            args: ['query (string, 1..10000): Dataview query text.'],
-            returns: 'JSON envelope with the query echoed; full execution requires the Dataview plugin at runtime.',
-            errors: ['"Dataview plugin is not installed or enabled" if the plugin is missing.'],
+            summary: 'Execute a Dataview DQL query and return the rendered markdown.',
+            args: ['query (string, 1..10000): Dataview DQL query text. Use plugin_dataview_describe_js_query for Dataview-JS sources.'],
+            returns: 'Plain text: the markdown that Dataview rendered. JSON form returns { query, markdown }.',
+            errors: [
+              '"Plugin not installed or disabled: dataview" if Dataview is missing.',
+              '"Plugin API unavailable for dataview" if Dataview is loaded but its API is not yet exposed.',
+              '"Dataview query failed: <reason>" if the query parses but does not execute cleanly.',
+            ],
           }, dataviewSchema),
           schema: dataviewSchema,
           handler: h.dataviewQuery,
           annotations: annotations.readExternal,
         }),
         defineTool({
-          name: 'plugin_templater_execute',
+          name: 'plugin_dataview_describe_js_query',
           description: describeTool({
-            summary: 'Execute a Templater template file.',
+            summary: 'Echo a Dataview-JS source for client-side execution. Returns the source and a note that the host must run it.',
+            args: ['query (string, 1..10000): Dataview-JS source.'],
+            returns: 'JSON: { query, note }. The server never evaluates Dataview-JS.',
+          }, dataviewJsSchema),
+          schema: dataviewJsSchema,
+          handler: h.dataviewDescribeJsQuery,
+          annotations: annotations.readExternal,
+        }),
+        defineTool({
+          name: 'plugin_templater_describe_template',
+          description: describeTool({
+            summary: 'Echo a Templater template path for client-side execution. Returns the path and a note that the host must run it via Templater.',
             args: ['templatePath (string): Vault-relative path to the Templater template.'],
-            returns: 'JSON envelope noting the template path; full execution requires the Templater plugin.',
-            errors: ['"Templater plugin is not installed or enabled" if the plugin is missing.'],
-          }),
+            returns: 'JSON: { templatePath, note }. The server never executes Templater itself.',
+          }, templaterSchema),
           schema: templaterSchema,
-          handler: h.templaterExecute,
-          annotations: annotations.destructiveExternal,
+          handler: h.templaterDescribeTemplate,
+          annotations: annotations.readExternal,
         }),
         defineTool({
           name: 'plugin_execute_command',

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -4,7 +4,6 @@ import { createSearchHandlers } from './handlers';
 import { describeTool } from '../shared/describe';
 import {
   searchFulltextSchema,
-  filePathSchema,
   searchByTagSchema,
   searchByFrontmatterSchema,
   readOnlySchema,
@@ -17,7 +16,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
     metadata: {
       id: 'search',
       name: 'Search and Metadata',
-      description: 'Search vault contents and query file metadata, tags, links, and frontmatter',
+      description: 'Vault-wide search across contents, tags, frontmatter, and link maps',
     },
 
     tools(): ToolDefinition[] {
@@ -36,18 +35,6 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           annotations: annotations.read,
         }),
         defineTool({
-          name: 'search_frontmatter',
-          description: describeTool({
-            summary: 'Get the parsed YAML frontmatter block for a file.',
-            args: ['path (string): Vault-relative path.'],
-            returns: 'JSON: the frontmatter object, or {} when absent.',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchFrontmatter,
-          annotations: annotations.read,
-        }),
-        defineTool({
           name: 'search_tags',
           description: describeTool({
             summary: 'List every tag used anywhere in the vault with the files that use it.',
@@ -55,54 +42,6 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           }, readOnlySchema),
           schema: readOnlySchema,
           handler: handlers.searchTags,
-          annotations: annotations.read,
-        }),
-        defineTool({
-          name: 'search_headings',
-          description: describeTool({
-            summary: 'List headings (with levels) for a file.',
-            args: ['path (string): Vault-relative path.'],
-            returns: 'JSON: [{ heading, level }].',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchHeadings,
-          annotations: annotations.read,
-        }),
-        defineTool({
-          name: 'search_outgoing_links',
-          description: describeTool({
-            summary: 'List outgoing links from a file.',
-            args: ['path (string): Vault-relative path.'],
-            returns: 'JSON: [{ link, displayText? }].',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchOutgoingLinks,
-          annotations: annotations.read,
-        }),
-        defineTool({
-          name: 'search_embeds',
-          description: describeTool({
-            summary: 'List embedded resources (![[...]]) referenced by a file.',
-            args: ['path (string): Vault-relative path.'],
-            returns: 'JSON: [{ link, displayText? }].',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchEmbeds,
-          annotations: annotations.read,
-        }),
-        defineTool({
-          name: 'search_backlinks',
-          description: describeTool({
-            summary: 'List files that link TO a given file (reverse links).',
-            args: ['path (string): Target file path.'],
-            returns: 'JSON: string[] of paths that reference the target.',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchBacklinks,
           annotations: annotations.read,
         }),
         defineTool({
@@ -124,18 +63,6 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           }, readOnlySchema),
           schema: readOnlySchema,
           handler: handlers.searchUnresolvedLinks,
-          annotations: annotations.read,
-        }),
-        defineTool({
-          name: 'search_block_references',
-          description: describeTool({
-            summary: 'List block references (^block-id) defined in a file.',
-            args: ['path (string): Vault-relative path.'],
-            returns: 'JSON: [{ id, line }].',
-            errors: ['"File not found" if the path does not exist.'],
-          }, filePathSchema),
-          schema: filePathSchema,
-          handler: handlers.searchBlockReferences,
           annotations: annotations.read,
         }),
         defineTool({

--- a/src/tools/shared/errors.ts
+++ b/src/tools/shared/errors.ts
@@ -54,6 +54,33 @@ export class TimeoutError extends Error {
 }
 
 /**
+ * The user-requested third-party plugin (e.g. Dataview, Templater) is
+ * not installed or is currently disabled in Obsidian.
+ */
+export class PluginNotInstalledError extends Error {
+  constructor(pluginId: string) {
+    super(`Plugin not installed or disabled: ${pluginId}`);
+    this.name = 'PluginNotInstalledError';
+  }
+}
+
+/**
+ * The third-party plugin is enabled but does not currently expose the
+ * API surface we need (typically because it is mid-load or its API
+ * changed in a newer version).
+ */
+export class PluginApiUnavailableError extends Error {
+  constructor(pluginId: string, reason?: string) {
+    super(
+      reason
+        ? `Plugin API unavailable for ${pluginId}: ${reason}`
+        : `Plugin API unavailable for ${pluginId}`,
+    );
+    this.name = 'PluginApiUnavailableError';
+  }
+}
+
+/**
  * Map any caught value to a well-formed CallToolResult with `isError: true`.
  * Callers can use this as a single `catch` target so they don't need to
  * maintain their own per-module `errorResult()` helper.
@@ -82,6 +109,12 @@ export function handleToolError(error: unknown): CallToolResult {
   }
   if (error instanceof TimeoutError) {
     return errorFrom(`Operation timed out: ${error.message}`);
+  }
+  if (error instanceof PluginNotInstalledError) {
+    return errorFrom(error.message);
+  }
+  if (error instanceof PluginApiUnavailableError) {
+    return errorFrom(error.message);
   }
   const message = error instanceof Error ? error.message : String(error);
   return errorFrom(message);

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import { ToolModule, ToolDefinition, annotations, defineTool } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createHandlers, WriteMutex } from './handlers';
+import { createSearchHandlers } from '../search/handlers';
+import { filePathSchema as searchFilePathSchema } from '../search/schemas';
 import { describeTool } from '../shared/describe';
 import {
   createFileSchema,
@@ -82,6 +84,7 @@ const listRecursiveOutputSchema = {
 export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
   const mutex = new WriteMutex();
   const handlers = createHandlers(adapter, mutex);
+  const searchHandlers = createSearchHandlers(adapter);
 
   return {
     metadata: {
@@ -354,6 +357,78 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
           schema: writeBinarySchema,
           handler: handlers.writeBinary,
           annotations: annotations.destructiveIdempotent,
+        }),
+        defineTool({
+          name: 'vault_get_frontmatter',
+          description: describeTool({
+            summary: 'Get the parsed YAML frontmatter block for a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: the frontmatter object, or {} when absent.',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchFrontmatter,
+          annotations: annotations.read,
+        }),
+        defineTool({
+          name: 'vault_get_headings',
+          description: describeTool({
+            summary: 'List headings (with levels) for a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ heading, level }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchHeadings,
+          annotations: annotations.read,
+        }),
+        defineTool({
+          name: 'vault_get_outgoing_links',
+          description: describeTool({
+            summary: 'List outgoing links from a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ link, displayText? }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchOutgoingLinks,
+          annotations: annotations.read,
+        }),
+        defineTool({
+          name: 'vault_get_embeds',
+          description: describeTool({
+            summary: 'List embedded resources (![[...]]) referenced by a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ link, displayText? }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchEmbeds,
+          annotations: annotations.read,
+        }),
+        defineTool({
+          name: 'vault_get_backlinks',
+          description: describeTool({
+            summary: 'List files that link TO a given file (reverse links).',
+            args: ['path (string): Target file path.'],
+            returns: 'JSON: string[] of paths that reference the target.',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchBacklinks,
+          annotations: annotations.read,
+        }),
+        defineTool({
+          name: 'vault_get_block_references',
+          description: describeTool({
+            summary: 'List block references (^block-id) defined in a file.',
+            args: ['path (string): Vault-relative path.'],
+            returns: 'JSON: [{ id, line }].',
+            errors: ['"File not found" if the path does not exist.'],
+          }, searchFilePathSchema),
+          schema: searchFilePathSchema,
+          handler: searchHandlers.searchBlockReferences,
+          annotations: annotations.read,
         }),
       ];
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,21 @@ export interface McpPluginSettings {
    * `curl`/native clients working.
    */
   requireOrigin: boolean;
+  /**
+   * Explicit acknowledgement that running the server with
+   * `authEnabled === false` is acceptable. Defaults to `false`.
+   * When `authEnabled === false && iAcceptInsecureMode !== true`, the
+   * server refuses to bind. Existing installs that were running
+   * default-insecure pre-v10 are grandfathered to `true` by the
+   * v9 → v10 migration so they keep working after upgrade.
+   */
+  iAcceptInsecureMode: boolean;
+  /**
+   * Internal one-shot flag: did we already show the user the
+   * "auth is disabled" grandfather notice on plugin load? Persisted so
+   * the warning fires exactly once, never again.
+   */
+  seenInsecureWarning: boolean;
   /** Per-module enabled/disabled state, keyed by module ID */
   moduleStates: Record<string, ModuleState>;
 }
@@ -78,10 +93,10 @@ export const DEFAULT_ALLOWED_HOSTS: readonly string[] = [
 ] as const;
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 9,
+  schemaVersion: 10,
   serverAddress: '127.0.0.1',
   port: 28741,
-  authEnabled: false,
+  authEnabled: true,
   accessKey: '',
   httpsEnabled: false,
   tlsCertificate: null,
@@ -95,5 +110,7 @@ export const DEFAULT_SETTINGS: McpPluginSettings = {
   allowedHosts: [...DEFAULT_ALLOWED_HOSTS],
   allowNullOrigin: false,
   requireOrigin: false,
+  iAcceptInsecureMode: false,
+  seenInsecureWarning: false,
   moduleStates: {},
 };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -51,15 +51,19 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(startSpy).not.toHaveBeenCalled();
   });
 
-  it('starts the server when autoStart is true and an access key is set', async () => {
+  it('starts the server when autoStart is true, authEnabled is true, and an access key is set', async () => {
     const plugin = createPlugin({
-      schemaVersion: 3,
+      schemaVersion: 10,
       serverAddress: '127.0.0.1',
       port: 28741,
       accessKey: 'configured-key',
       httpsEnabled: false,
+      tlsCertificate: null,
       debugMode: false,
       autoStart: true,
+      authEnabled: true,
+      iAcceptInsecureMode: false,
+      seenInsecureWarning: true,
       moduleStates: {},
     });
     const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
@@ -69,9 +73,9 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(startSpy).toHaveBeenCalled();
   });
 
-  it('does not start the server when autoStart is true, auth is required, but no access key is set', async () => {
+  it('auto-starts the server when autoStart is true and authEnabled is on with an empty key (a key is auto-generated on first load)', async () => {
     const plugin = createPlugin({
-      schemaVersion: 6,
+      schemaVersion: 10,
       serverAddress: '127.0.0.1',
       port: 28741,
       accessKey: '',
@@ -80,6 +84,55 @@ describe('McpPlugin.onload autoStart behaviour', () => {
       debugMode: false,
       autoStart: true,
       authEnabled: true,
+      iAcceptInsecureMode: false,
+      seenInsecureWarning: true,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    // After ensureAccessKey() auto-generates a 32-byte key, the
+    // canBindServer() guard is satisfied and the server auto-starts.
+    expect(plugin.settings.accessKey).not.toBe('');
+    expect(startSpy).toHaveBeenCalled();
+  });
+
+  it('starts the server when autoStart is true, auth is off, and the user explicitly accepted insecure mode', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 10,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: true,
+      authEnabled: false,
+      iAcceptInsecureMode: true,
+      seenInsecureWarning: true,
+      moduleStates: {},
+    });
+    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+
+    await plugin.onload();
+
+    expect(startSpy).toHaveBeenCalled();
+  });
+
+  it('refuses to auto-start when authEnabled is off and iAcceptInsecureMode is not set', async () => {
+    const plugin = createPlugin({
+      schemaVersion: 10,
+      serverAddress: '127.0.0.1',
+      port: 28741,
+      accessKey: '',
+      httpsEnabled: false,
+      tlsCertificate: null,
+      debugMode: false,
+      autoStart: true,
+      authEnabled: false,
+      iAcceptInsecureMode: false,
+      seenInsecureWarning: true,
       moduleStates: {},
     });
     const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
@@ -89,24 +142,29 @@ describe('McpPlugin.onload autoStart behaviour', () => {
     expect(startSpy).not.toHaveBeenCalled();
   });
 
-  it('starts the server when autoStart is true and Bearer auth is disabled, even without an access key', async () => {
+  it('auto-generates a 32-byte access key on first load when authEnabled is true and the key is empty', async () => {
     const plugin = createPlugin({
-      schemaVersion: 6,
+      schemaVersion: 10,
       serverAddress: '127.0.0.1',
       port: 28741,
       accessKey: '',
       httpsEnabled: false,
       tlsCertificate: null,
       debugMode: false,
-      autoStart: true,
-      authEnabled: false,
+      autoStart: false,
+      authEnabled: true,
+      iAcceptInsecureMode: false,
+      seenInsecureWarning: true,
       moduleStates: {},
     });
-    const startSpy = vi.spyOn(plugin, 'startServer').mockResolvedValue();
+    vi.spyOn(plugin, 'startServer').mockResolvedValue();
 
     await plugin.onload();
 
-    expect(startSpy).toHaveBeenCalled();
+    expect(plugin.settings.accessKey).not.toBe('');
+    // base64url of 32 bytes is 43 chars (no padding).
+    expect(plugin.settings.accessKey).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(plugin.saveData).toHaveBeenCalled();
   });
 
   it('swaps the ribbon icon glyph when the server transitions between stopped and running', async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,7 +7,7 @@ describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to current schema', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -25,7 +25,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -43,7 +43,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
@@ -59,7 +59,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.autoStart).toBe(false);
   });
 
@@ -78,7 +78,7 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
@@ -97,7 +97,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.tlsCertificate).toBeNull();
   });
 
@@ -114,7 +114,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.authEnabled).toBe(false);
   });
 
@@ -124,7 +124,7 @@ describe('migrateSettings', () => {
       accessKey: 'pre-existing-key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.authEnabled).toBe(false);
     expect(result.accessKey).toBe('pre-existing-key');
   });
@@ -135,7 +135,7 @@ describe('migrateSettings', () => {
       authEnabled: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.authEnabled).toBe(true);
   });
 
@@ -173,7 +173,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.useCustomTls).toBe(false);
     expect(result.customTlsCertPath).toBeNull();
     expect(result.customTlsKeyPath).toBeNull();
@@ -189,7 +189,7 @@ describe('migrateSettings', () => {
       customTlsKeyPath: '/etc/ssl/my.key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.useCustomTls).toBe(true);
     expect(result.customTlsCertPath).toBe('/etc/ssl/my.crt');
     expect(result.customTlsKeyPath).toBe('/etc/ssl/my.key');
@@ -201,7 +201,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.tlsCertificate).toEqual({
       cert: 'EXISTING_CERT',
       key: 'EXISTING_KEY',
@@ -213,7 +213,7 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
@@ -222,7 +222,7 @@ describe('migrateSettings', () => {
     expect(result.authEnabled).toBe(false);
   });
 
-  it('should migrate v3 extras state to per-tool states (enabled -> get_date on)', () => {
+  it('should migrate v3 extras state to per-tool states (enabled -> extras_get_date on)', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 3,
       serverAddress: '127.0.0.1',
@@ -234,12 +234,12 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
     >;
-    expect(states.extras.toolStates).toEqual({ get_date: true });
+    expect(states.extras.toolStates).toEqual({ extras_get_date: true });
   });
 
   it('should migrate v3 extras state to per-tool states (disabled -> empty)', () => {
@@ -255,7 +255,7 @@ describe('migrateSettings', () => {
     expect(states.extras.toolStates).toEqual({});
   });
 
-  it('should leave existing v4 toolStates untouched', () => {
+  it('renames get_date toolState to extras_get_date as part of the v9 → v10 hop and preserves siblings', () => {
     const data: Record<string, unknown> = {
       schemaVersion: 4,
       moduleStates: {
@@ -272,7 +272,7 @@ describe('migrateSettings', () => {
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }
     >;
     expect(states.extras.toolStates).toEqual({
-      get_date: true,
+      extras_get_date: true,
       something_else: false,
     });
   });
@@ -283,18 +283,26 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.autoStart).toBe(false);
   });
 
-  it('should default authEnabled to false', () => {
-    expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
+  it('should default authEnabled to true (secure-by-default)', () => {
+    expect(DEFAULT_SETTINGS.authEnabled).toBe(true);
   });
 
-  it('declares schemaVersion 9', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(9);
+  it('declares schemaVersion 10', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(10);
   });
 
   it('defaults custom TLS fields to off/null', () => {
     expect(DEFAULT_SETTINGS.useCustomTls).toBe(false);
     expect(DEFAULT_SETTINGS.customTlsCertPath).toBeNull();
     expect(DEFAULT_SETTINGS.customTlsKeyPath).toBeNull();
+  });
+
+  it('defaults iAcceptInsecureMode to false (refuse to bind without auth or explicit opt-in)', () => {
+    expect(DEFAULT_SETTINGS.iAcceptInsecureMode).toBe(false);
+  });
+
+  it('defaults seenInsecureWarning to false', () => {
+    expect(DEFAULT_SETTINGS.seenInsecureWarning).toBe(false);
   });
 });
 

--- a/tests/settings/migrations.test.ts
+++ b/tests/settings/migrations.test.ts
@@ -9,6 +9,7 @@ import {
   migrateV6ToV7,
   migrateV7ToV8,
   migrateV8ToV9,
+  migrateV9ToV10,
   migrateSettings,
   CURRENT_SCHEMA_VERSION,
 } from '../../src/settings/migrations';
@@ -147,6 +148,91 @@ describe('settings migrations — per-version hops', () => {
     expect(data.allowedHosts).toEqual(['my.example']);
     expect(data.allowNullOrigin).toBe(true);
     expect(data.requireOrigin).toBe(true);
+  });
+
+  it('V9 -> V10 grandfathers default-insecure installs to iAcceptInsecureMode: true', () => {
+    // Pre-v10 default was authEnabled: false + accessKey: ''. Those
+    // installs would refuse to bind on the new posture; preserve their
+    // behaviour by setting iAcceptInsecureMode: true so the server
+    // keeps starting after upgrade. The plugin will surface a one-time
+    // notice on next load (gated by seenInsecureWarning).
+    const data: Record<string, unknown> = {
+      authEnabled: false,
+      accessKey: '',
+    };
+    migrateV9ToV10(data);
+    expect(data.iAcceptInsecureMode).toBe(true);
+    expect(data.seenInsecureWarning).toBe(false);
+  });
+
+  it('V9 -> V10 leaves iAcceptInsecureMode: false when the user explicitly set authEnabled: true', () => {
+    const data: Record<string, unknown> = {
+      authEnabled: true,
+      accessKey: 'real-key',
+    };
+    migrateV9ToV10(data);
+    expect(data.iAcceptInsecureMode).toBe(false);
+    expect(data.seenInsecureWarning).toBe(false);
+  });
+
+  it('V9 -> V10 leaves iAcceptInsecureMode: false when auth was off but the user had set an access key', () => {
+    // The "auth off + key present" shape implies the user toggled auth
+    // off deliberately at some point — not the historical default.
+    // Keep them on the strict posture so they hit the insecure-mode
+    // notice and choose explicitly.
+    const data: Record<string, unknown> = {
+      authEnabled: false,
+      accessKey: 'a-key',
+    };
+    migrateV9ToV10(data);
+    expect(data.iAcceptInsecureMode).toBe(false);
+  });
+
+  it('V9 -> V10 renames extras.toolStates.get_date to extras_get_date', () => {
+    const data: Record<string, unknown> = {
+      moduleStates: {
+        extras: {
+          enabled: true,
+          toolStates: { get_date: true, other: false },
+        },
+      },
+    };
+    migrateV9ToV10(data);
+    const states = data.moduleStates as Record<
+      string,
+      { toolStates?: Record<string, boolean> }
+    >;
+    expect(states.extras.toolStates).toEqual({
+      extras_get_date: true,
+      other: false,
+    });
+  });
+
+  it('V9 -> V10 leaves extras.toolStates alone when it does not contain get_date', () => {
+    const data: Record<string, unknown> = {
+      moduleStates: {
+        extras: {
+          enabled: true,
+          toolStates: { extras_get_date: true },
+        },
+      },
+    };
+    migrateV9ToV10(data);
+    const states = data.moduleStates as Record<
+      string,
+      { toolStates?: Record<string, boolean> }
+    >;
+    expect(states.extras.toolStates).toEqual({ extras_get_date: true });
+  });
+
+  it('V9 -> V10 preserves an existing iAcceptInsecureMode setting', () => {
+    const data: Record<string, unknown> = {
+      authEnabled: false,
+      accessKey: '',
+      iAcceptInsecureMode: false,
+    };
+    migrateV9ToV10(data);
+    expect(data.iAcceptInsecureMode).toBe(false);
   });
 });
 

--- a/tests/tools/extras/extras.test.ts
+++ b/tests/tools/extras/extras.test.ts
@@ -24,18 +24,18 @@ describe('Extras module', () => {
     expect(module.tools()).toHaveLength(1);
   });
 
-  it('registers get_date as a read-only tool', () => {
+  it('registers extras_get_date as a read-only tool', () => {
     const adapter = new MockObsidianAdapter();
     const module = createExtrasModule(adapter);
     const tool = module.tools()[0];
-    expect(tool.name).toBe('get_date');
+    expect(tool.name).toBe('extras_get_date');
     expect(tool.annotations.readOnlyHint).toBe(true);
   });
 
-  it('get_date returns a plain ISO-8601 string with timezone offset', async () => {
+  it('extras_get_date returns a plain ISO-8601 string with timezone offset', async () => {
     const adapter = new MockObsidianAdapter();
     const module = createExtrasModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'get_date')!;
+    const tool = module.tools().find((t) => t.name === 'extras_get_date')!;
     const result = await tool.handler({});
     expect(result.isError).toBeUndefined();
 
@@ -44,10 +44,10 @@ describe('Extras module', () => {
     expect(content.text).toMatch(ISO_WITH_OFFSET);
   });
 
-  it('get_date encodes the current local UTC offset in the ISO string', async () => {
+  it('extras_get_date encodes the current local UTC offset in the ISO string', async () => {
     const adapter = new MockObsidianAdapter();
     const module = createExtrasModule(adapter);
-    const tool = module.tools().find((t) => t.name === 'get_date')!;
+    const tool = module.tools().find((t) => t.name === 'extras_get_date')!;
     const before = new Date().getTimezoneOffset();
     const result = await tool.handler({});
     const after = new Date().getTimezoneOffset();

--- a/tests/tools/plugin-interop/plugin-interop.test.ts
+++ b/tests/tools/plugin-interop/plugin-interop.test.ts
@@ -14,9 +14,22 @@ describe('plugin interop module', () => {
     adapter = new MockObsidianAdapter();
   });
 
-  it('should register 5 tools', () => {
+  it('should register 6 tools', () => {
     const module = createPluginInteropModule(adapter);
-    expect(module.tools()).toHaveLength(5);
+    expect(module.tools()).toHaveLength(6);
+  });
+
+  it('registers the renamed dataview-js and templater describe tools', () => {
+    const module = createPluginInteropModule(adapter);
+    const names = module.tools().map((t) => t.name).sort();
+    expect(names).toEqual([
+      'plugin_check',
+      'plugin_dataview_describe_js_query',
+      'plugin_dataview_query',
+      'plugin_execute_command',
+      'plugin_list',
+      'plugin_templater_describe_template',
+    ]);
   });
 
   it('should list installed plugins (json)', async () => {
@@ -39,11 +52,95 @@ describe('plugin interop module', () => {
     expect(data.enabled).toBe(true);
   });
 
-  it('should return error for Dataview query when not installed', async () => {
+  it('should return error for Dataview query when the plugin is not installed', async () => {
     const module = createPluginInteropModule(adapter);
     const tool = module.tools().find((t) => t.name === 'plugin_dataview_query')!;
     const result = await tool.handler({ query: 'TABLE file.name FROM "notes"' });
     expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Plugin not installed or disabled: dataview');
+  });
+
+  it('should return error for Dataview query when the plugin is enabled but the API is unavailable', async () => {
+    adapter.addInstalledPlugin('dataview', 'Dataview', true);
+    // No setDataviewApi() call — getDataviewApi() returns null.
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_dataview_query')!;
+    const result = await tool.handler({ query: 'TABLE file.name FROM "notes"' });
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Plugin API unavailable for dataview');
+  });
+
+  it('should execute a Dataview DQL query and return rendered markdown', async () => {
+    adapter.addInstalledPlugin('dataview', 'Dataview', true);
+    adapter.setDataviewApi({
+      queryMarkdown: async (query: string) => {
+        expect(query).toBe('TABLE file.name FROM "notes"');
+        return Promise.resolve({
+          successful: true as const,
+          value: '| file.name |\n|---|\n| a.md |\n| b.md |',
+        });
+      },
+    });
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_dataview_query')!;
+    const result = await tool.handler({ query: 'TABLE file.name FROM "notes"' });
+    expect(result.isError).toBeUndefined();
+    expect(getText(result)).toContain('| file.name |');
+    expect(result.structuredContent).toMatchObject({
+      query: 'TABLE file.name FROM "notes"',
+      markdown: expect.stringContaining('a.md') as unknown,
+    });
+  });
+
+  it('surfaces queryMarkdown failures via the error envelope', async () => {
+    adapter.addInstalledPlugin('dataview', 'Dataview', true);
+    adapter.setDataviewApi({
+      queryMarkdown: async (_query: string) =>
+        Promise.resolve({
+          successful: false as const,
+          error: 'syntax error near FROM',
+        }),
+    });
+    const module = createPluginInteropModule(adapter);
+    const tool = module.tools().find((t) => t.name === 'plugin_dataview_query')!;
+    const result = await tool.handler({ query: 'TABLE FROM' });
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Dataview query failed: syntax error near FROM');
+  });
+
+  it('plugin_dataview_describe_js_query echoes the source verbatim and never executes it', async () => {
+    const module = createPluginInteropModule(adapter);
+    const tool = module
+      .tools()
+      .find((t) => t.name === 'plugin_dataview_describe_js_query')!;
+    const result = await tool.handler({
+      query: 'dv.pages("#projects").file.name',
+      response_format: 'json',
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({
+      query: 'dv.pages("#projects").file.name',
+    });
+    const data = JSON.parse(getText(result)) as { note: string; query: string };
+    expect(data.note).toContain('intentionally not performed');
+  });
+
+  it('plugin_templater_describe_template echoes the path and never executes it', async () => {
+    const module = createPluginInteropModule(adapter);
+    const tool = module
+      .tools()
+      .find((t) => t.name === 'plugin_templater_describe_template')!;
+    const result = await tool.handler({
+      templatePath: 'Templates/daily.md',
+      response_format: 'json',
+    });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(getText(result)) as {
+      templatePath: string;
+      note: string;
+    };
+    expect(data.templatePath).toBe('Templates/daily.md');
+    expect(data.note).toContain('intentionally not performed');
   });
 
   describe('plugin_execute_command allowlist', () => {

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -17,10 +17,10 @@ describe('search module', () => {
     expect(module.metadata.id).toBe('search');
   });
 
-  it('should register 12 tools', () => {
+  it('should register 6 tools', () => {
     const adapter = new MockObsidianAdapter();
     const module = createSearchModule(adapter);
-    expect(module.tools()).toHaveLength(12);
+    expect(module.tools()).toHaveLength(6);
   });
 
   it('should have all read-only tools', () => {
@@ -311,15 +311,9 @@ describe('search tool descriptions document shared args', () => {
 
   it('documents response_format on tools that only spread responseFormatField', () => {
     for (const name of [
-      'search_frontmatter',
       'search_tags',
-      'search_headings',
-      'search_outgoing_links',
-      'search_embeds',
-      'search_backlinks',
       'search_resolved_links',
       'search_unresolved_links',
-      'search_block_references',
     ]) {
       const desc = descriptionFor(name);
       expect(desc).toContain('response_format (enum');

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -12,18 +12,18 @@ describe('vault module', () => {
     expect(module.metadata.name).toBe('Vault and File Operations');
   });
 
-  it('should register 16 tools', () => {
+  it('should register 22 tools', () => {
     const adapter = new MockObsidianAdapter();
     const module = createVaultModule(adapter);
     const tools = module.tools();
-    expect(tools).toHaveLength(16);
+    expect(tools).toHaveLength(22);
   });
 
-  it('should have 5 read-only tools', () => {
+  it('should have 11 read-only tools', () => {
     const adapter = new MockObsidianAdapter();
     const module = createVaultModule(adapter);
     const readOnlyTools = module.tools().filter((t) => t.annotations.readOnlyHint);
-    expect(readOnlyTools).toHaveLength(5);
+    expect(readOnlyTools).toHaveLength(11);
   });
 
   it('should have 11 write tools', () => {
@@ -44,7 +44,13 @@ describe('vault module', () => {
       'vault_create_folder',
       'vault_delete',
       'vault_delete_folder',
+      'vault_get_backlinks',
+      'vault_get_block_references',
+      'vault_get_embeds',
+      'vault_get_frontmatter',
+      'vault_get_headings',
       'vault_get_metadata',
+      'vault_get_outgoing_links',
       'vault_list',
       'vault_list_recursive',
       'vault_move',

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 9', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(9);
+  it('should have schema version 10', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(10);
   });
 
   it('should have loopback-only Origin and Host allowlists by default', () => {
@@ -44,8 +44,16 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.customTlsKeyPath).toBeNull();
   });
 
-  it('should have Bearer authentication disabled by default', () => {
-    expect(DEFAULT_SETTINGS.authEnabled).toBe(false);
+  it('should have Bearer authentication enabled by default (secure-by-default)', () => {
+    expect(DEFAULT_SETTINGS.authEnabled).toBe(true);
+  });
+
+  it('should have iAcceptInsecureMode set to false by default', () => {
+    expect(DEFAULT_SETTINGS.iAcceptInsecureMode).toBe(false);
+  });
+
+  it('should have seenInsecureWarning set to false by default', () => {
+    expect(DEFAULT_SETTINGS.seenInsecureWarning).toBe(false);
   });
 
   it('should have a null TLS certificate by default', () => {

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -65,7 +65,7 @@ function makeModule(
 }
 
 const baseSettings: McpPluginSettings = {
-  schemaVersion: 9,
+  schemaVersion: 10,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: true,
@@ -87,6 +87,8 @@ const baseSettings: McpPluginSettings = {
   allowedHosts: ['127.0.0.1', 'localhost'],
   allowNullOrigin: false,
   requireOrigin: false,
+  iAcceptInsecureMode: false,
+  seenInsecureWarning: true,
   moduleStates: {},
 };
 


### PR DESCRIPTION
Closes #250
Closes #251
Closes #253
Closes #255

## Summary

- **#251** — Renames the `get_date` tool to `extras_get_date` so its
  name carries the service prefix the rest of the registry uses.
- **#255** — Moves the six single-path getters (`search_frontmatter`,
  `search_headings`, `search_outgoing_links`, `search_embeds`,
  `search_backlinks`, `search_block_references`) to the `vault`
  module under `vault_get_*` names. The `search` module now only
  ships genuine vault-wide search tools.
- **#250** — `plugin_dataview_query` actually executes a DQL query
  via Dataview's read-only `queryMarkdown` API. Dataview-JS sources
  are exposed via a separate, hands-off `plugin_dataview_describe_js_query`.
  Templater's stub is renamed to `plugin_templater_describe_template`.
- **#253** — `authEnabled` defaults to `true`, fresh installs
  auto-generate a 32-byte access key, and the server refuses to bind
  with auth off unless the user explicitly sets `iAcceptInsecureMode: true`.
  Existing default-insecure installs are grandfathered with a one-time
  notice.

## Test plan

- `npm run lint` — green.
- `npm run typecheck` — green.
- `npm test` — 593 passed across 44 files.
- `npm run docs:check` — green; `docs/tools.generated.md` regenerated
  to match the new registry.
- New unit tests cover:
  - V9 → V10 migration (grandfather, non-grandfather, fresh, and
    `extras.toolStates.get_date` rename).
  - Plugin-interop: DQL execution success, `PluginNotInstalledError`
    when Dataview is missing, `PluginApiUnavailableError` when the
    API is not exposed, `queryMarkdown` failure surfacing as an MCP
    error envelope, and the renamed `*_describe_*` stubs echoing
    inputs verbatim.
  - Auth defaults: auto-generation of a 32-byte base64url access key
    on first load, refusal to auto-start without
    `iAcceptInsecureMode`, and successful start when the flag is set.

## Migration notes for users

### Renamed tools

| Old name | New name |
|---|---|
| `get_date` | `extras_get_date` |
| `search_frontmatter` | `vault_get_frontmatter` |
| `search_headings` | `vault_get_headings` |
| `search_outgoing_links` | `vault_get_outgoing_links` |
| `search_embeds` | `vault_get_embeds` |
| `search_backlinks` | `vault_get_backlinks` |
| `search_block_references` | `vault_get_block_references` |
| `plugin_templater_execute` | `plugin_templater_describe_template` |

There are **no deprecation aliases**. Update your client/agent calls
in lockstep with this release.

### `plugin_dataview_query` behaviour change

- Previously a stub that echoed the query back. Now actually executes
  the query against Dataview's read-only `queryMarkdown` API and
  returns the rendered markdown.
- DQL only — Dataview-JS sources go through the new
  `plugin_dataview_describe_js_query` (which still echoes verbatim;
  the server never evaluates JS).
- Errors return typed envelopes:
  `PluginNotInstalledError` if Dataview is missing,
  `PluginApiUnavailableError` if the plugin is loaded but its API
  isn't exposed, and `Dataview query failed: <reason>` if the query
  parses but does not execute cleanly.

### Auth default flip (#253)

- Fresh installs now ship with `authEnabled: true` and `accessKey: ''`.
  On first plugin load a 32-byte base64url access key is auto-generated
  and persisted; copy it from **Settings → MCP Server → Access Key**.
- The server refuses to bind when `authEnabled === false &&
  iAcceptInsecureMode !== true`. To run unauthenticated (only safe on
  a trusted, localhost-only setup), turn off **Require Bearer
  authentication** and turn on the new **Accept insecure mode**
  toggle.
- Existing installs that ran default-insecure (`authEnabled === false
  && accessKey === ''`) are **grandfathered** by the v9 → v10
  migration: `iAcceptInsecureMode` is flipped to `true` so the server
  keeps starting after upgrade. A one-time notice fires on next load
  pointing the user to settings (gated by `seenInsecureWarning` so it
  fires exactly once).
- Installs that explicitly turned auth off but had a key set keep
  `iAcceptInsecureMode: false` — they will hit the refusal on next
  start and pick a posture deliberately.
- Schema bumps to `10`. The same migration carries
  `extras.toolStates.get_date` over to `extras.toolStates.extras_get_date`
  so per-tool toggle state survives the rename in #251.

## Screenshots required before merge

The auth-default flip and the new "Accept insecure mode" toggle change
the settings tab. The screenshot pipeline is host-only (#270), so the
agent didn't capture them. Please attach the following before merging:

- Server section of the settings tab — fresh-install state
  (auto-generated key visible, auth on).
- Server section — insecure-mode state with `iAcceptInsecureMode: true`
  warning visible (auth off, "Accept insecure mode" on).
- Notice surface — the one-time grandfather notice triggered by the
  v9 → v10 migration.