### PR TITLE
feat(tools/search,vault): declare outputSchema for read tools

### DIFF
--- a/docs/superpowers/plans/276-output-schema-search.md
+++ b/docs/superpowers/plans/276-output-schema-search.md
@@ -1,0 +1,934 @@
+# Issue #276 — `outputSchema` declarations for Batch B (search + vault `get_*` getters)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare `outputSchema` on the 12 read tools that emit `structuredContent` in Batch B (six in the `search` module, six `vault_get_*` getters that live in the `vault` module post-#255), and parse-validate every shape with strict-mode Zod tests.
+
+**Architecture:** Mirror the framework PR (#279) exactly — module-level `outputSchema` raw-shape consts at the top of each `*/index.ts`, wired into `defineTool({ outputSchema: ... })`. Tests use `z.object(shape).strict().parse(result.structuredContent)` so any drift between the renderer and the structured payload fails loudly.
+
+**Tech Stack:** TypeScript, Zod, Vitest, MCP SDK (`@modelcontextprotocol/sdk`).
+
+**Refs:** [Design](../specs/2026-05-02-output-schema-batches-bcd-design.md), #248 / PR #279 (framework + Batch A), #258 (campaign tracker).
+
+---
+
+## Phase 0 — Branch and baseline
+
+### Task 1: Create branch and capture baseline
+
+**Files:** none modified yet.
+
+- [ ] **Step 1: Verify the working tree only contains the new design + plan files**
+
+Run: `git status`
+Expected: untracked files include `docs/superpowers/specs/2026-05-02-output-schema-batches-bcd-design.md` and `docs/superpowers/plans/276-output-schema-search.md` only. No other modifications.
+
+- [ ] **Step 2: Create the feature branch from `main`**
+
+Run:
+```bash
+git fetch origin
+git checkout -b feat/issue-276-output-schema-search origin/main
+```
+
+Expected: switches to a fresh branch off the latest `origin/main`.
+
+- [ ] **Step 3: Re-add the design + plan files (they were untracked, so the branch checkout preserves them)**
+
+Run: `git status`
+Expected: same untracked design + plan files now appear under the new branch.
+
+- [ ] **Step 4: Commit the design + plan**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-05-02-output-schema-batches-bcd-design.md \
+        docs/superpowers/plans/276-output-schema-search.md
+git commit -m "$(cat <<'EOF'
+docs(specs): design and plan for outputSchema batches B/C/D
+
+Brainstormed design covering #276 (Batch B), #277 (Batch C), and #278
+(Batch D), plus the per-PR implementation plan for Batch B.
+
+Refs #276
+Refs #258
+EOF
+)"
+```
+
+Expected: commit succeeds; pre-commit hooks (if any) pass.
+
+- [ ] **Step 5: Run the baseline test suite to confirm green starting point**
+
+Run: `npm test`
+Expected: all tests pass (matches `main`). Capture the test count for later comparison.
+
+- [ ] **Step 6: Run lint and typecheck baseline**
+
+Run:
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both clean.
+
+---
+
+## Phase 1 — Search module (`src/tools/search/index.ts`)
+
+The six search tools that emit `structuredContent` today: `search_fulltext`, `search_tags`, `search_resolved_links`, `search_unresolved_links`, `search_by_tag`, `search_by_frontmatter`. Verified against [`src/tools/search/handlers.ts`](../../../src/tools/search/handlers.ts).
+
+### Task 2: Write the failing parse-validation tests
+
+**Files:**
+- Modify: `tests/tools/search/search.test.ts` (append a new top-level `describe` block; do NOT create a new file).
+
+- [ ] **Step 1: Open `tests/tools/search/search.test.ts` and append a new top-level describe block at the end of the file**
+
+Add this block AFTER the existing `describe('search handlers', ...)` block (the file's current last block). Add `import { z } from 'zod';` at the top of the file if it's not already imported (currently it is not — see line 1 of the existing file).
+
+Add the import at the top (line 2 area) so the file's imports look like:
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
+import { createSearchHandlers, type SearchHandlers } from '../../../src/tools/search/handlers';
+import { createSearchModule } from '../../../src/tools/search/index';
+```
+
+Append at the end of the file:
+
+```ts
+/**
+ * Batch B of #248: every search tool that emits `structuredContent` must
+ * declare an `outputSchema`, and that schema must accurately describe the
+ * payload the handler produces. Strict-mode parsing catches drift between
+ * the markdown renderer and the structured payload.
+ */
+describe('search read tools — outputSchema declarations', () => {
+  function getStructured(
+    tool: { outputSchema?: z.ZodRawShape },
+  ): z.ZodObject<z.ZodRawShape> {
+    if (!tool.outputSchema) {
+      throw new Error('expected outputSchema to be declared');
+    }
+    return z.object(tool.outputSchema).strict();
+  }
+
+  function findTool(
+    name: string,
+  ): { name: string; outputSchema?: z.ZodRawShape } {
+    const adapter = new MockObsidianAdapter();
+    const module = createSearchModule(adapter);
+    const tool = module.tools().find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found`);
+    return tool;
+  }
+
+  it('search_fulltext declares outputSchema and parses with has_more=false', async () => {
+    const tool = findTool('search_fulltext');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', 'Hello World');
+    adapter.addFile('b.md', 'Goodbye World');
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFulltext({
+      query: 'World',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(2);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_offset).toBeUndefined();
+    expect(parsed.items).toHaveLength(2);
+  });
+
+  it('search_fulltext parses with has_more=true and next_offset', async () => {
+    const tool = findTool('search_fulltext');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    for (let i = 0; i < 5; i++) {
+      adapter.addFile(`f-${String(i)}.md`, 'World');
+    }
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFulltext({
+      query: 'World',
+      limit: 2,
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(5);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
+  });
+
+  it('search_tags declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_tags');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { tags: ['#project'] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchTags({ response_format: 'json' });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.tags).toEqual({ '#project': ['a.md'] });
+  });
+
+  it('search_resolved_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_resolved_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.addFile('b.md', '');
+    adapter.setMetadata('a.md', { links: [{ link: 'b' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchResolvedLinks({
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.links).toEqual({ 'a.md': { 'b.md': 1 } });
+  });
+
+  it('search_unresolved_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_unresolved_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { links: [{ link: 'missing' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchUnresolvedLinks({
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.links).toEqual({ 'a.md': { missing: 1 } });
+  });
+
+  it('search_by_tag declares outputSchema and parses with has_more=false', async () => {
+    const tool = findTool('search_by_tag');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { tags: ['#project'] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByTag({
+      tag: 'project',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(1);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_offset).toBeUndefined();
+    expect(parsed.items).toEqual(['a.md']);
+  });
+
+  it('search_by_tag parses with has_more=true and next_offset', async () => {
+    const tool = findTool('search_by_tag');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    for (let i = 0; i < 5; i++) {
+      adapter.addFile(`f-${String(i)}.md`, '');
+      adapter.setMetadata(`f-${String(i)}.md`, { tags: ['#project'] });
+    }
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByTag({
+      tag: 'project',
+      limit: 2,
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(5);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
+  });
+
+  it('search_by_frontmatter declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_by_frontmatter');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { frontmatter: { status: 'done' } });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByFrontmatter({
+      key: 'status',
+      value: 'done',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(1);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.items).toEqual(['a.md']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+Run: `npx vitest run tests/tools/search/search.test.ts -t "search read tools — outputSchema declarations"`
+Expected: every `it(...)` in the new block fails with `Error: expected outputSchema to be declared`. The pre-existing tests in `search.test.ts` should still pass.
+
+- [ ] **Step 3: Run lint and typecheck on the new test file**
+
+Run:
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both clean. If lint flags the new code, fix it now (most likely missing import sorting or trailing-newline issues).
+
+### Task 3: Add `outputSchema` consts and wire them to `defineTool` calls
+
+**Files:**
+- Modify: `src/tools/search/index.ts`
+
+- [ ] **Step 1: Add the import for `z`**
+
+`src/tools/search/index.ts` currently imports nothing from `zod`. Add this as the first line:
+
+```ts
+import { z } from 'zod';
+```
+
+- [ ] **Step 2: Add five `outputSchema` raw-shape consts between the imports and `createSearchModule`**
+
+Insert this block immediately before `export function createSearchModule(...)` (currently line 12):
+
+```ts
+/**
+ * Output schemas for the search tools that emit `structuredContent`. Each
+ * shape mirrors what the corresponding handler in `./handlers.ts` puts on
+ * `result.structuredContent` — declaring them lets modern MCP clients
+ * validate / introspect the typed payload (Batch B of #248).
+ */
+const searchFulltextOutputSchema = {
+  total: z.number().describe('Total number of matched files before pagination.'),
+  count: z.number().describe('Number of matches in this page.'),
+  offset: z.number().describe('Offset of the first item in this page.'),
+  items: z
+    .array(
+      z.object({
+        path: z.string().describe('Vault-relative path of the matching file.'),
+        matches: z
+          .array(z.string())
+          .describe('Lines from the file that contain the query.'),
+      }),
+    )
+    .describe('Matches in this page.'),
+  has_more: z
+    .boolean()
+    .describe('True when more results are available past this page.'),
+  next_offset: z
+    .number()
+    .optional()
+    .describe('Offset to use in the next request when has_more is true.'),
+};
+
+const searchTagsOutputSchema = {
+  tags: z
+    .record(z.string(), z.array(z.string()))
+    .describe('Map of tag (with leading #) to vault-relative file paths that use it.'),
+};
+
+const searchLinksMapOutputSchema = {
+  links: z
+    .record(z.string(), z.record(z.string(), z.number()))
+    .describe('Map of source file path to map of target file path to reference count.'),
+};
+
+const paginatedPathPageOutputSchema = {
+  total: z
+    .number()
+    .describe('Total number of matching files before pagination.'),
+  count: z.number().describe('Number of files in this page.'),
+  offset: z.number().describe('Offset of the first item in this page.'),
+  items: z
+    .array(z.string())
+    .describe('Vault-relative file paths in this page.'),
+  has_more: z
+    .boolean()
+    .describe('True when there are more files past this page.'),
+  next_offset: z
+    .number()
+    .optional()
+    .describe('Offset to use in the next request when has_more is true.'),
+};
+```
+
+- [ ] **Step 3: Wire each schema to its `defineTool` call**
+
+In the same file, modify each `defineTool({...})` block by adding an `outputSchema:` field directly after the existing `schema:` field. The six edits, in file order:
+
+For `search_fulltext` (currently line 24-36):
+```ts
+schema: searchFulltextSchema,
+outputSchema: searchFulltextOutputSchema,
+handler: handlers.searchFulltext,
+```
+
+For `search_tags` (currently line 37-46):
+```ts
+schema: readOnlySchema,
+outputSchema: searchTagsOutputSchema,
+handler: handlers.searchTags,
+```
+
+For `search_resolved_links` (currently line 47-56):
+```ts
+schema: readOnlySchema,
+outputSchema: searchLinksMapOutputSchema,
+handler: handlers.searchResolvedLinks,
+```
+
+For `search_unresolved_links` (currently line 57-67):
+```ts
+schema: readOnlySchema,
+outputSchema: searchLinksMapOutputSchema,
+handler: handlers.searchUnresolvedLinks,
+```
+
+For `search_by_tag` (currently line 68-78):
+```ts
+schema: searchByTagSchema,
+outputSchema: paginatedPathPageOutputSchema,
+handler: handlers.searchByTag,
+```
+
+For `search_by_frontmatter` (currently line 79-93):
+```ts
+schema: searchByFrontmatterSchema,
+outputSchema: paginatedPathPageOutputSchema,
+handler: handlers.searchByFrontmatter,
+```
+
+- [ ] **Step 4: Run the search outputSchema tests and confirm they pass**
+
+Run: `npx vitest run tests/tools/search/search.test.ts -t "search read tools — outputSchema declarations"`
+Expected: all 8 new tests pass; the existing search tests still pass.
+
+- [ ] **Step 5: Run lint and typecheck**
+
+Run:
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both clean.
+
+### Task 4: Commit the search module work
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add src/tools/search/index.ts tests/tools/search/search.test.ts
+git commit -m "$(cat <<'EOF'
+feat(tools/search): declare outputSchema for read tools
+
+Declare outputSchema on the six search tools that emit structuredContent
+(search_fulltext, search_tags, search_resolved_links,
+search_unresolved_links, search_by_tag, search_by_frontmatter) so modern
+MCP clients can validate and introspect the typed payload. Strict-mode
+parse tests pin every shape against the matching handler output and
+guard against renderer-vs-payload drift.
+
+Refs #276
+Refs #258
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Phase 2 — Vault `get_*` getters (`src/tools/vault/index.ts`)
+
+The six single-path getters renamed from `search_get_*` by #255 — they live in `src/tools/vault/index.ts` today but use search handlers. Tools: `vault_get_frontmatter`, `vault_get_headings`, `vault_get_outgoing_links`, `vault_get_embeds`, `vault_get_backlinks`, `vault_get_block_references`.
+
+### Task 5: Extend the existing vault outputSchema describe block with failing tests
+
+**Files:**
+- Modify: `tests/tools/vault/module.test.ts` — add six new `it(...)` blocks INSIDE the existing `describe('vault read tools — outputSchema declarations', ...)` block (currently lines 77-202). Add them after the `vault_read_binary` test at line 201, before the closing `});` of the describe block at line 202.
+
+- [ ] **Step 1: Add helper imports**
+
+The existing test file already imports what we need (`z`, `MockObsidianAdapter`, `createVaultModule`). Verify by reading the top of the file. Additionally, verify the test file imports `createSearchHandlers` — it does NOT today. Add this import at the top:
+
+```ts
+import { createSearchHandlers } from '../../../src/tools/search/handlers';
+```
+
+- [ ] **Step 2: Add six new `it(...)` blocks inside the existing describe block**
+
+Insert these tests inside `describe('vault read tools — outputSchema declarations', () => { ... })`, immediately before the closing `});` of that describe block (which is at line 202 of the current file):
+
+```ts
+  it('vault_get_frontmatter declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_frontmatter');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', '');
+    adapter.setMetadata('note.md', { frontmatter: { status: 'done', tags: ['x'] } });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFrontmatter({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('note.md');
+    expect(parsed.frontmatter).toEqual({ status: 'done', tags: ['x'] });
+  });
+
+  it('vault_get_headings declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_headings');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', '');
+    adapter.setMetadata('note.md', {
+      headings: [
+        { heading: 'Top', level: 1 },
+        { heading: 'Sub', level: 2 },
+      ],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchHeadings({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.headings).toEqual([
+      { heading: 'Top', level: 1 },
+      { heading: 'Sub', level: 2 },
+    ]);
+  });
+
+  it('vault_get_outgoing_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_outgoing_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', {
+      links: [{ link: 'b', displayText: 'Bee' }, { link: 'c' }],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchOutgoingLinks({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('a.md');
+    expect(parsed.links).toEqual([
+      { link: 'b', displayText: 'Bee' },
+      { link: 'c' },
+    ]);
+  });
+
+  it('vault_get_embeds declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_embeds');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', {
+      embeds: [{ link: 'image.png' }],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchEmbeds({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.embeds).toEqual([{ link: 'image.png' }]);
+  });
+
+  it('vault_get_backlinks declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_backlinks');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.addFile('b.md', '');
+    adapter.setMetadata('b.md', { links: [{ link: 'a' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchBacklinks({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('a.md');
+    expect(parsed.backlinks).toEqual(['b.md']);
+  });
+
+  it('vault_get_block_references declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_block_references');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', 'A line ^anchor-1\nAnother ^anchor-2\n');
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchBlockReferences({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('note.md');
+    expect(parsed.blockRefs).toEqual([
+      { id: 'anchor-1', line: 'A line ^anchor-1' },
+      { id: 'anchor-2', line: 'Another ^anchor-2' },
+    ]);
+  });
+```
+
+- [ ] **Step 3: Run the new tests and confirm they fail**
+
+Run: `npx vitest run tests/tools/vault/module.test.ts -t "vault read tools — outputSchema declarations"`
+Expected: the 6 new tests fail with `Error: expected outputSchema to be declared`. The 5 existing outputSchema tests in the same describe block (Batch A's `vault_read`, `vault_get_metadata`, `vault_list`, `vault_list_recursive` × 2 cases) still pass. The `vault_read_binary` test that asserts `outputSchema` is undefined still passes — it stays untouched in this PR (Batch D will flip it).
+
+- [ ] **Step 4: Run lint and typecheck**
+
+Run:
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both clean.
+
+### Task 6: Add the six `outputSchema` consts to `src/tools/vault/index.ts`
+
+**Files:**
+- Modify: `src/tools/vault/index.ts`
+
+- [ ] **Step 1: Add the six new consts immediately AFTER the existing `listRecursiveOutputSchema` (currently line 82) and BEFORE `export function createVaultModule(...)` (currently line 84)**
+
+Insert this block:
+
+```ts
+/**
+ * Output schemas for the `vault_get_*` single-path getters. These tools were
+ * renamed from `search_get_*` by #255 and use search handlers, but they live
+ * in the vault module today and so their `outputSchema` declarations live
+ * alongside the rest of the vault read schemas (Batch B of #248).
+ */
+const getFrontmatterOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  frontmatter: z
+    .record(z.string(), z.unknown())
+    .describe('Parsed YAML frontmatter object, or {} when absent.'),
+};
+
+const getHeadingsOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  headings: z
+    .array(
+      z.object({
+        heading: z.string().describe('Heading text.'),
+        level: z.number().describe('Heading level (1..6).'),
+      }),
+    )
+    .describe('Headings in document order.'),
+};
+
+const getOutgoingLinksOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  links: z
+    .array(
+      z.object({
+        link: z.string().describe('Link target.'),
+        displayText: z
+          .string()
+          .optional()
+          .describe('Optional alias used in [[link|alias]] notation.'),
+      }),
+    )
+    .describe('Outgoing links from this file.'),
+};
+
+const getEmbedsOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  embeds: z
+    .array(
+      z.object({
+        link: z.string().describe('Embed target.'),
+        displayText: z.string().optional().describe('Optional alias.'),
+      }),
+    )
+    .describe('Embeds (![[...]]) referenced by this file.'),
+};
+
+const getBacklinksOutputSchema = {
+  path: z.string().describe('Target path that was queried.'),
+  backlinks: z
+    .array(z.string())
+    .describe('Vault-relative paths of files that link TO the target.'),
+};
+
+const getBlockReferencesOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  blockRefs: z
+    .array(
+      z.object({
+        id: z.string().describe('Block-reference id (without the leading ^).'),
+        line: z.string().describe('The line of text the block-reference is on.'),
+      }),
+    )
+    .describe('Block references defined in this file.'),
+};
+```
+
+- [ ] **Step 2: Wire each new schema to its corresponding `defineTool` call**
+
+In the same file, modify the six `vault_get_*` `defineTool({...})` blocks (currently lines 361-432) by adding `outputSchema:` directly after `schema:`. Six edits in file order:
+
+For `vault_get_frontmatter`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getFrontmatterOutputSchema,
+handler: searchHandlers.searchFrontmatter,
+```
+
+For `vault_get_headings`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getHeadingsOutputSchema,
+handler: searchHandlers.searchHeadings,
+```
+
+For `vault_get_outgoing_links`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getOutgoingLinksOutputSchema,
+handler: searchHandlers.searchOutgoingLinks,
+```
+
+For `vault_get_embeds`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getEmbedsOutputSchema,
+handler: searchHandlers.searchEmbeds,
+```
+
+For `vault_get_backlinks`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getBacklinksOutputSchema,
+handler: searchHandlers.searchBacklinks,
+```
+
+For `vault_get_block_references`:
+```ts
+schema: searchFilePathSchema,
+outputSchema: getBlockReferencesOutputSchema,
+handler: searchHandlers.searchBlockReferences,
+```
+
+- [ ] **Step 3: Run the vault outputSchema tests and confirm they pass**
+
+Run: `npx vitest run tests/tools/vault/module.test.ts -t "vault read tools — outputSchema declarations"`
+Expected: all 11 tests in the describe block pass (the 5 from Batch A + the 6 new ones; the `vault_read_binary` "intentionally omits" test is also still passing).
+
+- [ ] **Step 4: Run lint and typecheck**
+
+Run:
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both clean.
+
+### Task 7: Commit the vault-getter work
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add src/tools/vault/index.ts tests/tools/vault/module.test.ts
+git commit -m "$(cat <<'EOF'
+feat(tools/vault): declare outputSchema for vault_get_* getters
+
+Declare outputSchema on the six single-path getters renamed from
+search_get_* by #255 (vault_get_frontmatter, vault_get_headings,
+vault_get_outgoing_links, vault_get_embeds, vault_get_backlinks,
+vault_get_block_references). They live in the vault module but use
+search handlers; this PR completes Batch B of #248 by giving each one
+a strict-mode-tested outputSchema.
+
+Refs #276
+Refs #258
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Phase 3 — Verification gate, docs, push, PR
+
+### Task 8: Regenerate `docs/tools.generated.md` and run the full gate
+
+**Files:**
+- Possibly modify: `docs/tools.generated.md` (if regeneration produces a diff).
+
+- [ ] **Step 1: Regenerate the tools doc**
+
+Run: `npm run docs:tools`
+Expected: the script runs to completion. Per the framework PR's note, the current generator only lists tool names, so there should be NO diff for this batch (no tools were added or renamed). Verify with `git status`.
+
+- [ ] **Step 2: If `git status` shows a diff for `docs/tools.generated.md`, commit it**
+
+If there's a diff (unexpected for this batch), inspect it first:
+```bash
+git diff docs/tools.generated.md
+```
+
+If the diff is purely from the regeneration (no manual edits needed), commit:
+```bash
+git add docs/tools.generated.md
+git commit -m "$(cat <<'EOF'
+docs(tools): regenerate tools.generated.md after Batch B
+
+Refs #276
+EOF
+)"
+```
+
+If there's no diff, skip this step.
+
+- [ ] **Step 3: Run the full verification gate**
+
+Run each command separately (per CLAUDE.md rule 15):
+```bash
+npm test
+```
+
+Expected: all tests pass — search and vault test counts each grew by their new outputSchema tests; nothing else regressed.
+
+```bash
+npm run lint
+```
+
+Expected: clean.
+
+```bash
+npm run typecheck
+```
+
+Expected: clean.
+
+```bash
+npm run docs:check
+```
+
+Expected: clean.
+
+If any of the four commands fails, debug the cause and fix before proceeding. Common pitfalls:
+- `npm test` failing on a search/vault test → re-check the schema descriptions match what the handler emits (extra field, missing optional, wrong type).
+- `npm run lint` failing → most likely an unused `paginatedPathPageOutputSchema` const if the wiring step missed one of `search_by_tag`/`search_by_frontmatter`.
+- `npm run typecheck` failing → `outputSchema` field's type must be `z.ZodRawShape`; if a `.describe(...)` chain produced an unexpected type, simplify (Zod's `.describe()` is type-preserving, so this is unlikely).
+- `npm run docs:check` failing → re-run `npm run docs:tools` and commit any diff.
+
+### Task 9: Push and open the PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/issue-276-output-schema-search`
+Expected: branch is created on `origin` and tracks the local branch.
+
+- [ ] **Step 2: Open the PR with `gh`**
+
+Run:
+```bash
+gh pr create --title "feat(tools/search,vault): declare outputSchema for read tools" --body "$(cat <<'EOF'
+Closes #276
+
+## Summary
+
+- Declare `outputSchema` on the six search tools that emit `structuredContent` (`search_fulltext`, `search_tags`, `search_resolved_links`, `search_unresolved_links`, `search_by_tag`, `search_by_frontmatter`).
+- Declare `outputSchema` on the six `vault_get_*` getters renamed from `search_get_*` by #255 (`vault_get_frontmatter`, `vault_get_headings`, `vault_get_outgoing_links`, `vault_get_embeds`, `vault_get_backlinks`, `vault_get_block_references`).
+- Strict-mode (`z.object(shape).strict().parse(...)`) parse tests pin every shape against the matching handler output, mirroring the framework PR (#279).
+
+## Cross-module split
+
+The issue's "add the declaration to `src/tools/search/index.ts`" wording predates the #255 rename. After #255, the `vault_get_*` getters live in `src/tools/vault/index.ts` (using search handlers) — so this PR splits the schema declarations across both files to match the actual tool-registration sites:
+
+- Tools registered in `src/tools/search/index.ts` → schemas in that file, tests in `tests/tools/search/search.test.ts`.
+- `vault_get_*` getters registered in `src/tools/vault/index.ts` → schemas in that file, tests added to the existing `vault read tools — outputSchema declarations` describe block in `tests/tools/vault/module.test.ts`.
+
+## Test plan
+
+- [x] `npm test` — pre-existing tests still green; new strict-mode parse tests cover all 12 in-scope tools (with `has_more=true`/`false` cases for the paginated ones).
+- [x] `npm run lint` — clean.
+- [x] `npm run typecheck` — clean.
+- [x] `npm run docs:check` — clean (no diff: the generator only lists tool names, no new tools or renames in this PR).
+
+## Refs
+
+- Builds on #248 / PR #279 (framework + Batch A).
+- Tracker: #258.
+- Followups: #277 (Batch C — workspace + editor read), #278 (Batch D — extras + plugin-interop + templates + `vault_read_binary` retrofit).
+EOF
+)"
+```
+
+Expected: PR is created on GitHub and `gh` prints the URL.
+
+- [ ] **Step 3: Print the PR URL**
+
+Run: `gh pr view --json url -q .url`
+Expected: the URL is printed for the user to open. Stop here and wait for review/merge before starting Plan 2 (Batch C / #277).
+
+---
+
+## Self-review checklist (run after writing this plan)
+
+This section is for the plan author. Check before handing off:
+
+- **Spec coverage.** Each item in the design's PR-1 scope has a task:
+  - Six `search/index.ts` schemas → Task 3 step 2
+  - Six `vault/index.ts` schemas → Task 6 step 1
+  - Six search-tool tests → Task 2 step 1
+  - Six vault-getter tests → Task 5 step 2
+  - `docs/tools.generated.md` regen → Task 8 step 1
+  - `npm test`, `npm run lint`, `npm run typecheck`, `npm run docs:check` gate → Task 8 step 3
+  - PR body cross-module-split note → Task 9 step 2
+- **No placeholders.** Every code step contains the actual code; every command step contains the actual command. No "TBD"/"TODO"/"add appropriate error handling".
+- **Type consistency.** `outputSchema` field used everywhere matches `ToolDefinition`'s optional `z.ZodRawShape` field (typed by PR #279). Helpers `getStructured` and `findTool` have the same signature in both test files.
+
+## Out of scope (here, deferred to Batch C / D plans)
+
+- Workspace and editor read-tool schemas — Plan 2 (#277).
+- Extras + plugin-interop + templates schemas — Plan 3 (#278).
+- `vault_read_binary` `structuredContent` retrofit — Plan 3 (#278). The `tests/tools/vault/module.test.ts:194-201` "intentionally omits outputSchema" assertion stays untouched in this PR.

--- a/docs/superpowers/specs/2026-05-02-output-schema-batches-bcd-design.md
+++ b/docs/superpowers/specs/2026-05-02-output-schema-batches-bcd-design.md
@@ -1,0 +1,301 @@
+# Design — `outputSchema` declarations for read-tool batches B / C / D
+
+- **Date:** 2026-05-02
+- **Closes:** [#276](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/276), [#277](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/277), [#278](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/278)
+- **Refs:** [#258](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/258) (campaign tracker), [#248](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/248) / [PR #279](https://github.com/KingOfKalk/obsidian-plugin-mcp/pull/279) (framework + Batch A)
+- **Status:** Approved design; per-issue implementation plans follow separately.
+
+## 1. Goal
+
+Close the three remaining `outputSchema` follow-ups by declaring schemas for every read tool that emits `structuredContent`, so modern MCP clients can validate and introspect the typed payload. No framework changes — `ToolDefinition` already carries the optional field and `registerTools` already forwards it (PR #279).
+
+## 2. Locked decisions
+
+Captured during the brainstorming session:
+
+- **`vault_read_binary` retrofit (#278):** Option A — restructure the structured payload to `{ path, data, encoding: 'base64', size_bytes }` and declare an `outputSchema`. The plain-text rendering remains the bare base64 string, so existing `result.content[0].text` callers see no change.
+- **Opaque workspace shapes (#277):** Option A — `workspace_get_active_leaf` and `workspace_get_layout` use `.passthrough()` parse tests. Schemas declare the documented fields the adapter actually returns; `.passthrough()` insulates against Obsidian internal additions.
+- **PR cadence:** Option A — three independent PRs, one per issue, in the order B → C → D. Matches the campaign plan's 1:1 issue-to-PR baseline.
+- **Scope additions:** Option A — Batch B's `vault_get_*` getters get their schemas where the tools live today (`src/tools/vault/index.ts`, post-#255). Batch D includes `plugin_dataview_describe_js_query`, `plugin_templater_describe_template`, and `template_expand` per the issues' "plus any other read-only entries" clauses.
+
+## 3. Shape of the work
+
+Three independent PRs (B → C → D), each:
+
+- Adds module-level `outputSchema` consts in the affected `*/index.ts` (mirroring [`src/tools/vault/index.ts:38-82`](../../../src/tools/vault/index.ts#L38-L82)).
+- Adds a `<module> read tools — outputSchema declarations` describe block to the existing module test file (mirroring [`tests/tools/vault/module.test.ts:77-202`](../../../tests/tools/vault/module.test.ts#L77-L202)). The naming convention is `tests/tools/<module>/<module>.test.ts` for every module except `vault`, which uses `tests/tools/vault/module.test.ts`. Add to the existing file rather than creating a new one.
+- Uses `z.object(shape).strict().parse(...)` — except for the two opaque workspace tools, which use `.passthrough()`.
+- Regenerates `docs/tools.generated.md` via `npm run docs:tools`.
+- Runs `npm run lint`, `npm test`, `npm run typecheck`, `npm run docs:check` clean.
+- Conventional Commits per project rule 1 + 7; `Refs #<issue>` and `Refs #258` in commit bodies; `Closes #<issue>` in PR body.
+
+Grand total across the three PRs: **29 `outputSchema` declarations + ~29 strict-mode parse tests + 1 handler retrofit**.
+
+## 4. PR-by-PR scope
+
+### PR 1 — Batch B (#276)
+
+- **Branch:** `feat/issue-276-output-schema-search`
+- **`src/tools/search/index.ts`** — declare `outputSchema` on 6 tools:
+  - `search_fulltext`, `search_tags`, `search_resolved_links`, `search_unresolved_links`, `search_by_tag`, `search_by_frontmatter`
+- **`src/tools/vault/index.ts`** — declare `outputSchema` on the 6 single-path getters renamed from `search_get_*` by #255 (use search handlers but live in the vault module today):
+  - `vault_get_frontmatter`, `vault_get_headings`, `vault_get_outgoing_links`, `vault_get_embeds`, `vault_get_backlinks`, `vault_get_block_references`
+- **Tests:**
+  - New `describe('search read tools — outputSchema declarations', …)` in `tests/tools/search/search.test.ts` for the 6 search tools.
+  - Extend the existing `describe('vault read tools — outputSchema declarations', …)` block in `tests/tools/vault/module.test.ts` with parse-validation for the 6 `vault_get_*` getters.
+- **PR body:** notes that the issue's `src/tools/search/index.ts` location guidance is partly stale post-#255 — getters get their schema in `vault/index.ts` (where they live), search-prefixed tools in `search/index.ts`. **Closes #276.**
+- Total: 12 schemas, ~12 parse tests.
+
+### PR 2 — Batch C (#277)
+
+- **Branch:** `feat/issue-277-output-schema-workspace-editor`
+- **`src/tools/workspace/index.ts`** — declare `outputSchema` on 3 tools:
+  - `workspace_get_active_leaf` (permissive, `.passthrough()` test), `workspace_list_leaves` (strict), `workspace_get_layout` (permissive, `.passthrough()` test).
+- **`src/tools/editor/index.ts`** — declare `outputSchema` on 5 tools:
+  - `editor_get_content`, `editor_get_active_file`, `editor_get_cursor`, `editor_get_selection`, `editor_get_line_count` (all strict).
+- **Tests:** new `describe(...)` blocks in `tests/tools/workspace/workspace.test.ts` and `tests/tools/editor/editor.test.ts`. Permissive tools use `z.object(shape).passthrough().parse(...)` — clearly commented as the documented exception.
+- **PR body:** notes the two permissive schemas + reason. **Closes #277.**
+- Total: 8 schemas, ~8 parse tests.
+
+### PR 3 — Batch D (#278)
+
+- **Branch:** `feat/issue-278-output-schema-extras-interop-templates-binary`
+- **`src/tools/extras/index.ts`** — `extras_get_date` (1 schema).
+- **`src/tools/plugin-interop/index.ts`** — 5 schemas: `plugin_list`, `plugin_check`, `plugin_dataview_query`, `plugin_dataview_describe_js_query`, `plugin_templater_describe_template`.
+- **`src/tools/templates/index.ts`** — 2 schemas: `template_list`, `template_expand`.
+- **`src/tools/vault/{handlers,index}.ts`** — retrofit `vault_read_binary` to emit `structuredContent: { path, data, encoding: 'base64', size_bytes }` via `makeResponse(...)`. Plain-text rendering stays as the bare base64 string. Update the tool description's "Returns" line to reflect the structured shape under `response_format: 'json'`.
+- **Tests:** new describe blocks in `tests/tools/extras/extras.test.ts`, `tests/tools/plugin-interop/plugin-interop.test.ts`, `tests/tools/templates/templates.test.ts`. In `tests/tools/vault/module.test.ts:194-201`, flip the "intentionally omits outputSchema" assertion to a positive parse test (see Section 6).
+- **PR body:** explicitly records the locked Option A retrofit decision for `vault_read_binary` and lists the three scope-addition tools per the issue's "plus any other read-only entries" clause. **Closes #278.**
+- Total: 9 schemas, ~9 parse tests, 1 handler retrofit.
+
+## 5. Exact `outputSchema` shapes per tool
+
+Verified against handler implementations and adapter signatures. All shapes are `z.ZodRawShape` literals matching what the handler puts on `result.structuredContent`.
+
+### Batch B — search module (`src/tools/search/index.ts`)
+
+```ts
+// Pagination shape reused by 3 search tools
+const paginatedStringPage = {
+  total: z.number(), count: z.number(), offset: z.number(),
+  items: z.array(z.string()),
+  has_more: z.boolean(), next_offset: z.number().optional(),
+};
+
+// search_fulltext — page of { path, matches: string[] }
+{
+  total: z.number(), count: z.number(), offset: z.number(),
+  items: z.array(z.object({ path: z.string(), matches: z.array(z.string()) })),
+  has_more: z.boolean(), next_offset: z.number().optional(),
+}
+// search_tags
+{ tags: z.record(z.string(), z.array(z.string())) }
+// search_resolved_links / search_unresolved_links (same shape)
+{ links: z.record(z.string(), z.record(z.string(), z.number())) }
+// search_by_tag / search_by_frontmatter — page of strings
+paginatedStringPage
+```
+
+### Batch B — vault module (`src/tools/vault/index.ts`), the 6 ex-`search_get_*` getters
+
+```ts
+// vault_get_frontmatter
+{ path: z.string(), frontmatter: z.record(z.string(), z.unknown()) }
+// vault_get_headings
+{ path: z.string(),
+  headings: z.array(z.object({ heading: z.string(), level: z.number() })) }
+// vault_get_outgoing_links / vault_get_embeds (same shape, different field name)
+{ path: z.string(),
+  links /* embeds */: z.array(z.object({ link: z.string(), displayText: z.string().optional() })) }
+// vault_get_backlinks
+{ path: z.string(), backlinks: z.array(z.string()) }
+// vault_get_block_references
+{ path: z.string(),
+  blockRefs: z.array(z.object({ id: z.string(), line: z.string() })) }
+```
+
+### Batch C — workspace (`src/tools/workspace/index.ts`)
+
+```ts
+// workspace_get_active_leaf — adapter returns { id, type, filePath } today;
+// Obsidian may add more fields. Test uses .passthrough(); schema declares the known three.
+{ id: z.string(), type: z.string(), filePath: z.string().nullable() }
+// workspace_list_leaves — strict
+{ leaves: z.array(z.object({ leafId: z.string(), path: z.string() })) }
+// workspace_get_layout — fully opaque (adapter passes through Obsidian's getLayout()).
+// Empty raw shape + .passthrough() in test = "an object, contents not described".
+{} /* with .passthrough() in the parse test */
+```
+
+### Batch C — editor (`src/tools/editor/index.ts`)
+
+```ts
+// editor_get_content
+{ content: z.string() }
+// editor_get_active_file
+{ path: z.string() }
+// editor_get_cursor
+{ line: z.number(), ch: z.number() }
+// editor_get_selection
+{ from: z.object({ line: z.number(), ch: z.number() }),
+  to:   z.object({ line: z.number(), ch: z.number() }),
+  text: z.string() }
+// editor_get_line_count
+{ lineCount: z.number() }
+```
+
+### Batch D — extras / plugin-interop / templates
+
+```ts
+// extras_get_date
+{ iso: z.string() }
+// plugin_list — adapter typed as Array<{ id, name, enabled }>
+{ plugins: z.array(z.object({ id: z.string(), name: z.string(), enabled: z.boolean() })) }
+// plugin_check
+{ pluginId: z.string(), installed: z.boolean(), enabled: z.boolean() }
+// plugin_dataview_query
+{ query: z.string(), markdown: z.string() }
+// plugin_dataview_describe_js_query
+{ query: z.string(), note: z.string() }
+// plugin_templater_describe_template
+{ templatePath: z.string(), note: z.string() }
+// template_list
+{ files: z.array(z.string()) }
+// template_expand
+{ expanded: z.string() }
+```
+
+### Batch D — `vault_read_binary` retrofit (`src/tools/vault/{handlers,index}.ts`)
+
+```ts
+// Handler: replace `textResult(base64)` with
+//   makeResponse(
+//     { path, data: base64, encoding: 'base64' as const, size_bytes: data.byteLength },
+//     (v) => v.data,
+//     readResponseFormat(params),
+//   )
+// Index outputSchema:
+{
+  path: z.string(),
+  data: z.string(),
+  encoding: z.literal('base64'),
+  size_bytes: z.number(),
+}
+```
+
+## 6. Test pattern
+
+Mirrors `tests/tools/vault/module.test.ts:77-202`. Each module's test file gets one new `describe('<module> read tools — outputSchema declarations', …)` block with two helpers and one `it(...)` per tool.
+
+```ts
+function getStructured(
+  tool: { outputSchema?: z.ZodRawShape },
+  { passthrough = false } = {},
+): z.ZodObject<z.ZodRawShape> {
+  if (!tool.outputSchema) throw new Error('expected outputSchema to be declared');
+  const obj = z.object(tool.outputSchema);
+  return passthrough ? obj.passthrough() : obj.strict();
+}
+
+function findTool(name: string): { name: string; outputSchema?: z.ZodRawShape } {
+  const adapter = new MockObsidianAdapter();
+  const tool = createXModule(adapter).tools().find(t => t.name === name);
+  if (!tool) throw new Error(`tool ${name} not found`);
+  return tool;
+}
+```
+
+Each `it(...)`:
+
+1. Builds a small fixture via `MockObsidianAdapter` (existing helpers like `addFile`, `addFolder`).
+2. Calls the handler directly with `response_format: 'json'` so `result.structuredContent` is populated.
+3. `schema.parse(result.structuredContent)` — the parse is the assertion; the test fails loudly if any field is missing, mistyped, or extra (under strict mode).
+
+### Strict vs. passthrough policy
+
+- **Default: strict.** Catches drift between renderer and structured payload — the original `mcp-builder` motivation.
+- **Two documented exceptions in Batch C:**
+  - `workspace_get_active_leaf` — `getStructured(tool, { passthrough: true })`, with an inline comment: `// Obsidian's leaf state may carry additional fields beyond { id, type, filePath } in future versions; .passthrough() absorbs those without test churn.`
+  - `workspace_get_layout` — same call, same comment phrased for the layout descriptor. Schema is `{}`, so the test only asserts that `structuredContent` is an object (`expect(typeof parsed).toBe('object')`).
+
+### Pagination coverage in Batch B
+
+For `search_fulltext`, `search_by_tag`, and `search_by_frontmatter` — mirror PR #279's two-case pattern: one fixture small enough that `has_more=false` (asserts `next_offset` is absent) and one with `limit` low enough to force `has_more=true` (asserts `next_offset` matches `offset + count`). This catches drift in pagination metadata, which is the most pagination-aware part of the surface.
+
+### `vault_read_binary` test flip in Batch D
+
+`tests/tools/vault/module.test.ts:194-201` currently asserts the absence:
+
+```ts
+it('vault_read_binary intentionally omits outputSchema (no structuredContent emitted)', () => { ... });
+```
+
+Becomes:
+
+```ts
+it('vault_read_binary declares outputSchema and structuredContent parses against it', async () => {
+  const tool = findTool('vault_read_binary');
+  const schema = getStructured(tool);
+  const adapter = new MockObsidianAdapter();
+  // Use whichever binary-fixture helper the mock adapter exposes (addBinaryFile or
+  // direct `setFileContents` with a Buffer); confirmed at implementation time.
+  adapter.addBinaryFile('img.png', Uint8Array.from([0xff, 0xd8, 0xff]));
+  const handlers = createHandlers(adapter, new WriteMutex());
+  const result = await handlers.readBinary({ path: 'img.png', response_format: 'json' });
+  const parsed = schema.parse(result.structuredContent);
+  expect(parsed).toEqual({
+    path: 'img.png', data: '/9j/', encoding: 'base64', size_bytes: 3,
+  });
+});
+```
+
+A second `it(...)` for `vault_read_binary` asserts that `response_format: 'text'` (the default) still returns the bare base64 string in `result.content[0].text` — pins the no-callsite-churn promise.
+
+## 7. Docs, commits, PR plumbing
+
+### Per-PR doc updates
+
+- **`docs/tools.generated.md`** — regenerate via `npm run docs:tools` in every PR. The current generator only lists tool names, so the file is unchanged for B and C (no new tools, no renames). Batch D's `vault_read_binary` description gains a structured-shape line; whether that surfaces in the generated doc depends on the generator. Run `npm run docs:check` either way; CI fails otherwise (project rule 5).
+- **`docs/help/en.md`** — only Batch D needs a touch: the `vault_read_binary` entry's "Returns" line gains a one-liner about the structured payload. B and C are pure protocol-level additions (no user-visible surface change) — no help-doc update required. Project rule 5 is satisfied because no user-facing surface is altered for B/C.
+
+### Commit plan, per PR
+
+Default: one commit per PR.
+
+- **PR 1 (Batch B, #276):** `feat(tools/search,vault): declare outputSchema for read tools`. Body: `Refs #276`, `Refs #258`. PR body explains the cross-module split (search-prefixed tools in `search/index.ts`; `vault_get_*` getters in `vault/index.ts`) and notes that the issue's location guidance was partly stale post-#255.
+- **PR 2 (Batch C, #277):** `feat(tools/workspace,editor): declare outputSchema for read tools`. Body: `Refs #277`, `Refs #258`. PR body lists the two `.passthrough()` exceptions and the reason.
+- **PR 3 (Batch D, #278):** split into two commits — the binary retrofit is a payload change, not a pure declaration:
+  1. `feat(tools/vault): structuredContent for vault_read_binary` — handler change + index `outputSchema` + test flip + help-doc tweak.
+  2. `feat(tools/extras,plugin-interop,templates): declare outputSchema for read tools` — pure declarative work.
+  Both commits cite `Refs #278`, `Refs #258`. PR body records the locked Option A retrofit decision and lists the three scope-addition tools per the issue's "plus any other read-only entries" clause. **Closes #278.**
+
+### Branch names
+
+- `feat/issue-276-output-schema-search`
+- `feat/issue-277-output-schema-workspace-editor`
+- `feat/issue-278-output-schema-extras-interop-templates-binary`
+
+### Cadence
+
+Strict serial. Open PR 1, wait for user merge; rebase/branch from updated `main` for PR 2; same for PR 3. Matches the campaign plan and project workflow §7.
+
+### Verification gate per PR
+
+Per project workflow §4:
+
+1. `npm test` — all green.
+2. `npm run lint` — clean.
+3. `npm run typecheck` — clean.
+4. `npm run docs:check` — clean.
+
+## 8. Risks and non-issues
+
+- **Type-system churn — none.** PR #279 already typed `outputSchema?: z.ZodRawShape` as optional on `ToolDefinition`; adding more declarations does not propagate type changes anywhere. Confirmed by the framework PR's note ("`npm run typecheck` stays clean across the whole codebase without touching any other tool definition").
+- **Schema drift** — guarded by strict-mode parse tests for 27 of 29 tools. The two passthrough exceptions are documented and tested; their failure mode is "Obsidian internal shape changed in a way the renderer also didn't expect", which is rare and would surface as a renderer crash before the schema becomes visibly wrong.
+- **`vault_read_binary` retrofit blast radius** — minimal. Plain-text rendering stays unchanged; only `response_format: 'json'` callers see the new fields, and they were already getting nothing structured before this PR. The Returns docstring is the only user-visible change.
+
+## 9. Out of scope
+
+- Restructuring `structuredContent` payloads for any tool other than `vault_read_binary` — keep existing shapes, only describe them (per #248's original out-of-scope clause).
+- Write/destructive tools — they emit confirmation lines; `outputSchema` is low-value (covered by #216's exclusion list).
+- Any work on tools registered in modules not named in this design (e.g. UI, if it gains read tools later).

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { ToolModule, ToolDefinition, annotations, defineTool } from '../../registry/types';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { createSearchHandlers } from './handlers';
@@ -8,6 +9,65 @@ import {
   searchByFrontmatterSchema,
   readOnlySchema,
 } from './schemas';
+
+/**
+ * Output schemas for the search tools that emit `structuredContent`. Each
+ * shape mirrors what the corresponding handler in `./handlers.ts` puts on
+ * `result.structuredContent` — declaring them lets modern MCP clients
+ * validate / introspect the typed payload (Batch B of #248).
+ */
+const searchFulltextOutputSchema = {
+  total: z.number().describe('Total number of matched files before pagination.'),
+  count: z.number().describe('Number of matches in this page.'),
+  offset: z.number().describe('Offset of the first item in this page.'),
+  items: z
+    .array(
+      z.object({
+        path: z.string().describe('Vault-relative path of the matching file.'),
+        matches: z
+          .array(z.string())
+          .describe('Lines from the file that contain the query.'),
+      }),
+    )
+    .describe('Matches in this page.'),
+  has_more: z
+    .boolean()
+    .describe('True when more results are available past this page.'),
+  next_offset: z
+    .number()
+    .optional()
+    .describe('Offset to use in the next request when has_more is true.'),
+};
+
+const searchTagsOutputSchema = {
+  tags: z
+    .record(z.string(), z.array(z.string()))
+    .describe('Map of tag (with leading #) to vault-relative file paths that use it.'),
+};
+
+const searchLinksMapOutputSchema = {
+  links: z
+    .record(z.string(), z.record(z.string(), z.number()))
+    .describe('Map of source file path to map of target file path to reference count.'),
+};
+
+const paginatedPathPageOutputSchema = {
+  total: z
+    .number()
+    .describe('Total number of matching files before pagination.'),
+  count: z.number().describe('Number of files in this page.'),
+  offset: z.number().describe('Offset of the first item in this page.'),
+  items: z
+    .array(z.string())
+    .describe('Vault-relative file paths in this page.'),
+  has_more: z
+    .boolean()
+    .describe('True when there are more files past this page.'),
+  next_offset: z
+    .number()
+    .optional()
+    .describe('Offset to use in the next request when has_more is true.'),
+};
 
 export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
   const handlers = createSearchHandlers(adapter);
@@ -31,6 +91,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"Query must not be empty" on empty input.'],
           }, searchFulltextSchema),
           schema: searchFulltextSchema,
+          outputSchema: searchFulltextOutputSchema,
           handler: handlers.searchFulltext,
           annotations: annotations.read,
         }),
@@ -41,6 +102,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: Record<tag, string[]>. Each key is the tag including leading #.',
           }, readOnlySchema),
           schema: readOnlySchema,
+          outputSchema: searchTagsOutputSchema,
           handler: handlers.searchTags,
           annotations: annotations.read,
         }),
@@ -51,6 +113,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: Record<source, Record<target, count>>.',
           }, readOnlySchema),
           schema: readOnlySchema,
+          outputSchema: searchLinksMapOutputSchema,
           handler: handlers.searchResolvedLinks,
           annotations: annotations.read,
         }),
@@ -62,6 +125,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             examples: ['Use when: hunting for broken [[wikilinks]] to clean up.'],
           }, readOnlySchema),
           schema: readOnlySchema,
+          outputSchema: searchLinksMapOutputSchema,
           handler: handlers.searchUnresolvedLinks,
           annotations: annotations.read,
         }),
@@ -73,6 +137,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: string[] of vault-relative file paths.',
           }, searchByTagSchema),
           schema: searchByTagSchema,
+          outputSchema: paginatedPathPageOutputSchema,
           handler: handlers.searchByTag,
           annotations: annotations.read,
         }),
@@ -88,6 +153,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             examples: ['Use when: "find all notes where status == done".'],
           }, searchByFrontmatterSchema),
           schema: searchByFrontmatterSchema,
+          outputSchema: paginatedPathPageOutputSchema,
           handler: handlers.searchByFrontmatter,
           annotations: annotations.read,
         }),

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -81,6 +81,77 @@ const listRecursiveOutputSchema = {
     .describe('Offset to use in the next request when has_more is true.'),
 };
 
+/**
+ * Output schemas for the `vault_get_*` single-path getters. These tools were
+ * renamed from `search_get_*` by #255 and use search handlers, but they live
+ * in the vault module today and so their `outputSchema` declarations live
+ * alongside the rest of the vault read schemas (Batch B of #248).
+ */
+const getFrontmatterOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  frontmatter: z
+    .record(z.string(), z.unknown())
+    .describe('Parsed YAML frontmatter object, or {} when absent.'),
+};
+
+const getHeadingsOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  headings: z
+    .array(
+      z.object({
+        heading: z.string().describe('Heading text.'),
+        level: z.number().describe('Heading level (1..6).'),
+      }),
+    )
+    .describe('Headings in document order.'),
+};
+
+const getOutgoingLinksOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  links: z
+    .array(
+      z.object({
+        link: z.string().describe('Link target.'),
+        displayText: z
+          .string()
+          .optional()
+          .describe('Optional alias used in [[link|alias]] notation.'),
+      }),
+    )
+    .describe('Outgoing links from this file.'),
+};
+
+const getEmbedsOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  embeds: z
+    .array(
+      z.object({
+        link: z.string().describe('Embed target.'),
+        displayText: z.string().optional().describe('Optional alias.'),
+      }),
+    )
+    .describe('Embeds (![[...]]) referenced by this file.'),
+};
+
+const getBacklinksOutputSchema = {
+  path: z.string().describe('Target path that was queried.'),
+  backlinks: z
+    .array(z.string())
+    .describe('Vault-relative paths of files that link TO the target.'),
+};
+
+const getBlockReferencesOutputSchema = {
+  path: z.string().describe('Vault-relative path that was inspected.'),
+  blockRefs: z
+    .array(
+      z.object({
+        id: z.string().describe('Block-reference id (without the leading ^).'),
+        line: z.string().describe('The line of text the block-reference is on.'),
+      }),
+    )
+    .describe('Block references defined in this file.'),
+};
+
 export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
   const mutex = new WriteMutex();
   const handlers = createHandlers(adapter, mutex);
@@ -367,6 +438,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getFrontmatterOutputSchema,
           handler: searchHandlers.searchFrontmatter,
           annotations: annotations.read,
         }),
@@ -379,6 +451,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getHeadingsOutputSchema,
           handler: searchHandlers.searchHeadings,
           annotations: annotations.read,
         }),
@@ -391,6 +464,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getOutgoingLinksOutputSchema,
           handler: searchHandlers.searchOutgoingLinks,
           annotations: annotations.read,
         }),
@@ -403,6 +477,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getEmbedsOutputSchema,
           handler: searchHandlers.searchEmbeds,
           annotations: annotations.read,
         }),
@@ -415,6 +490,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getBacklinksOutputSchema,
           handler: searchHandlers.searchBacklinks,
           annotations: annotations.read,
         }),
@@ -427,6 +503,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             errors: ['"File not found" if the path does not exist.'],
           }, searchFilePathSchema),
           schema: searchFilePathSchema,
+          outputSchema: getBlockReferencesOutputSchema,
           handler: searchHandlers.searchBlockReferences,
           annotations: annotations.read,
         }),

--- a/tests/tools/search/search.test.ts
+++ b/tests/tools/search/search.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
 import { createSearchHandlers, type SearchHandlers } from '../../../src/tools/search/handlers';
@@ -320,5 +321,185 @@ describe('search tool descriptions document shared args', () => {
       expect(desc).not.toContain('limit (integer');
       expect(desc).not.toContain('offset (integer');
     }
+  });
+});
+
+/**
+ * Batch B of #248: every search tool that emits `structuredContent` must
+ * declare an `outputSchema`, and that schema must accurately describe the
+ * payload the handler produces. Strict-mode parsing catches drift between
+ * the markdown renderer and the structured payload.
+ */
+describe('search read tools — outputSchema declarations', () => {
+  function getStructured(
+    tool: { outputSchema?: z.ZodRawShape },
+  ): z.ZodObject<z.ZodRawShape> {
+    if (!tool.outputSchema) {
+      throw new Error('expected outputSchema to be declared');
+    }
+    return z.object(tool.outputSchema).strict();
+  }
+
+  function findTool(
+    name: string,
+  ): { name: string; outputSchema?: z.ZodRawShape } {
+    const adapter = new MockObsidianAdapter();
+    const module = createSearchModule(adapter);
+    const tool = module.tools().find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found`);
+    return tool;
+  }
+
+  it('search_fulltext declares outputSchema and parses with has_more=false', async () => {
+    const tool = findTool('search_fulltext');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', 'Hello World');
+    adapter.addFile('b.md', 'Goodbye World');
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFulltext({
+      query: 'World',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(2);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_offset).toBeUndefined();
+    expect(parsed.items).toHaveLength(2);
+  });
+
+  it('search_fulltext parses with has_more=true and next_offset', async () => {
+    const tool = findTool('search_fulltext');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    for (let i = 0; i < 5; i++) {
+      adapter.addFile(`f-${String(i)}.md`, 'World');
+    }
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFulltext({
+      query: 'World',
+      limit: 2,
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(5);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
+  });
+
+  it('search_tags declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_tags');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { tags: ['#project'] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchTags({ response_format: 'json' });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.tags).toEqual({ '#project': ['a.md'] });
+  });
+
+  it('search_resolved_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_resolved_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.addFile('b.md', '');
+    adapter.setMetadata('a.md', { links: [{ link: 'b' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchResolvedLinks({
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.links).toEqual({ 'a.md': { 'b.md': 1 } });
+  });
+
+  it('search_unresolved_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_unresolved_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { links: [{ link: 'missing' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchUnresolvedLinks({
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.links).toEqual({ 'a.md': { missing: 1 } });
+  });
+
+  it('search_by_tag declares outputSchema and parses with has_more=false', async () => {
+    const tool = findTool('search_by_tag');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { tags: ['#project'] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByTag({
+      tag: 'project',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(1);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_offset).toBeUndefined();
+    expect(parsed.items).toEqual(['a.md']);
+  });
+
+  it('search_by_tag parses with has_more=true and next_offset', async () => {
+    const tool = findTool('search_by_tag');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    for (let i = 0; i < 5; i++) {
+      adapter.addFile(`f-${String(i)}.md`, '');
+      adapter.setMetadata(`f-${String(i)}.md`, { tags: ['#project'] });
+    }
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByTag({
+      tag: 'project',
+      limit: 2,
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(5);
+    expect(parsed.count).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
+  });
+
+  it('search_by_frontmatter declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('search_by_frontmatter');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', { frontmatter: { status: 'done' } });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchByFrontmatter({
+      key: 'status',
+      value: 'done',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.total).toBe(1);
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.items).toEqual(['a.md']);
   });
 });

--- a/tests/tools/vault/module.test.ts
+++ b/tests/tools/vault/module.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { MockObsidianAdapter } from '../../../src/obsidian/mock-adapter';
 import { createVaultModule } from '../../../src/tools/vault/index';
 import { createHandlers, WriteMutex } from '../../../src/tools/vault/handlers';
+import { createSearchHandlers } from '../../../src/tools/search/handlers';
 
 describe('vault module', () => {
   it('should have correct metadata', () => {
@@ -198,6 +199,130 @@ describe('vault read tools — outputSchema declarations', () => {
     // future change cannot silently add one without re-checking that the
     // handler also emits a matching structuredContent slot.
     expect(tool.outputSchema).toBeUndefined();
+  });
+
+  it('vault_get_frontmatter declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_frontmatter');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', '');
+    adapter.setMetadata('note.md', { frontmatter: { status: 'done', tags: ['x'] } });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchFrontmatter({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('note.md');
+    expect(parsed.frontmatter).toEqual({ status: 'done', tags: ['x'] });
+  });
+
+  it('vault_get_headings declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_headings');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', '');
+    adapter.setMetadata('note.md', {
+      headings: [
+        { heading: 'Top', level: 1 },
+        { heading: 'Sub', level: 2 },
+      ],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchHeadings({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.headings).toEqual([
+      { heading: 'Top', level: 1 },
+      { heading: 'Sub', level: 2 },
+    ]);
+  });
+
+  it('vault_get_outgoing_links declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_outgoing_links');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', {
+      links: [{ link: 'b', displayText: 'Bee' }, { link: 'c' }],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchOutgoingLinks({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('a.md');
+    expect(parsed.links).toEqual([
+      { link: 'b', displayText: 'Bee' },
+      { link: 'c' },
+    ]);
+  });
+
+  it('vault_get_embeds declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_embeds');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.setMetadata('a.md', {
+      embeds: [{ link: 'image.png' }],
+    });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchEmbeds({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.embeds).toEqual([{ link: 'image.png' }]);
+  });
+
+  it('vault_get_backlinks declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_backlinks');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('a.md', '');
+    adapter.addFile('b.md', '');
+    adapter.setMetadata('b.md', { links: [{ link: 'a' }] });
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchBacklinks({
+      path: 'a.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('a.md');
+    expect(parsed.backlinks).toEqual(['b.md']);
+  });
+
+  it('vault_get_block_references declares outputSchema and parses against handler output', async () => {
+    const tool = findTool('vault_get_block_references');
+    const schema = getStructured(tool);
+
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('note.md', 'A line ^anchor-1\nAnother ^anchor-2\n');
+    const handlers = createSearchHandlers(adapter);
+
+    const result = await handlers.searchBlockReferences({
+      path: 'note.md',
+      response_format: 'json',
+    });
+    const parsed = schema.parse(result.structuredContent);
+    expect(parsed.path).toBe('note.md');
+    expect(parsed.blockRefs).toEqual([
+      { id: 'anchor-1', line: 'A line ^anchor-1' },
+      { id: 'anchor-2', line: 'Another ^anchor-2' },
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #276

## Summary

- Declare `outputSchema` on the six search tools that emit `structuredContent` (`search_fulltext`, `search_tags`, `search_resolved_links`, `search_unresolved_links`, `search_by_tag`, `search_by_frontmatter`).
- Declare `outputSchema` on the six `vault_get_*` getters renamed from `search_get_*` by #255 (`vault_get_frontmatter`, `vault_get_headings`, `vault_get_outgoing_links`, `vault_get_embeds`, `vault_get_backlinks`, `vault_get_block_references`).
- Strict-mode (`z.object(shape).strict().parse(...)`) parse tests pin every shape against the matching handler output, mirroring the framework PR (#279).

## Cross-module split

The issue's "add the declaration to \`src/tools/search/index.ts\`" wording predates the #255 rename. After #255, the \`vault_get_*\` getters live in \`src/tools/vault/index.ts\` (using search handlers) — so this PR splits the schema declarations across both files to match the actual tool-registration sites:

- Tools registered in \`src/tools/search/index.ts\` → schemas in that file, tests in \`tests/tools/search/search.test.ts\`.
- \`vault_get_*\` getters registered in \`src/tools/vault/index.ts\` → schemas in that file, tests added to the existing \`vault read tools — outputSchema declarations\` describe block in \`tests/tools/vault/module.test.ts\`.

## Test plan

- [x] \`npm test\` — 607 / 607 passing (was 593 baseline; +14 new strict-mode parse tests covering all 12 in-scope tools, with \`has_more=true\`/\`false\` cases for the paginated ones).
- [x] \`npm run lint\` — clean.
- [x] \`npm run typecheck\` — clean.
- [x] \`npm run docs:check\` — clean (no diff: the generator only lists tool names, no new tools or renames in this PR).

## Refs

- Builds on #248 / PR #279 (framework + Batch A).
- Tracker: #258.
- Followups: #277 (Batch C — workspace + editor read), #278 (Batch D — extras + plugin-interop + templates + \`vault_read_binary\` retrofit).