### PR TITLE
feat(tools): add title annotation to all tools and add sibling cross-refs

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -195,11 +195,11 @@ There is also an **Extras** group for utility tools that don't mirror an
 Obsidian API. Extras are toggled **per tool**, not per module, and are off by
 default. Today this contains:
 
-- `extras_get_date` — returns the current local time as ISO-8601 with offset.
+- `extras_get_date` (Get current date) — returns the current local time as ISO-8601 with offset.
 
 ### Execute Command Allowlist
 
-The `plugin_execute_command` tool in Plugin Interop can run any Obsidian
+The `plugin_execute_command` (Execute command) tool in Plugin Interop can run any Obsidian
 command — including destructive ones (e.g. `app:delete-file`). By default
 the allowlist is empty, which means the tool refuses every call with a
 clear error. To enable specific commands, add their ids (one per line) to
@@ -356,7 +356,7 @@ again retries the start.
 
 - The module that ships the tool is disabled. Enable it under **Feature
   Modules**.
-- For Extras tools (e.g. `extras_get_date`), the per-tool toggle is off by default.
+- For Extras tools (e.g. `extras_get_date` (Get current date)), the per-tool toggle is off by default.
 - The client cached the previous `tools/list` response. Reconnect.
 
 ### How do I expose the server to another machine on my LAN?

--- a/docs/superpowers/plans/2026-05-03-tool-titles-and-sibling-cross-refs.md
+++ b/docs/superpowers/plans/2026-05-03-tool-titles-and-sibling-cross-refs.md
@@ -1,0 +1,1214 @@
+# Tool titles and sibling cross-references — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Backfill the missing `title` annotation on all 54 tools and add structured `seeAlso` cross-references between documented sibling pairs, per spec [`docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md`](../specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md).
+
+**Architecture:** Add a required top-level `title: string` field on `ToolDefinition`; forward it to **both** `Tool.title` and `ToolAnnotations.title` at registration time. Add a `seeAlso?: string[]` slot to `describeTool` rendered as a `See also:` block. Register the title via a single source of truth in tool definitions; never duplicate.
+
+**Tech Stack:** TypeScript, Zod, vitest, MCP TS SDK (`@modelcontextprotocol/sdk`), tsx for the docs generator script.
+
+**Issue:** [#289](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/289)
+**Branch:** `feat/issue-289-tool-titles-and-sibling-cross-refs` (already created — verify `git rev-parse --abbrev-ref HEAD` returns this).
+
+**Title catalogue and sibling pairs are defined in the spec — refer to that doc when filling in titles in tasks 4–10 and `seeAlso` blocks in tasks 11–14.**
+
+**Sequencing rationale:** the type change to `ToolDefinition` flips compile-time errors on every `defineTool` call site at once. We add `title` as **optional** first, backfill all 54 tools, then flip to **required** in one commit. This keeps every intermediate commit green for `tsc`.
+
+---
+
+## Task 1: Plumbing — add optional `title` field, forward at registration
+
+**Files:**
+- Modify: `src/registry/types.ts:30-48` (interface), `src/registry/types.ts:65-69` (defineTool)
+- Modify: `src/server/mcp-server.ts:88-97` (registerTool call)
+- Test: `tests/server/mcp-server.test.ts` (new test case in the existing describe block)
+
+- [ ] **Step 1: Write the failing test in `tests/server/mcp-server.test.ts`**
+
+Add a new `it` block inside the existing `describe('createMcpServer', …)` that captures the `registerTool` config calls (the test already has a `capturedRegisterToolCalls` mechanism — reuse it):
+
+```typescript
+it('forwards tool.title to both Tool.title and annotations.title', async () => {
+  const { ModuleRegistry } = await import('../../src/registry/module-registry');
+  const { createMcpServer } = await import('../../src/server/mcp-server');
+
+  const titledTool = {
+    name: 'titled',
+    title: 'Pretty title',
+    description: 'has title',
+    schema: { foo: z.string() },
+    handler: () =>
+      Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    annotations: annotations.read,
+  } as unknown as ToolDefinition;
+
+  const stubModule: ToolModule = {
+    metadata: { id: 'stub', name: 'Stub', description: 'test' },
+    tools: () => [titledTool],
+  };
+
+  const registry = new ModuleRegistry(makeLogger());
+  registry.registerModule(stubModule);
+  createMcpServer(registry, makeLogger());
+
+  const call = capturedRegisterToolCalls.find((c) => c.name === 'titled');
+  expect(call).toBeDefined();
+  expect(call?.config.title).toBe('Pretty title');
+  expect(call?.config.annotations?.title).toBe('Pretty title');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+npx vitest run tests/server/mcp-server.test.ts -t 'forwards tool.title'
+```
+
+Expected: FAIL — `call?.config.title` is `undefined` (forwarding code not yet present); also `tool.title` does not exist on `ToolDefinition`.
+
+- [ ] **Step 3: Add the optional `title` field to `ToolDefinition`**
+
+In `src/registry/types.ts`, change the interface (at lines 30-48):
+
+```typescript
+export interface ToolDefinition<
+  Shape extends z.ZodRawShape = z.ZodRawShape,
+> {
+  name: string;
+  /**
+   * Human-readable title used by hosts in confirmation / auto-approve UI.
+   * Sentence case, no module prefix, ≤40 characters. See spec
+   * `docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md`.
+   *
+   * Marked optional during the backfill rollout (#289). Will become required
+   * once every defineTool call site has been updated.
+   */
+  title?: string;
+  description: string;
+  schema: Shape;
+  outputSchema?: z.ZodRawShape;
+  handler: TypedHandler<Shape>;
+  annotations: ToolAnnotations;
+}
+```
+
+- [ ] **Step 4: Forward `title` to both slots in `src/server/mcp-server.ts`**
+
+Replace the `server.registerTool` call (currently lines 88-97):
+
+```typescript
+server.registerTool(
+  tool.name,
+  {
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.schema,
+    outputSchema: tool.outputSchema,
+    annotations: tool.title
+      ? { ...tool.annotations, title: tool.title }
+      : tool.annotations,
+  },
+  createToolDispatcher(tool, logger),
+);
+```
+
+(The conditional spread keeps `annotations` referentially identical when `title` is absent — preserves a property the existing tests assert.)
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+```
+npx vitest run tests/server/mcp-server.test.ts -t 'forwards tool.title'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full mcp-server suite to confirm no regression**
+
+```
+npx vitest run tests/server/mcp-server.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/registry/types.ts src/server/mcp-server.ts tests/server/mcp-server.test.ts
+git commit -m "feat(registry): add optional title field and forward to both spec slots
+
+Refs #289"
+```
+
+---
+
+## Task 2: Plumbing — add `seeAlso` section to `describeTool`
+
+**Files:**
+- Modify: `src/tools/shared/describe.ts:33-39` (interface), `src/tools/shared/describe.ts:55-106` (renderer)
+- Test: `tests/tools/shared/describe.test.ts` (new cases)
+
+- [ ] **Step 1: Write the failing test cases**
+
+Append to `tests/tools/shared/describe.test.ts` inside the existing `describe('describeTool', …)`:
+
+```typescript
+it('renders a See also section when seeAlso entries are supplied', () => {
+  const out = describeTool({
+    summary: 'Read a thing.',
+    seeAlso: [
+      'other_tool — when you want the other variant.',
+    ],
+  });
+  expect(out).toContain('See also:');
+  expect(out).toContain('  - other_tool — when you want the other variant.');
+});
+
+it('places See also between Examples and Errors', () => {
+  const out = describeTool({
+    summary: 'Read.',
+    examples: ['Use when: testing.'],
+    seeAlso: ['other_tool — alternative.'],
+    errors: ['"boom" on failure.'],
+  });
+  const examplesIdx = out.indexOf('Examples:');
+  const seeAlsoIdx = out.indexOf('See also:');
+  const errorsIdx = out.indexOf('Errors:');
+  expect(examplesIdx).toBeGreaterThan(0);
+  expect(seeAlsoIdx).toBeGreaterThan(examplesIdx);
+  expect(errorsIdx).toBeGreaterThan(seeAlsoIdx);
+});
+
+it('omits See also when no seeAlso entries are supplied', () => {
+  const out = describeTool({ summary: 'Read.' });
+  expect(out).not.toContain('See also:');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npx vitest run tests/tools/shared/describe.test.ts -t 'See also'
+```
+
+Expected: FAIL — `seeAlso` is not on the type yet, and the helper does not render it.
+
+- [ ] **Step 3: Add `seeAlso` to the `ToolDoc` interface**
+
+In `src/tools/shared/describe.ts`, update the interface (lines 33-39):
+
+```typescript
+export interface ToolDoc {
+  summary: string;
+  args?: string[];
+  returns?: string;
+  examples?: string[];
+  seeAlso?: string[];
+  errors?: string[];
+}
+```
+
+- [ ] **Step 4: Render the `See also:` block**
+
+In the same file, immediately after the `Examples:` rendering block (currently around lines 95-98) and before the `Errors:` block (lines 100-103), insert:
+
+```typescript
+if (doc.seeAlso && doc.seeAlso.length > 0) {
+  lines.push('', 'See also:');
+  for (const s of doc.seeAlso) lines.push(`  - ${s}`);
+}
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+```
+npx vitest run tests/tools/shared/describe.test.ts
+```
+
+Expected: all PASS (the new cases plus all 9 existing ones).
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/tools/shared/describe.ts tests/tools/shared/describe.test.ts
+git commit -m "feat(tools/shared): add seeAlso section to describeTool
+
+Refs #289"
+```
+
+---
+
+## Task 3: Registry test — title presence, length cap, uniqueness
+
+**Files:**
+- Create: `tests/registry/tool-titles.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+Write `tests/registry/tool-titles.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { discoverModules } from '../../src/tools';
+import type { ToolDefinition } from '../../src/registry/types';
+
+function allTools(): ToolDefinition[] {
+  const adapter = new MockObsidianAdapter();
+  return discoverModules(adapter).flatMap((m) => m.tools());
+}
+
+describe('tool titles', () => {
+  it('every tool has a non-empty title (after trim)', () => {
+    const missing = allTools()
+      .filter((t) => !t.title || t.title.trim().length === 0)
+      .map((t) => t.name);
+    expect(missing).toEqual([]);
+  });
+
+  it('every title is at most 40 characters', () => {
+    const tooLong = allTools()
+      .filter((t) => (t.title ?? '').length > 40)
+      .map((t) => `${t.name}: "${t.title ?? ''}" (${String((t.title ?? '').length)} chars)`);
+    expect(tooLong).toEqual([]);
+  });
+
+  it('titles are unique across the registry', () => {
+    const tools = allTools();
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+    for (const t of tools) {
+      const title = t.title ?? '';
+      const prior = seen.get(title);
+      if (prior !== undefined) {
+        duplicates.push(`${prior} and ${t.name} share title "${title}"`);
+      } else {
+        seen.set(title, t.name);
+      }
+    }
+    expect(duplicates).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect ALL three to fail**
+
+```
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+Expected: FAIL on the non-empty assertion (54 missing titles); the length and uniqueness tests will spuriously pass since `''` is short and unique-empty-strings are deduped to one entry. That's fine — they will become load-bearing as titles get filled in.
+
+- [ ] **Step 3: Commit the failing test**
+
+```
+git add tests/registry/tool-titles.test.ts
+git commit -m "test(registry): assert every tool has a non-empty unique title ≤40 chars
+
+Test fails until the title backfill across modules is complete (#289).
+
+Refs #289"
+```
+
+---
+
+## Task 4: Backfill titles — vault module
+
+**Files:**
+- Modify: `src/tools/vault/index.ts` (22 `defineTool` call sites)
+
+For every `defineTool({ name: 'vault_*', ...})` block, add a `title: '<value>'` line directly after `name`. Use the catalogue from the spec — copied here for convenience (do not deviate):
+
+| Name | Title |
+|---|---|
+| `vault_create` | Create file |
+| `vault_read` | Read file |
+| `vault_update` | Replace file content |
+| `vault_delete` | Delete file |
+| `vault_append` | Append to file |
+| `vault_get_metadata` | Get file metadata |
+| `vault_rename` | Rename file |
+| `vault_move` | Move file |
+| `vault_copy` | Copy file |
+| `vault_create_folder` | Create folder |
+| `vault_delete_folder` | Delete folder |
+| `vault_rename_folder` | Rename folder |
+| `vault_list` | List folder |
+| `vault_list_recursive` | List folder (recursive) |
+| `vault_read_binary` | Read binary file |
+| `vault_write_binary` | Write binary file |
+| `vault_get_frontmatter` | Get frontmatter |
+| `vault_get_headings` | Get headings |
+| `vault_get_outgoing_links` | Get outgoing links |
+| `vault_get_embeds` | Get embeds |
+| `vault_get_backlinks` | Get backlinks |
+| `vault_get_block_references` | Get block references |
+
+Pattern (example):
+
+```typescript
+defineTool({
+  name: 'vault_create',
+  title: 'Create file',
+  description: describeTool({ … }),
+  schema: createFileSchema,
+  handler: handlers.createFile,
+  annotations: annotations.additive,
+}),
+```
+
+- [ ] **Step 1: Add the title to all 22 `vault_*` definitions in `src/tools/vault/index.ts`**
+
+- [ ] **Step 2: Run typecheck and the registry test**
+
+```
+npm run typecheck
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+Expected: typecheck PASS; the registry test still FAILS (32 tools across other modules still untitled), but the failure list should now be exactly those 32 names — verify `vault_*` names are absent from the failure output.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/tools/vault/index.ts
+git commit -m "feat(tools/vault): add title annotation to every vault tool
+
+Refs #289"
+```
+
+---
+
+## Task 5: Backfill titles — editor module
+
+**Files:**
+- Modify: `src/tools/editor/index.ts` (10 `defineTool` call sites)
+
+| Name | Title |
+|---|---|
+| `editor_get_content` | Get active file content |
+| `editor_get_active_file` | Get active file path |
+| `editor_insert` | Insert at cursor |
+| `editor_replace` | Replace range |
+| `editor_delete` | Delete range |
+| `editor_get_cursor` | Get cursor position |
+| `editor_set_cursor` | Set cursor position |
+| `editor_get_selection` | Get selection |
+| `editor_set_selection` | Set selection |
+| `editor_get_line_count` | Get line count |
+
+- [ ] **Step 1: Add titles**
+
+- [ ] **Step 2: Verify**
+
+```
+npm run typecheck
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+Expected: typecheck PASS; failure list shrinks by 10.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/tools/editor/index.ts
+git commit -m "feat(tools/editor): add title annotation to every editor tool
+
+Refs #289"
+```
+
+---
+
+## Task 6: Backfill titles — search module
+
+**Files:**
+- Modify: `src/tools/search/index.ts` (6 `defineTool` call sites)
+
+| Name | Title |
+|---|---|
+| `search_fulltext` | Full-text search |
+| `search_tags` | List tags |
+| `search_resolved_links` | Find resolved links |
+| `search_unresolved_links` | Find unresolved links |
+| `search_by_tag` | Find notes by tag |
+| `search_by_frontmatter` | Find notes by frontmatter |
+
+- [ ] **Step 1: Add titles**
+
+- [ ] **Step 2: Verify**
+
+```
+npm run typecheck
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/tools/search/index.ts
+git commit -m "feat(tools/search): add title annotation to every search tool
+
+Refs #289"
+```
+
+---
+
+## Task 7: Backfill titles — workspace module
+
+**Files:**
+- Modify: `src/tools/workspace/index.ts` (5 `defineTool` call sites)
+
+| Name | Title |
+|---|---|
+| `workspace_get_active_leaf` | Get active leaf |
+| `workspace_open_file` | Open file in workspace |
+| `workspace_list_leaves` | List open leaves |
+| `workspace_set_active_leaf` | Set active leaf |
+| `workspace_get_layout` | Get workspace layout |
+
+- [ ] **Step 1: Add titles**
+
+- [ ] **Step 2: Verify**
+
+```
+npm run typecheck
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/tools/workspace/index.ts
+git commit -m "feat(tools/workspace): add title annotation to every workspace tool
+
+Refs #289"
+```
+
+---
+
+## Task 8: Backfill titles — ui, templates, plugin-interop, extras
+
+**Files:**
+- Modify: `src/tools/ui/index.ts` (1 site)
+- Modify: `src/tools/templates/index.ts` (3 sites)
+- Modify: `src/tools/plugin-interop/index.ts` (6 sites)
+- Modify: `src/tools/extras/index.ts` (1 site)
+
+| Name | Title |
+|---|---|
+| `ui_notice` | Show notice |
+| `template_list` | List templates |
+| `template_create_from` | Create file from template |
+| `template_expand` | Expand template inline |
+| `plugin_list` | List plugins |
+| `plugin_check` | Check plugin enabled |
+| `plugin_dataview_query` | Run Dataview query |
+| `plugin_dataview_describe_js_query` | Describe Dataview JS query |
+| `plugin_templater_describe_template` | Describe Templater template |
+| `plugin_execute_command` | Execute command |
+| `extras_get_date` | Get current date |
+
+- [ ] **Step 1: Add titles to all four files**
+
+- [ ] **Step 2: Verify the registry test now PASSES**
+
+```
+npm run typecheck
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+Expected: all three test cases PASS — non-empty, ≤40 chars, unique.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/tools/ui/index.ts src/tools/templates/index.ts src/tools/plugin-interop/index.ts src/tools/extras/index.ts
+git commit -m "feat(tools): add title annotation to remaining modules
+
+Completes the title backfill from #289 across ui, templates, plugin-interop,
+and extras modules — every active tool now ships a non-empty title.
+
+Refs #289"
+```
+
+---
+
+## Task 9: Flip `title` from optional to required + fix test fixtures
+
+With every `defineTool` call site carrying a title, we can promote `title` from optional to required so future tools fail at compile time without one.
+
+**Files:**
+- Modify: `src/registry/types.ts` (interface)
+- Modify: `tests/registry/module-registry.test.ts:15-26` (`createMockTool`)
+- Modify: `tests/server/mcp-server.test.ts:100-117` (the two inline ToolDefinition stubs)
+
+The `tests/server/dispatcher.test.ts` `makeTool` returns a plain object with `Partial<ToolDefinition>` overrides spread; once `title` is required, the default object literal must include it. Update that file too.
+
+- [ ] **Step 1: Change `title?:` to `title:` in `src/registry/types.ts`**
+
+Update the interface (the field added in Task 1, around line 36):
+
+```typescript
+/**
+ * Human-readable title used by hosts in confirmation / auto-approve UI.
+ * Sentence case, no module prefix, ≤40 characters. See spec
+ * `docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md`.
+ */
+title: string;
+```
+
+Remove the rollout-phase note from the JSDoc.
+
+- [ ] **Step 2: Run typecheck — expect fixture failures**
+
+```
+npm run typecheck
+```
+
+Expected: FAIL with errors in `tests/registry/module-registry.test.ts` (the `createMockTool` factory no longer satisfies `ToolDefinition`) and in `tests/server/mcp-server.test.ts` (the two `as unknown as ToolDefinition` casts still compile, but TypeScript may flag inconsistencies depending on strictness — note any errors and fix). `tests/server/dispatcher.test.ts:makeTool` returns `ToolDefinition` directly so it will fail.
+
+- [ ] **Step 3: Update `tests/registry/module-registry.test.ts:createMockTool`**
+
+```typescript
+function createMockTool(name: string, readOnly: boolean): ToolDefinition {
+  return {
+    name,
+    title: `Mock ${name}`,
+    description: `Mock tool: ${name}`,
+    schema: {},
+    handler: (): Promise<CallToolResult> =>
+      Promise.resolve({
+        content: [{ type: 'text' as const, text: 'ok' }],
+      }),
+    annotations: readOnly ? annPresets.read : annPresets.destructive,
+  };
+}
+```
+
+- [ ] **Step 4: Update `tests/server/dispatcher.test.ts:makeTool`**
+
+In the default object (around line 15) add:
+
+```typescript
+return {
+  name: 'demo_tool',
+  title: 'Demo tool',
+  description: 'Demo tool for the dispatcher tests',
+  …
+};
+```
+
+- [ ] **Step 5: Update `tests/server/mcp-server.test.ts`**
+
+Add `title: 'tool with output'` to the `toolWithOutputSchema` literal (around line 100), `title: 'tool without output'` to `toolWithoutOutputSchema` (around line 110), and `title: 'test tool'` to the second `makeTool` (around line 167) inside `describe('createToolDispatcher', …)`.
+
+- [ ] **Step 6: Run typecheck and the full test suite**
+
+```
+npm run typecheck
+npm test
+```
+
+Expected: typecheck PASS; all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/registry/types.ts tests/registry/module-registry.test.ts tests/server/dispatcher.test.ts tests/server/mcp-server.test.ts
+git commit -m "feat(registry)!: make title required on ToolDefinition
+
+Now that every defineTool call site carries a title, promote the field to
+required so a future tool added without a title fails at compile time.
+
+Test fixtures that hand-construct ToolDefinition values updated accordingly.
+
+Refs #289"
+```
+
+(Conventional Commits: `!` because the public `ToolDefinition` interface gains a required field — strict semver-MAJOR. Same scope token as the type lives in.)
+
+---
+
+## Task 10: Sibling cross-references — issue-scope pairs
+
+**Files:**
+- Modify: `src/tools/vault/index.ts` (`vault_read`, `vault_list`, `vault_list_recursive`, `vault_get_metadata`)
+- Modify: `src/tools/editor/index.ts` (`editor_get_content`)
+- Modify: `src/tools/search/index.ts` (`search_resolved_links`, `search_unresolved_links`)
+- Modify: `src/tools/extras/index.ts` (`extras_get_date`)
+
+Each pair is symmetric — both sides add a `seeAlso` entry naming the other tool.
+
+- [ ] **Step 1: `editor_get_content` ↔ `vault_read`**
+
+In `src/tools/editor/index.ts` for `editor_get_content`, add to the `describeTool` call:
+
+```typescript
+seeAlso: [
+  'vault_read — when reading any file by path, not just the active one.',
+],
+```
+
+In `src/tools/vault/index.ts` for `vault_read`, add:
+
+```typescript
+seeAlso: [
+  'editor_get_content — when reading the file currently open in the editor (no path needed).',
+],
+```
+
+- [ ] **Step 2: `vault_list` ↔ `vault_list_recursive`**
+
+In `src/tools/vault/index.ts` for `vault_list`:
+
+```typescript
+seeAlso: [
+  'vault_list_recursive — when you also need files in subfolders.',
+],
+```
+
+For `vault_list_recursive`:
+
+```typescript
+seeAlso: [
+  'vault_list — when you only need direct children of one folder.',
+],
+```
+
+- [ ] **Step 3: `search_resolved_links` ↔ `search_unresolved_links`**
+
+In `src/tools/search/index.ts` for `search_resolved_links`:
+
+```typescript
+seeAlso: [
+  'search_unresolved_links — when you want broken/dangling links instead.',
+],
+```
+
+For `search_unresolved_links`:
+
+```typescript
+seeAlso: [
+  'search_resolved_links — when you want only links that successfully resolve.',
+],
+```
+
+- [ ] **Step 4: `extras_get_date` ↔ `vault_get_metadata`**
+
+In `src/tools/extras/index.ts` for `extras_get_date`:
+
+```typescript
+seeAlso: [
+  'vault_get_metadata — when you need a file\'s modified/created timestamp, not today\'s date.',
+],
+```
+
+In `src/tools/vault/index.ts` for `vault_get_metadata`:
+
+```typescript
+seeAlso: [
+  'extras_get_date — when you need the current date in a specific format, not a file\'s timestamp.',
+],
+```
+
+- [ ] **Step 5: Run typecheck and the full suite**
+
+```
+npm run typecheck
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/tools/vault/index.ts src/tools/editor/index.ts src/tools/search/index.ts src/tools/extras/index.ts
+git commit -m "feat(tools): cross-reference siblings called out in #289
+
+Adds symmetric seeAlso entries between four documented sibling pairs so
+Claude's description sees both sides of the choice.
+
+Refs #289"
+```
+
+---
+
+## Task 11: Sibling cross-references — in-scope expansion (editor triple, search_tags ↔ search_by_tag)
+
+**Files:**
+- Modify: `src/tools/editor/index.ts` (`editor_insert`, `editor_replace`, `editor_delete`)
+- Modify: `src/tools/search/index.ts` (`search_tags`, `search_by_tag`)
+
+- [ ] **Step 1: `editor_insert` / `editor_replace` / `editor_delete` triple — each lists the other two**
+
+In `src/tools/editor/index.ts` for `editor_insert`:
+
+```typescript
+seeAlso: [
+  'editor_replace — when you want to overwrite an existing range, not insert at a point.',
+  'editor_delete — when you want to remove a range without writing anything in its place.',
+],
+```
+
+For `editor_replace`:
+
+```typescript
+seeAlso: [
+  'editor_insert — when you want to add text at a single point without overwriting anything.',
+  'editor_delete — when you want to remove a range without writing anything in its place.',
+],
+```
+
+For `editor_delete`:
+
+```typescript
+seeAlso: [
+  'editor_insert — when you want to add text at a single point without overwriting anything.',
+  'editor_replace — when you want to overwrite an existing range, not just remove it.',
+],
+```
+
+- [ ] **Step 2: `search_tags` ↔ `search_by_tag`**
+
+In `src/tools/search/index.ts` for `search_tags`:
+
+```typescript
+seeAlso: [
+  'search_by_tag — when you want notes carrying a tag, not the list of tags.',
+],
+```
+
+For `search_by_tag`:
+
+```typescript
+seeAlso: [
+  'search_tags — when you want the list of tags in the vault, not notes.',
+],
+```
+
+- [ ] **Step 3: Run typecheck and the suite**
+
+```
+npm run typecheck
+npm test
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/tools/editor/index.ts src/tools/search/index.ts
+git commit -m "feat(tools): cross-reference editor triple and search tag siblings
+
+Expanded sibling-disambiguation scope of #289 with confusable cases noticed
+during review: editor_insert/replace/delete and search_tags/search_by_tag.
+
+Refs #289"
+```
+
+---
+
+## Task 12: Sibling-symmetry registry test
+
+**Files:**
+- Modify: `tests/registry/tool-titles.test.ts` (append the symmetry block)
+
+- [ ] **Step 1: Append the symmetry test cases**
+
+Add to the existing `describe('tool titles', …)` block in `tests/registry/tool-titles.test.ts`:
+
+```typescript
+const SIBLING_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['editor_get_content', 'vault_read'],
+  ['vault_list', 'vault_list_recursive'],
+  ['search_resolved_links', 'search_unresolved_links'],
+  ['extras_get_date', 'vault_get_metadata'],
+  ['editor_insert', 'editor_replace'],
+  ['editor_insert', 'editor_delete'],
+  ['editor_replace', 'editor_delete'],
+  ['search_tags', 'search_by_tag'],
+];
+
+describe('sibling cross-references', () => {
+  function descriptionByName(name: string): string {
+    const tool = allTools().find((t) => t.name === name);
+    if (!tool) throw new Error(`Tool not found in registry: ${name}`);
+    return tool.description;
+  }
+
+  for (const [a, b] of SIBLING_PAIRS) {
+    it(`${a} description names ${b}`, () => {
+      expect(descriptionByName(a)).toContain(b);
+    });
+    it(`${b} description names ${a}`, () => {
+      expect(descriptionByName(b)).toContain(a);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```
+npx vitest run tests/registry/tool-titles.test.ts
+```
+
+Expected: PASS — every documented pair is symmetric thanks to Tasks 10–11.
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/registry/tool-titles.test.ts
+git commit -m "test(registry): assert sibling pairs are mutually cross-referenced
+
+Refs #289"
+```
+
+---
+
+## Task 13: Extend `scripts/list-tools.ts` to emit per-module title and annotation tables
+
+**Files:**
+- Modify: `scripts/list-tools.ts`
+- Modify: `tests/scripts/list-tools.test.ts` (new assertions for the new section)
+
+- [ ] **Step 1: Write failing test cases**
+
+Append to `tests/scripts/list-tools.test.ts` inside the existing `describe('scripts/list-tools', …)`:
+
+```typescript
+it('renders a per-module Tools section with name, title, and annotation columns', () => {
+  const rows = collectToolRows();
+  const md = renderMarkdown(rows);
+  expect(md).toContain('## Tools by module');
+  expect(md).toContain('| Name | Title | readOnly | destructive |');
+  expect(md).toContain('| `vault_create` | Create file |');
+  expect(md).toContain('| `vault_read` | Read file | ✓ |');
+});
+
+it('every tool name appears in the per-module section with its title', () => {
+  const rows = collectToolRows();
+  const md = renderMarkdown(rows);
+  for (const row of rows) {
+    for (const tool of row.tools) {
+      expect(md).toContain(`| \`${tool.name}\` | ${tool.title} |`);
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npx vitest run tests/scripts/list-tools.test.ts
+```
+
+Expected: FAIL — `row.tools` is currently `string[]` (just names); the new sections aren't emitted.
+
+- [ ] **Step 3: Update `scripts/list-tools.ts`**
+
+Replace the file with:
+
+```typescript
+/**
+ * Walk the tool registry and emit a markdown snapshot of every module and
+ * its tools. Used as the source of truth for `docs/tools.generated.md` so
+ * CI can detect drift between the code and the documentation.
+ *
+ * Run via `npm run docs:tools`.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { argv } from 'node:process';
+import { MockObsidianAdapter } from '../src/obsidian/mock-adapter';
+import { discoverModules } from '../src/tools';
+
+interface ToolEntry {
+  name: string;
+  title: string;
+  readOnly: boolean;
+  destructive: boolean;
+}
+
+interface ToolRow {
+  moduleId: string;
+  moduleName: string;
+  tools: ToolEntry[];
+}
+
+export function collectToolRows(): ToolRow[] {
+  const adapter = new MockObsidianAdapter();
+  const modules = discoverModules(adapter);
+  return modules.map((module) => ({
+    moduleId: module.metadata.id,
+    moduleName: module.metadata.name,
+    tools: module.tools().map((t) => ({
+      name: t.name,
+      title: t.title,
+      readOnly: t.annotations.readOnlyHint === true,
+      destructive: t.annotations.destructiveHint === true,
+    })),
+  }));
+}
+
+function check(value: boolean): string {
+  return value ? '✓' : '';
+}
+
+export function renderMarkdown(rows: ToolRow[]): string {
+  const lines: string[] = [];
+  lines.push('<!-- AUTO-GENERATED by `npm run docs:tools`. Do not edit manually. -->');
+  lines.push('');
+  lines.push('# Tool Registry Snapshot');
+  lines.push('');
+  lines.push(
+    'This file is regenerated from the tool registry and committed so CI can detect doc drift.',
+  );
+  lines.push('');
+
+  // Summary table — preserved for backward compatibility with existing tests.
+  lines.push('| Module ID | Module Name | Count | Tools |');
+  lines.push('|---|---|---|---|');
+
+  let total = 0;
+  for (const row of rows) {
+    total += row.tools.length;
+    const tools = row.tools.map((t) => t.name).join(', ');
+    lines.push(
+      `| \`${row.moduleId}\` | ${row.moduleName} | ${String(row.tools.length)} | ${tools} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push(`**Total tools:** ${String(total)} across ${String(rows.length)} modules.`);
+  lines.push('');
+
+  // Per-module detail tables — new in #289. Surfaces the three Directory
+  // hard-pass criteria (title + readOnlyHint + destructiveHint) per tool.
+  lines.push('## Tools by module');
+  lines.push('');
+  for (const row of rows) {
+    lines.push(`### ${row.moduleName} (\`${row.moduleId}\`)`);
+    lines.push('');
+    lines.push('| Name | Title | readOnly | destructive |');
+    lines.push('|---|---|---|---|');
+    for (const t of row.tools) {
+      lines.push(
+        `| \`${t.name}\` | ${t.title} | ${check(t.readOnly)} | ${check(t.destructive)} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function main(): void {
+  const outPath = argv[2] ?? 'docs/tools.generated.md';
+  const rows = collectToolRows();
+  const markdown = renderMarkdown(rows);
+  writeFileSync(outPath, markdown);
+  // eslint-disable-next-line no-console
+  console.log(`Wrote ${outPath} (${String(rows.length)} modules, ${String(rows.reduce((n, r) => n + r.tools.length, 0))} tools)`);
+}
+
+if (import.meta.url === `file://${argv[1]}`) {
+  main();
+}
+```
+
+- [ ] **Step 4: Update the existing list-tools test to match the new shape**
+
+The pre-existing test at `tests/scripts/list-tools.test.ts:24-32` iterates `row.tools` as strings. Replace its inner loop with:
+
+```typescript
+for (const row of rows) {
+  for (const tool of row.tools) {
+    expect(md).toContain(tool.name);
+  }
+}
+```
+
+And in the first test (lines 5-14), update `expect(row.tools.length)` — already references `.length`, which works for arrays of objects too. No change needed there.
+
+- [ ] **Step 5: Run all list-tools tests**
+
+```
+npx vitest run tests/scripts/list-tools.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add scripts/list-tools.ts tests/scripts/list-tools.test.ts
+git commit -m "feat(scripts): list-tools emits per-module title and annotation tables
+
+Refs #289"
+```
+
+---
+
+## Task 14: Regenerate `docs/tools.generated.md`
+
+**Files:**
+- Modify: `docs/tools.generated.md` (auto-generated)
+
+- [ ] **Step 1: Regenerate**
+
+```
+npm run docs:tools
+```
+
+Expected output: `Wrote docs/tools.generated.md (8 modules, 54 tools)`.
+
+- [ ] **Step 2: Run `docs:check` to confirm zero drift**
+
+```
+npm run docs:check
+```
+
+Expected: exit 0 (no diff).
+
+- [ ] **Step 3: Commit the regenerated doc**
+
+```
+git add docs/tools.generated.md
+git commit -m "docs(tools): regenerate snapshot with titles and annotation columns
+
+Refs #289"
+```
+
+---
+
+## Task 15: Spot-check `docs/help/en.md` for tool-name references
+
+The user manual generally describes surfaces, not individual tools, so no change is expected. Confirm.
+
+**Files:**
+- Inspect (modify only if needed): `docs/help/en.md` and any sibling `docs/help/<locale>.md`.
+
+- [ ] **Step 1: Search the manual for tool-name patterns**
+
+```
+grep -nE '(vault|editor|search|workspace|ui|template|plugin|extras)_[a-z_]+' docs/help/*.md
+```
+
+If the result is empty, the manual does not name individual tools — no change needed; skip to Step 3 with no commit.
+
+- [ ] **Step 2: If a tool name appears, append its title in parentheses next to the name**
+
+Example: `vault_read` → `vault_read (Read file)`. Edit the manual section in place. Repeat in every locale file that mirrors the section.
+
+- [ ] **Step 3: If changes were made, commit; otherwise note "no manual change required" in PR body**
+
+```
+git add docs/help/*.md
+git commit -m "docs(help): surface tool titles next to tool-name references
+
+Refs #289"
+```
+
+---
+
+## Task 16: Final full-suite verification
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: Run lint**
+
+```
+npm run lint
+```
+
+Expected: PASS (no errors).
+
+- [ ] **Step 2: Run typecheck**
+
+```
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+```
+npm test
+```
+
+Expected: every suite PASS, including the new `tests/registry/tool-titles.test.ts`.
+
+- [ ] **Step 4: Run docs:check one more time as a guard against drift introduced after Task 14**
+
+```
+npm run docs:check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Inspect the commit log to confirm scope and message style**
+
+```
+git log --oneline main..HEAD
+```
+
+Expected: a sequence of commits, each touching one logical concern, all referencing `#289` in the body, all conforming to Conventional Commits and the project's no-AI-attribution rule.
+
+---
+
+## Task 17: Push and open the PR
+
+**Files:**
+- (none — git/forge interaction only)
+
+- [ ] **Step 1: Push the branch**
+
+```
+git push -u origin feat/issue-289-tool-titles-and-sibling-cross-refs
+```
+
+- [ ] **Step 2: Open the PR**
+
+```
+gh pr create --title "feat(tools): add title annotation to all tools and add sibling cross-refs" --body "$(cat <<'EOF'
+Closes #289
+
+## Summary
+
+- Adds a required `title: string` field to `ToolDefinition`; forwarded to both `Tool.title` and `ToolAnnotations.title` at registration so hosts render a human-readable label in confirmation/auto-approve UI (Anthropic Directory hard-pass criterion).
+- Adds a structured `seeAlso` section to `describeTool`, populated for the four sibling pairs called out in #289 plus two in-scope expansions (editor `insert`/`replace`/`delete` and `search_tags` ↔ `search_by_tag`).
+- Regenerates `docs/tools.generated.md` with per-module title + annotation tables.
+- New registry tests assert title presence/length/uniqueness and sibling-pair symmetry; existing tests updated to satisfy the now-required field.
+
+## Test plan
+
+- [x] `npm run lint` — clean
+- [x] `npm run typecheck` — clean
+- [x] `npm test` — all suites green, including the new `tests/registry/tool-titles.test.ts`
+- [x] `npm run docs:check` — no drift between code and `docs/tools.generated.md`
+EOF
+)"
+```
+
+- [ ] **Step 3: Note follow-up issues to file after merge**
+
+After this PR merges, file follow-up issues for the deferred sibling pairs (deferred per the spec's "in-scope vs out-of-scope" split):
+
+- `vault_get_outgoing_links` / `vault_get_embeds` / `vault_get_backlinks`
+- `editor_set_cursor` / `editor_set_selection`
+- `editor_get_active_file` / `workspace_get_active_leaf`
+- `template_create_from` / `template_expand`
+
+Use `gh issue create` with the `enhancement` label for each.
+
+---
+
+## Self-review
+
+- **Spec coverage:** every section of the spec has at least one task (architecture → 1, 2, 9; title catalogue → 4–8; sibling pairs → 10, 11; tests → 3, 12; generated docs → 13, 14; user manual → 15). ✓
+- **Placeholders:** no TBDs, no "implement later", no "similar to". ✓
+- **Type consistency:** `title` is the field name everywhere (interface, defineTool, registration forwarding, fixtures, tests, scripts). `seeAlso` is consistent across the helper, the call sites, and the test pair list. ✓
+- **Commit boundaries:** every commit is one logical concern (one module's titles per commit; sibling cross-refs split between scope and expansion; doc generator separated from doc regen). ✓

--- a/docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md
+++ b/docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md
@@ -1,0 +1,285 @@
+# Tool titles and sibling cross-references
+
+- **Issue:** [#289](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/289)
+- **Date:** 2026-05-03
+- **Status:** approved (brainstorm phase)
+
+## Goal
+
+Bring the tool registry into compliance with two `mcp-server-dev:build-mcp-server`
+hard-pass criteria from `references/tool-design.md`:
+
+1. Every tool ships a non-empty `title` annotation (alongside the existing
+   `readOnlyHint` / `destructiveHint`). Hosts use this for confirmation /
+   auto-approve UI; today they fall back to the raw tool name (`vault_create`).
+2. Sibling tools cross-reference each other in their descriptions so Claude
+   picks the right one of a near-duplicate pair.
+
+Purely additive. No tool rename, no schema change, no breaking change.
+
+## Architecture
+
+### `title` is a top-level required field on `ToolDefinition`
+
+The MCP spec slot for the human-readable label is `annotations.title`. We
+expose it one level higher in source — as a top-level required field on
+`ToolDefinition` — and merge it into the annotations object at registration
+time. This keeps the per-tool nature (each tool has its own title) without
+forcing every call site to spread an annotations preset.
+
+```ts
+// src/registry/types.ts
+export interface ToolDefinition<Shape extends z.ZodRawShape = z.ZodRawShape> {
+  name: string;
+  title: string;            // NEW — required, sentence case, ≤40 chars
+  description: string;
+  schema: Shape;
+  outputSchema?: z.ZodRawShape;
+  handler: TypedHandler<Shape>;
+  annotations: ToolAnnotations;
+}
+```
+
+```ts
+// src/server/mcp-server.ts (registerTools)
+server.registerTool(tool.name, {
+  title: tool.title,                                       // top-level (modern protocol)
+  description: tool.description,
+  inputSchema: tool.schema,
+  outputSchema: tool.outputSchema,
+  annotations: { ...tool.annotations, title: tool.title }, // legacy hint slot
+}, dispatcher);
+```
+
+The title is set in **both** locations for forward and backward compatibility:
+the top-level `Tool.title` is the spec-preferred slot in current MCP protocol
+revisions; `ToolAnnotations.title` is the older hint location and the one
+called out as a Directory hard-pass criterion. Both forms cost nothing
+extra — single `tool.title` source of truth in registry data, two slots on
+the wire.
+
+**Why this layout:**
+
+- Compile-time required. `tsc` rejects a new tool added without a title.
+- Annotation presets (`annotations.read`, `annotations.destructive`, …) stay
+  shareable. Per-tool `title` doesn't pollute them.
+- Wire-level shape unchanged — clients still see `annotations.title`.
+
+The runtime test from the issue's scope becomes a belt-and-braces check
+(non-empty after trim, length cap, uniqueness) rather than the primary
+guarantee.
+
+### `seeAlso` section in `describeTool`
+
+Sibling cross-references land in a new structured section in the description
+helper, not in free-form prose inside `examples`. Structure makes audits
+trivial: the registry test asserts that each documented pair is mutually
+cross-referenced.
+
+```ts
+// src/tools/shared/describe.ts
+export interface ToolDoc {
+  summary: string;
+  args?: string[];
+  returns?: string;
+  examples?: string[];
+  errors?: string[];
+  seeAlso?: string[];   // NEW — each entry: "tool_name — when to use it instead"
+}
+```
+
+Rendered between `Examples` and `Errors`:
+
+```
+See also:
+  - <tool_name> — <when to use it instead>
+```
+
+Each entry names the sibling tool by its registry name and gives one short
+clause on when to pick the other one.
+
+## Title catalogue (54 tools)
+
+Sentence case, no module prefix, ≤40 characters, disambiguator suffix where
+two titles would otherwise collide.
+
+### vault (22)
+
+| Name | Title |
+|---|---|
+| `vault_create` | Create file |
+| `vault_read` | Read file |
+| `vault_update` | Replace file content |
+| `vault_delete` | Delete file |
+| `vault_append` | Append to file |
+| `vault_get_metadata` | Get file metadata |
+| `vault_rename` | Rename file |
+| `vault_move` | Move file |
+| `vault_copy` | Copy file |
+| `vault_create_folder` | Create folder |
+| `vault_delete_folder` | Delete folder |
+| `vault_rename_folder` | Rename folder |
+| `vault_list` | List folder |
+| `vault_list_recursive` | List folder (recursive) |
+| `vault_read_binary` | Read binary file |
+| `vault_write_binary` | Write binary file |
+| `vault_get_frontmatter` | Get frontmatter |
+| `vault_get_headings` | Get headings |
+| `vault_get_outgoing_links` | Get outgoing links |
+| `vault_get_embeds` | Get embeds |
+| `vault_get_backlinks` | Get backlinks |
+| `vault_get_block_references` | Get block references |
+
+### editor (10)
+
+| Name | Title |
+|---|---|
+| `editor_get_content` | Get active file content |
+| `editor_get_active_file` | Get active file path |
+| `editor_insert` | Insert at cursor |
+| `editor_replace` | Replace range |
+| `editor_delete` | Delete range |
+| `editor_get_cursor` | Get cursor position |
+| `editor_set_cursor` | Set cursor position |
+| `editor_get_selection` | Get selection |
+| `editor_set_selection` | Set selection |
+| `editor_get_line_count` | Get line count |
+
+### search (6)
+
+| Name | Title |
+|---|---|
+| `search_fulltext` | Full-text search |
+| `search_tags` | List tags |
+| `search_resolved_links` | Find resolved links |
+| `search_unresolved_links` | Find unresolved links |
+| `search_by_tag` | Find notes by tag |
+| `search_by_frontmatter` | Find notes by frontmatter |
+
+### workspace (5)
+
+| Name | Title |
+|---|---|
+| `workspace_get_active_leaf` | Get active leaf |
+| `workspace_open_file` | Open file in workspace |
+| `workspace_list_leaves` | List open leaves |
+| `workspace_set_active_leaf` | Set active leaf |
+| `workspace_get_layout` | Get workspace layout |
+
+### ui (1)
+
+| Name | Title |
+|---|---|
+| `ui_notice` | Show notice |
+
+### templates (3)
+
+| Name | Title |
+|---|---|
+| `template_list` | List templates |
+| `template_create_from` | Create file from template |
+| `template_expand` | Expand template inline |
+
+### plugin-interop (6)
+
+| Name | Title |
+|---|---|
+| `plugin_list` | List plugins |
+| `plugin_check` | Check plugin enabled |
+| `plugin_dataview_query` | Run Dataview query |
+| `plugin_dataview_describe_js_query` | Describe Dataview JS query |
+| `plugin_templater_describe_template` | Describe Templater template |
+| `plugin_execute_command` | Execute command |
+
+### extras (1)
+
+| Name | Title |
+|---|---|
+| `extras_get_date` | Get current date |
+
+## Sibling cross-references
+
+Each pair is symmetric — both sides name the other tool.
+
+### Pairs from issue scope
+
+| Pair | A description gains | B description gains |
+|---|---|---|
+| `editor_get_content` ↔ `vault_read` | `vault_read` — when reading any file by path, not just the active one. | `editor_get_content` — when reading the file currently open in the editor (no path needed). |
+| `vault_list` ↔ `vault_list_recursive` | `vault_list_recursive` — when you also need files in subfolders. | `vault_list` — when you only need direct children of one folder. |
+| `search_resolved_links` ↔ `search_unresolved_links` | `search_unresolved_links` — when you want broken/dangling links instead. | `search_resolved_links` — when you want only links that successfully resolve. |
+| `extras_get_date` ↔ `vault_get_metadata` | `vault_get_metadata` — when you need a file's modified/created timestamp, not today's date. | `extras_get_date` — when you need the current date in a specific format, not a file's timestamp. |
+
+### Additional pairs added in this PR (in-scope expansion)
+
+| Pair | Cross-ref |
+|---|---|
+| `editor_insert` / `editor_replace` / `editor_delete` (triple) | each lists the other two with one-line "use when…" pointers. |
+| `search_tags` ↔ `search_by_tag` | `search_by_tag` — when you want notes carrying a tag, not the list of tags. ↔ `search_tags` — when you want the list of tags in the vault, not notes. |
+
+### Deferred (follow-up issues filed after this PR lands)
+
+- `vault_get_outgoing_links` / `vault_get_embeds` / `vault_get_backlinks`
+- `editor_set_cursor` / `editor_set_selection`
+- `editor_get_active_file` / `workspace_get_active_leaf`
+- `template_create_from` / `template_expand`
+
+## Tests
+
+New file `tests/registry/tool-titles.test.ts` with the following cases (the
+compile-time required field already enforces presence; these are the runtime
+guarantees that survive whitespace, length, and rename regressions):
+
+- **Every active tool has a non-empty title** — `title.trim().length > 0`.
+- **Title length cap** — `title.length <= 40`.
+- **Titles are unique across the registry** — guards against accidental
+  duplicate sentence-case labels (e.g. two tools both called "List folder").
+- **Sibling-pair symmetry** — for each documented pair, the partner tool's
+  registry name appears in the description text. The pair list is a const
+  exported from the test file so adding a new pair is a one-line edit.
+
+## Generated docs
+
+Extend `scripts/list-tools.ts` to emit, in addition to the existing summary
+table, a per-module `## <Module Name>` section containing:
+
+```
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| vault_create | Create file |  | ✓ |
+| vault_read | Read file | ✓ |  |
+…
+```
+
+This surfaces the three Directory hard-pass criteria (`title`, `readOnlyHint`,
+`destructiveHint`) in one place per module. CI's `docs:check` regenerates the
+file and diffs against the committed copy — drift fails the build.
+
+## User manual
+
+[docs/help/en.md](../../help/en.md) does not currently enumerate tools per
+surface — titles are protocol-level metadata that hosts render in their own
+UI. **No content change is required by default.** Spot-check during
+implementation: if a section names a specific tool, surface the new title
+alongside the name. Locale siblings receive the same treatment.
+
+## Out of scope
+
+- Tool renames, additions, or removals.
+- Schema changes.
+- Editing the `readOnlyHint` / `destructiveHint` presets.
+- Sibling cross-refs for the deferred pairs listed above (separate follow-up
+  issues).
+
+## Risks and mitigations
+
+- **Title drift across locales.** Titles ship in English only; the MCP
+  protocol exposes a single string per tool. Acceptable today — the rest of
+  the user-facing surface is also English-default. Revisit only if the
+  protocol gains localisation.
+- **Host UI truncation.** 40-char cap is a guess at what most hosts render
+  cleanly. If a real host truncates earlier we can shorten in a follow-up
+  without breaking anything.
+- **Disambiguator suffix on `vault_list_recursive`.** Reads as "List folder
+  (recursive)" — slightly awkward but precedent-consistent with how the SDK
+  example uses parenthetical qualifiers.

--- a/docs/tools.generated.md
+++ b/docs/tools.generated.md
@@ -16,3 +16,99 @@ This file is regenerated from the tool registry and committed so CI can detect d
 | `extras` | Extras | 1 | extras_get_date |
 
 **Total tools:** 54 across 8 modules.
+
+## Tools by module
+
+### Vault and File Operations (`vault`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `vault_create` | Create file |  |  |
+| `vault_read` | Read file | ✓ |  |
+| `vault_update` | Replace file content |  | ✓ |
+| `vault_delete` | Delete file |  | ✓ |
+| `vault_append` | Append to file |  |  |
+| `vault_get_metadata` | Get file metadata | ✓ |  |
+| `vault_rename` | Rename file |  | ✓ |
+| `vault_move` | Move file |  | ✓ |
+| `vault_copy` | Copy file |  |  |
+| `vault_create_folder` | Create folder |  |  |
+| `vault_delete_folder` | Delete folder |  | ✓ |
+| `vault_rename_folder` | Rename folder |  | ✓ |
+| `vault_list` | List folder | ✓ |  |
+| `vault_list_recursive` | List folder (recursive) | ✓ |  |
+| `vault_read_binary` | Read binary file | ✓ |  |
+| `vault_write_binary` | Write binary file |  | ✓ |
+| `vault_get_frontmatter` | Get frontmatter | ✓ |  |
+| `vault_get_headings` | Get headings | ✓ |  |
+| `vault_get_outgoing_links` | Get outgoing links | ✓ |  |
+| `vault_get_embeds` | Get embeds | ✓ |  |
+| `vault_get_backlinks` | Get backlinks | ✓ |  |
+| `vault_get_block_references` | Get block references | ✓ |  |
+
+### Editor Operations (`editor`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `editor_get_content` | Get active file content | ✓ |  |
+| `editor_get_active_file` | Get active file path | ✓ |  |
+| `editor_insert` | Insert at cursor |  |  |
+| `editor_replace` | Replace range |  | ✓ |
+| `editor_delete` | Delete range |  | ✓ |
+| `editor_get_cursor` | Get cursor position | ✓ |  |
+| `editor_set_cursor` | Set cursor position |  |  |
+| `editor_get_selection` | Get selection | ✓ |  |
+| `editor_set_selection` | Set selection |  |  |
+| `editor_get_line_count` | Get line count | ✓ |  |
+
+### Search and Metadata (`search`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `search_fulltext` | Full-text search | ✓ |  |
+| `search_tags` | List tags | ✓ |  |
+| `search_resolved_links` | Find resolved links | ✓ |  |
+| `search_unresolved_links` | Find unresolved links | ✓ |  |
+| `search_by_tag` | Find notes by tag | ✓ |  |
+| `search_by_frontmatter` | Find notes by frontmatter | ✓ |  |
+
+### Workspace and Navigation (`workspace`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `workspace_get_active_leaf` | Get active leaf | ✓ |  |
+| `workspace_open_file` | Open file in workspace |  |  |
+| `workspace_list_leaves` | List open leaves | ✓ |  |
+| `workspace_set_active_leaf` | Set active leaf |  |  |
+| `workspace_get_layout` | Get workspace layout | ✓ |  |
+
+### UI Interactions (`ui`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `ui_notice` | Show notice |  |  |
+
+### Templates and Content Generation (`templates`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `template_list` | List templates | ✓ |  |
+| `template_create_from` | Create file from template |  |  |
+| `template_expand` | Expand template inline | ✓ |  |
+
+### Plugin Interop (`plugin-interop`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `plugin_list` | List plugins | ✓ |  |
+| `plugin_check` | Check plugin enabled | ✓ |  |
+| `plugin_dataview_query` | Run Dataview query | ✓ |  |
+| `plugin_dataview_describe_js_query` | Describe Dataview JS query | ✓ |  |
+| `plugin_templater_describe_template` | Describe Templater template | ✓ |  |
+| `plugin_execute_command` | Execute command |  | ✓ |
+
+### Extras (`extras`)
+
+| Name | Title | readOnly | destructive |
+|---|---|---|---|
+| `extras_get_date` | Get current date | ✓ |  |

--- a/scripts/list-tools.ts
+++ b/scripts/list-tools.ts
@@ -11,10 +11,17 @@ import { argv } from 'node:process';
 import { MockObsidianAdapter } from '../src/obsidian/mock-adapter';
 import { discoverModules } from '../src/tools';
 
+interface ToolEntry {
+  name: string;
+  title: string;
+  readOnly: boolean;
+  destructive: boolean;
+}
+
 interface ToolRow {
   moduleId: string;
   moduleName: string;
-  tools: string[];
+  tools: ToolEntry[];
 }
 
 export function collectToolRows(): ToolRow[] {
@@ -23,8 +30,17 @@ export function collectToolRows(): ToolRow[] {
   return modules.map((module) => ({
     moduleId: module.metadata.id,
     moduleName: module.metadata.name,
-    tools: module.tools().map((t) => t.name),
+    tools: module.tools().map((t) => ({
+      name: t.name,
+      title: t.title,
+      readOnly: t.annotations.readOnlyHint === true,
+      destructive: t.annotations.destructiveHint === true,
+    })),
   }));
+}
+
+function check(value: boolean): string {
+  return value ? '✓' : '';
 }
 
 export function renderMarkdown(rows: ToolRow[]): string {
@@ -37,13 +53,15 @@ export function renderMarkdown(rows: ToolRow[]): string {
     'This file is regenerated from the tool registry and committed so CI can detect doc drift.',
   );
   lines.push('');
+
+  // Summary table — preserved for backward compatibility with existing tests.
   lines.push('| Module ID | Module Name | Count | Tools |');
   lines.push('|---|---|---|---|');
 
   let total = 0;
   for (const row of rows) {
     total += row.tools.length;
-    const tools = row.tools.join(', ');
+    const tools = row.tools.map((t) => t.name).join(', ');
     lines.push(
       `| \`${row.moduleId}\` | ${row.moduleName} | ${String(row.tools.length)} | ${tools} |`,
     );
@@ -52,6 +70,24 @@ export function renderMarkdown(rows: ToolRow[]): string {
   lines.push('');
   lines.push(`**Total tools:** ${String(total)} across ${String(rows.length)} modules.`);
   lines.push('');
+
+  // Per-module detail tables — new in #289. Surfaces the three Directory
+  // hard-pass criteria (title + readOnlyHint + destructiveHint) per tool.
+  lines.push('## Tools by module');
+  lines.push('');
+  for (const row of rows) {
+    lines.push(`### ${row.moduleName} (\`${row.moduleId}\`)`);
+    lines.push('');
+    lines.push('| Name | Title | readOnly | destructive |');
+    lines.push('|---|---|---|---|');
+    for (const t of row.tools) {
+      lines.push(
+        `| \`${t.name}\` | ${t.title} | ${check(t.readOnly)} | ${check(t.destructive)} |`,
+      );
+    }
+    lines.push('');
+  }
+
   return lines.join('\n');
 }
 
@@ -64,7 +100,6 @@ function main(): void {
   console.log(`Wrote ${outPath} (${String(rows.length)} modules, ${String(rows.reduce((n, r) => n + r.tools.length, 0))} tools)`);
 }
 
-// Execute when run directly (not when imported for testing).
 if (import.meta.url === `file://${argv[1]}`) {
   main();
 }

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -31,6 +31,15 @@ export interface ToolDefinition<
   Shape extends z.ZodRawShape = z.ZodRawShape,
 > {
   name: string;
+  /**
+   * Human-readable title used by hosts in confirmation / auto-approve UI.
+   * Sentence case, no module prefix, ≤40 characters. See spec
+   * `docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md`.
+   *
+   * Marked optional during the backfill rollout (#289). Will become required
+   * once every defineTool call site has been updated.
+   */
+  title?: string;
   description: string;
   schema: Shape;
   /**

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -35,11 +35,8 @@ export interface ToolDefinition<
    * Human-readable title used by hosts in confirmation / auto-approve UI.
    * Sentence case, no module prefix, ≤40 characters. See spec
    * `docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md`.
-   *
-   * Marked optional during the backfill rollout (#289). Will become required
-   * once every defineTool call site has been updated.
    */
-  title?: string;
+  title: string;
   description: string;
   schema: Shape;
   /**

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -88,10 +88,13 @@ function registerTools(
     server.registerTool(
       tool.name,
       {
+        title: tool.title,
         description: tool.description,
         inputSchema: tool.schema,
         outputSchema: tool.outputSchema,
-        annotations: tool.annotations,
+        annotations: tool.title
+          ? { ...tool.annotations, title: tool.title }
+          : tool.annotations,
       },
       createToolDispatcher(tool, logger),
     );

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -310,6 +310,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'editor_get_content',
+          title: 'Get active file content',
           description: describeTool({
             summary: 'Get the full text content of the currently active editor.',
             returns: 'Plain text: the editor\'s current content.',
@@ -322,6 +323,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_get_active_file',
+          title: 'Get active file path',
           description: describeTool({
             summary: 'Get the vault-relative path of the currently active file.',
             returns: 'Plain text: the path, e.g. "notes/today.md".',
@@ -334,6 +336,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_insert',
+          title: 'Insert at cursor',
           description: describeTool({
             summary: 'Insert text at a (line, ch) position in the active editor.',
             args: [
@@ -354,6 +357,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_replace',
+          title: 'Replace range',
           description: describeTool({
             summary: 'Replace text in a (fromLine, fromCh)→(toLine, toCh) range.',
             args: [
@@ -374,6 +378,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_delete',
+          title: 'Delete range',
           description: describeTool({
             summary: 'Delete text in a (fromLine, fromCh)→(toLine, toCh) range.',
             args: [
@@ -392,6 +397,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_get_cursor',
+          title: 'Get cursor position',
           description: describeTool({
             summary: 'Get the current cursor position in the active editor.',
             returns: 'JSON: { line, ch } (zero-based).',
@@ -404,6 +410,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_set_cursor',
+          title: 'Set cursor position',
           description: describeTool({
             summary: 'Move the cursor to a (line, ch) position in the active editor.',
             args: [
@@ -422,6 +429,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_get_selection',
+          title: 'Get selection',
           description: describeTool({
             summary: 'Get the current text selection in the active editor.',
             returns: 'JSON: { from: {line, ch}, to: {line, ch}, text }.',
@@ -434,6 +442,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_set_selection',
+          title: 'Set selection',
           description: describeTool({
             summary: 'Select a (fromLine, fromCh)→(toLine, toCh) range in the active editor.',
             args: [
@@ -452,6 +461,7 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'editor_get_line_count',
+          title: 'Get line count',
           description: describeTool({
             summary: 'Get the number of lines in the active editor.',
             returns: 'Plain text: the line count as a decimal integer.',

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -315,6 +315,9 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get the full text content of the currently active editor.',
             returns: 'Plain text: the editor\'s current content.',
             errors: ['"No active editor" if no markdown view is focused.'],
+            seeAlso: [
+              'vault_read — when reading any file by path, not just the active one.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: getContentOutputSchema,

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -353,6 +353,10 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"No active editor" if no markdown view is focused.',
               '"Position is out of range" if (line, ch) is outside the document.',
             ],
+            seeAlso: [
+              'editor_replace — when you want to overwrite an existing range, not insert at a point.',
+              'editor_delete — when you want to remove a range without writing anything in its place.',
+            ],
           }),
           schema: insertSchema,
           handler: h.insert,
@@ -374,6 +378,10 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
               '"No active editor" if no markdown view is focused.',
               '"Position is out of range" if either endpoint is outside the document.',
             ],
+            seeAlso: [
+              'editor_insert — when you want to add text at a single point without overwriting anything.',
+              'editor_delete — when you want to remove a range without writing anything in its place.',
+            ],
           }),
           schema: replaceSchema,
           handler: h.replace,
@@ -392,6 +400,10 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             errors: [
               '"No active editor" if no markdown view is focused.',
               '"Position is out of range" if either endpoint is outside the document.',
+            ],
+            seeAlso: [
+              'editor_insert — when you want to add text at a single point without overwriting anything.',
+              'editor_replace — when you want to overwrite an existing range, not just remove it.',
             ],
           }),
           schema: deleteRangeSchema,

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -89,6 +89,9 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
             returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',
             examples: ['Use when: stamping a daily note with the current local time.'],
+            seeAlso: [
+              'vault_get_metadata — when you need a file\'s modified/created timestamp, not today\'s date.',
+            ],
           }, getDateSchema),
           schema: getDateSchema,
           outputSchema: getDateOutputSchema,

--- a/src/tools/extras/index.ts
+++ b/src/tools/extras/index.ts
@@ -84,6 +84,7 @@ export function createExtrasModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'extras_get_date',
+          title: 'Get current date',
           description: describeTool({
             summary: 'Get the current local datetime as an ISO-8601 string with timezone offset.',
             returns: 'Plain text: e.g. "2026-04-19T08:30:00.000+02:00".',

--- a/src/tools/plugin-interop/index.ts
+++ b/src/tools/plugin-interop/index.ts
@@ -254,6 +254,7 @@ export function createPluginInteropModule(
       return [
         defineTool({
           name: 'plugin_list',
+          title: 'List plugins',
           description: describeTool({
             summary: 'List every installed community plugin with its enabled flag.',
             returns: 'JSON: [{ id, name, enabled, ... }].',
@@ -265,6 +266,7 @@ export function createPluginInteropModule(
         }),
         defineTool({
           name: 'plugin_check',
+          title: 'Check plugin enabled',
           description: describeTool({
             summary: 'Check whether a plugin is installed and enabled.',
             args: ['pluginId (string, 1..200): Plugin id, e.g. "dataview".'],
@@ -277,6 +279,7 @@ export function createPluginInteropModule(
         }),
         defineTool({
           name: 'plugin_dataview_query',
+          title: 'Run Dataview query',
           description: describeTool({
             summary: 'Execute a Dataview DQL query and return the rendered markdown.',
             args: ['query (string, 1..10000): Dataview DQL query text. Use plugin_dataview_describe_js_query for Dataview-JS sources.'],
@@ -294,6 +297,7 @@ export function createPluginInteropModule(
         }),
         defineTool({
           name: 'plugin_dataview_describe_js_query',
+          title: 'Describe Dataview JS query',
           description: describeTool({
             summary: 'Echo a Dataview-JS source for client-side execution. Returns the source and a note that the host must run it.',
             args: ['query (string, 1..10000): Dataview-JS source.'],
@@ -306,6 +310,7 @@ export function createPluginInteropModule(
         }),
         defineTool({
           name: 'plugin_templater_describe_template',
+          title: 'Describe Templater template',
           description: describeTool({
             summary: 'Echo a Templater template path for client-side execution. Returns the path and a note that the host must run it via Templater.',
             args: ['templatePath (string): Vault-relative path to the Templater template.'],
@@ -318,6 +323,7 @@ export function createPluginInteropModule(
         }),
         defineTool({
           name: 'plugin_execute_command',
+          title: 'Execute command',
           description: describeTool({
             summary: 'Execute any Obsidian command by its id.',
             args: ['commandId (string, 1..200): Command id, e.g. "app:reload".'],

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -114,6 +114,9 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           description: describeTool({
             summary: 'Get the vault-wide map of resolved links (targets that exist).',
             returns: 'JSON: Record<source, Record<target, count>>.',
+            seeAlso: [
+              'search_unresolved_links — when you want broken/dangling links instead.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: searchLinksMapOutputSchema,
@@ -127,6 +130,9 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get the vault-wide map of unresolved links (targets that do not exist).',
             returns: 'JSON: Record<source, Record<target, count>>.',
             examples: ['Use when: hunting for broken [[wikilinks]] to clean up.'],
+            seeAlso: [
+              'search_resolved_links — when you want only links that successfully resolve.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: searchLinksMapOutputSchema,

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -102,6 +102,9 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
           description: describeTool({
             summary: 'List every tag used anywhere in the vault with the files that use it.',
             returns: 'JSON: Record<tag, string[]>. Each key is the tag including leading #.',
+            seeAlso: [
+              'search_by_tag — when you want notes carrying a tag, not the list of tags.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: searchTagsOutputSchema,
@@ -146,6 +149,9 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Find files tagged with a given tag (with or without leading #).',
             args: ['tag (string, 1..200): Tag to search for, e.g. "project" or "#project".'],
             returns: 'JSON: string[] of vault-relative file paths.',
+            seeAlso: [
+              'search_tags — when you want the list of tags in the vault, not notes.',
+            ],
           }, searchByTagSchema),
           schema: searchByTagSchema,
           outputSchema: paginatedPathPageOutputSchema,

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -83,6 +83,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'search_fulltext',
+          title: 'Full-text search',
           description: describeTool({
             summary: 'Case-insensitive substring search across all vault file contents.',
             args: ['query (string, 1..500): Substring to look for.'],
@@ -97,6 +98,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'search_tags',
+          title: 'List tags',
           description: describeTool({
             summary: 'List every tag used anywhere in the vault with the files that use it.',
             returns: 'JSON: Record<tag, string[]>. Each key is the tag including leading #.',
@@ -108,6 +110,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'search_resolved_links',
+          title: 'Find resolved links',
           description: describeTool({
             summary: 'Get the vault-wide map of resolved links (targets that exist).',
             returns: 'JSON: Record<source, Record<target, count>>.',
@@ -119,6 +122,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'search_unresolved_links',
+          title: 'Find unresolved links',
           description: describeTool({
             summary: 'Get the vault-wide map of unresolved links (targets that do not exist).',
             returns: 'JSON: Record<source, Record<target, count>>.',
@@ -131,6 +135,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'search_by_tag',
+          title: 'Find notes by tag',
           description: describeTool({
             summary: 'Find files tagged with a given tag (with or without leading #).',
             args: ['tag (string, 1..200): Tag to search for, e.g. "project" or "#project".'],
@@ -143,6 +148,7 @@ export function createSearchModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'search_by_frontmatter',
+          title: 'Find notes by frontmatter',
           description: describeTool({
             summary: 'Find files whose YAML frontmatter has a key with a given value.',
             args: [

--- a/src/tools/shared/describe.ts
+++ b/src/tools/shared/describe.ts
@@ -35,6 +35,7 @@ export interface ToolDoc {
   args?: string[];
   returns?: string;
   examples?: string[];
+  seeAlso?: string[];
   errors?: string[];
 }
 
@@ -95,6 +96,11 @@ export function describeTool(doc: ToolDoc, schema?: z.ZodRawShape): string {
   if (doc.examples && doc.examples.length > 0) {
     lines.push('', 'Examples:');
     for (const ex of doc.examples) lines.push(`  - ${ex}`);
+  }
+
+  if (doc.seeAlso && doc.seeAlso.length > 0) {
+    lines.push('', 'See also:');
+    for (const s of doc.seeAlso) lines.push(`  - ${s}`);
   }
 
   if (doc.errors && doc.errors.length > 0) {

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -156,6 +156,7 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'template_list',
+          title: 'List templates',
           description: describeTool({
             summary: 'List files in the vault\'s "templates" folder.',
             returns: 'JSON: string[] of template file paths. Empty array if the folder is missing.',
@@ -167,6 +168,7 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'template_create_from',
+          title: 'Create file from template',
           description: describeTool({
             summary: 'Create a file by expanding {{variable}} placeholders in a template.',
             args: [
@@ -186,6 +188,7 @@ export function createTemplatesModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'template_expand',
+          title: 'Expand template inline',
           description: describeTool({
             summary: 'Expand {{variable}} placeholders in a supplied string without writing any file.',
             args: [

--- a/src/tools/ui/index.ts
+++ b/src/tools/ui/index.ts
@@ -48,6 +48,7 @@ export function createUiModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'ui_notice',
+          title: 'Show notice',
           description: describeTool({
             summary: 'Show a transient notice/toast in Obsidian.',
             args: [

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -217,6 +217,9 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
               '"File not found" if the path does not exist.',
               '"Path must not traverse outside the vault" on traversal attempts.',
             ],
+            seeAlso: [
+              'editor_get_content — when reading the file currently open in the editor (no path needed).',
+            ],
           }, readFileSchema),
           schema: readFileSchema,
           outputSchema: readFileOutputSchema,
@@ -283,6 +286,9 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: { path, size, created (ISO), modified (ISO) }.',
             examples: ['Use when: checking if a note has changed recently.'],
             errors: ['"File not found" if the path does not exist.'],
+            seeAlso: [
+              'extras_get_date — when you need the current date in a specific format, not a file\'s timestamp.',
+            ],
           }, getMetadataSchema),
           schema: getMetadataSchema,
           outputSchema: getMetadataOutputSchema,
@@ -400,6 +406,9 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
             returns: 'JSON: { files: string[], folders: string[] } (names only, no recursion).',
             examples: ['Use when: inspecting the top level of the vault.'],
             errors: ['"Folder not found" if path does not exist.'],
+            seeAlso: [
+              'vault_list_recursive — when you also need files in subfolders.',
+            ],
           }, listFolderSchema),
           schema: listFolderSchema,
           outputSchema: listFolderOutputSchema,
@@ -418,6 +427,9 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
               'Don\'t use when: the folder is very large — list a narrower subfolder.',
             ],
             errors: ['"Folder not found" if path does not exist.'],
+            seeAlso: [
+              'vault_list — when you only need direct children of one folder.',
+            ],
           }, listRecursiveSchema),
           schema: listRecursiveSchema,
           outputSchema: listRecursiveOutputSchema,

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -181,6 +181,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'vault_create',
+          title: 'Create file',
           description: describeTool({
             summary: 'Create a new file at a vault-relative path with text content.',
             args: [
@@ -203,6 +204,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_read',
+          title: 'Read file',
           description: describeTool({
             summary: 'Read the full UTF-8 content of a file by vault-relative path.',
             args: ['path (string): Vault-relative path to the file.'],
@@ -223,6 +225,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_update',
+          title: 'Replace file content',
           description: describeTool({
             summary: 'Overwrite an existing file with new content.',
             args: [
@@ -242,6 +245,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_delete',
+          title: 'Delete file',
           description: describeTool({
             summary: 'Delete a file by vault-relative path.',
             args: ['path (string): Vault-relative path to the file.'],
@@ -255,6 +259,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_append',
+          title: 'Append to file',
           description: describeTool({
             summary: 'Append content to the end of an existing file.',
             args: [
@@ -271,6 +276,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_metadata',
+          title: 'Get file metadata',
           description: describeTool({
             summary: 'Get file stat metadata (size, creation date, modification date).',
             args: ['path (string): Vault-relative path to the file.'],
@@ -285,6 +291,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_rename',
+          title: 'Rename file',
           description: describeTool({
             summary: 'Rename a file within its current folder.',
             args: [
@@ -304,6 +311,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_move',
+          title: 'Move file',
           description: describeTool({
             summary: 'Move a file to a different path (can change folder and name).',
             args: [
@@ -320,6 +328,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_copy',
+          title: 'Copy file',
           description: describeTool({
             summary: 'Copy a file to a new path, leaving the original in place.',
             args: [
@@ -336,6 +345,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_create_folder',
+          title: 'Create folder',
           description: describeTool({
             summary: 'Create a new folder at a vault-relative path.',
             args: ['path (string): Folder path to create.'],
@@ -349,6 +359,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_delete_folder',
+          title: 'Delete folder',
           description: describeTool({
             summary: 'Delete a folder, optionally recursively.',
             args: [
@@ -365,6 +376,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_rename_folder',
+          title: 'Rename folder',
           description: describeTool({
             summary: 'Rename or move a folder.',
             args: [
@@ -381,6 +393,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_list',
+          title: 'List folder',
           description: describeTool({
             summary: 'List files and folders directly under a path (non-recursive).',
             args: ['path (string): Folder to list.'],
@@ -395,6 +408,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_list_recursive',
+          title: 'List folder (recursive)',
           description: describeTool({
             summary: 'List all files and folders under a path, recursively.',
             args: ['path (string): Folder to walk.'],
@@ -412,6 +426,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_read_binary',
+          title: 'Read binary file',
           description: describeTool({
             summary: 'Read binary file contents as base64.',
             args: ['path (string): Vault-relative path to the file.'],
@@ -430,6 +445,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_write_binary',
+          title: 'Write binary file',
           description: describeTool({
             summary: 'Write binary file contents from a base64 string.',
             args: [
@@ -446,6 +462,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_frontmatter',
+          title: 'Get frontmatter',
           description: describeTool({
             summary: 'Get the parsed YAML frontmatter block for a file.',
             args: ['path (string): Vault-relative path.'],
@@ -459,6 +476,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_headings',
+          title: 'Get headings',
           description: describeTool({
             summary: 'List headings (with levels) for a file.',
             args: ['path (string): Vault-relative path.'],
@@ -472,6 +490,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_outgoing_links',
+          title: 'Get outgoing links',
           description: describeTool({
             summary: 'List outgoing links from a file.',
             args: ['path (string): Vault-relative path.'],
@@ -485,6 +504,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_embeds',
+          title: 'Get embeds',
           description: describeTool({
             summary: 'List embedded resources (![[...]]) referenced by a file.',
             args: ['path (string): Vault-relative path.'],
@@ -498,6 +518,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_backlinks',
+          title: 'Get backlinks',
           description: describeTool({
             summary: 'List files that link TO a given file (reverse links).',
             args: ['path (string): Target file path.'],
@@ -511,6 +532,7 @@ export function createVaultModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'vault_get_block_references',
+          title: 'Get block references',
           description: describeTool({
             summary: 'List block references (^block-id) defined in a file.',
             args: ['path (string): Vault-relative path.'],

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -149,6 +149,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
       return [
         defineTool({
           name: 'workspace_get_active_leaf',
+          title: 'Get active leaf',
           description: describeTool({
             summary: 'Get info about the currently-focused leaf (pane).',
             returns: 'JSON: { id, type, ... } describing the active leaf.',
@@ -161,6 +162,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'workspace_open_file',
+          title: 'Open file in workspace',
           description: describeTool({
             summary: 'Open a file in a leaf, optionally requesting a view mode.',
             args: [
@@ -176,6 +178,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'workspace_list_leaves',
+          title: 'List open leaves',
           description: describeTool({
             summary: 'List every open leaf and the file it holds.',
             returns: 'JSON: [{ path, leafId }].',
@@ -187,6 +190,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'workspace_set_active_leaf',
+          title: 'Set active leaf',
           description: describeTool({
             summary: 'Focus a specific leaf by id.',
             args: ['leafId (string): Leaf id from workspace_list_leaves.'],
@@ -199,6 +203,7 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
         }),
         defineTool({
           name: 'workspace_get_layout',
+          title: 'Get workspace layout',
           description: describeTool({
             summary: 'Get a summary of the current workspace layout.',
             returns: 'JSON: Obsidian\'s layout descriptor (nested splits and leaves).',

--- a/tests/registry/module-registry.test.ts
+++ b/tests/registry/module-registry.test.ts
@@ -15,6 +15,7 @@ function createMockLogger(): Logger {
 function createMockTool(name: string, readOnly: boolean): ToolDefinition {
   return {
     name,
+    title: `Mock ${name}`,
     description: `Mock tool: ${name}`,
     schema: {},
     handler: (): Promise<CallToolResult> =>

--- a/tests/registry/tool-titles.test.ts
+++ b/tests/registry/tool-titles.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { discoverModules } from '../../src/tools';
+import type { ToolDefinition } from '../../src/registry/types';
+
+function allTools(): ToolDefinition[] {
+  const adapter = new MockObsidianAdapter();
+  return discoverModules(adapter).flatMap((m) => m.tools());
+}
+
+describe('tool titles', () => {
+  it('every tool has a non-empty title (after trim)', () => {
+    const missing = allTools()
+      .filter((t) => !t.title || t.title.trim().length === 0)
+      .map((t) => t.name);
+    expect(missing).toEqual([]);
+  });
+
+  it('every title is at most 40 characters', () => {
+    const tooLong = allTools()
+      .filter((t) => (t.title ?? '').length > 40)
+      .map((t) => `${t.name}: "${t.title ?? ''}" (${String((t.title ?? '').length)} chars)`);
+    expect(tooLong).toEqual([]);
+  });
+
+  it('titles are unique across the registry', () => {
+    const tools = allTools();
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+    for (const t of tools) {
+      const title = t.title ?? '';
+      const prior = seen.get(title);
+      if (prior !== undefined) {
+        duplicates.push(`${prior} and ${t.name} share title "${title}"`);
+      } else {
+        seen.set(title, t.name);
+      }
+    }
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/tests/registry/tool-titles.test.ts
+++ b/tests/registry/tool-titles.test.ts
@@ -39,3 +39,31 @@ describe('tool titles', () => {
     expect(duplicates).toEqual([]);
   });
 });
+
+const SIBLING_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['editor_get_content', 'vault_read'],
+  ['vault_list', 'vault_list_recursive'],
+  ['search_resolved_links', 'search_unresolved_links'],
+  ['extras_get_date', 'vault_get_metadata'],
+  ['editor_insert', 'editor_replace'],
+  ['editor_insert', 'editor_delete'],
+  ['editor_replace', 'editor_delete'],
+  ['search_tags', 'search_by_tag'],
+];
+
+describe('sibling cross-references', () => {
+  function descriptionByName(name: string): string {
+    const tool = allTools().find((t) => t.name === name);
+    if (!tool) throw new Error(`Tool not found in registry: ${name}`);
+    return tool.description;
+  }
+
+  for (const [a, b] of SIBLING_PAIRS) {
+    it(`${a} description names ${b}`, () => {
+      expect(descriptionByName(a)).toContain(b);
+    });
+    it(`${b} description names ${a}`, () => {
+      expect(descriptionByName(b)).toContain(a);
+    });
+  }
+});

--- a/tests/scripts/list-tools.test.ts
+++ b/tests/scripts/list-tools.test.ts
@@ -26,7 +26,26 @@ describe('scripts/list-tools', () => {
     const md = renderMarkdown(rows);
     for (const row of rows) {
       for (const tool of row.tools) {
-        expect(md).toContain(tool);
+        expect(md).toContain(tool.name);
+      }
+    }
+  });
+
+  it('renders a per-module Tools section with name, title, and annotation columns', () => {
+    const rows = collectToolRows();
+    const md = renderMarkdown(rows);
+    expect(md).toContain('## Tools by module');
+    expect(md).toContain('| Name | Title | readOnly | destructive |');
+    expect(md).toContain('| `vault_create` | Create file |');
+    expect(md).toContain('| `vault_read` | Read file | ✓ |');
+  });
+
+  it('every tool name appears in the per-module section with its title', () => {
+    const rows = collectToolRows();
+    const md = renderMarkdown(rows);
+    for (const row of rows) {
+      for (const tool of row.tools) {
+        expect(md).toContain(`| \`${tool.name}\` | ${tool.title} |`);
       }
     }
   });

--- a/tests/server/dispatcher.test.ts
+++ b/tests/server/dispatcher.test.ts
@@ -14,6 +14,7 @@ function makeTool(
 ): ToolDefinition {
   return {
     name: 'demo_tool',
+    title: 'Demo tool',
     description: 'Demo tool for the dispatcher tests',
     schema: {
       path: z.string().min(1).describe('Required path'),

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -100,6 +100,7 @@ describe('createMcpServer', () => {
 
     const toolWithOutputSchema = {
       name: 'tool_with_output',
+      title: 'tool with output',
       description: 'has output schema',
       schema: inputSchema,
       outputSchema,
@@ -110,6 +111,7 @@ describe('createMcpServer', () => {
 
     const toolWithoutOutputSchema = {
       name: 'tool_without_output',
+      title: 'tool without output',
       description: 'no output schema',
       schema: inputSchema,
       handler: () =>
@@ -200,6 +202,7 @@ describe('createToolDispatcher', () => {
   ): ToolDefinition {
     return {
       name: 'test_tool',
+      title: 'test tool',
       description: 'test',
       schema,
       handler,

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -19,10 +19,11 @@ interface CapturedOptions {
 interface CapturedRegisterToolCall {
   name: string;
   config: {
+    title?: string;
     description?: string;
     inputSchema?: unknown;
     outputSchema?: unknown;
-    annotations?: unknown;
+    annotations?: { title?: string } & Record<string, unknown>;
   };
 }
 
@@ -147,6 +148,35 @@ describe('createMcpServer', () => {
     // The field IS present in the config object (we forward it
     // unconditionally) — but its value is undefined.
     expect('outputSchema' in (withoutOutput?.config ?? {})).toBe(true);
+  });
+
+  it('forwards tool.title to both Tool.title and annotations.title', async () => {
+    const { ModuleRegistry } = await import('../../src/registry/module-registry');
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+
+    const titledTool = {
+      name: 'titled',
+      title: 'Pretty title',
+      description: 'has title',
+      schema: { foo: z.string() },
+      handler: () =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      annotations: annotations.read,
+    } as unknown as ToolDefinition;
+
+    const stubModule: ToolModule = {
+      metadata: { id: 'stub', name: 'Stub', description: 'test' },
+      tools: () => [titledTool],
+    };
+
+    const registry = new ModuleRegistry(makeLogger());
+    registry.registerModule(stubModule);
+    createMcpServer(registry, makeLogger());
+
+    const call = capturedRegisterToolCalls.find((c) => c.name === 'titled');
+    expect(call).toBeDefined();
+    expect(call?.config.title).toBe('Pretty title');
+    expect(call?.config.annotations?.title).toBe('Pretty title');
   });
 });
 

--- a/tests/tools/shared/describe.test.ts
+++ b/tests/tools/shared/describe.test.ts
@@ -100,4 +100,35 @@ describe('describeTool', () => {
     expect(out).not.toContain('limit (integer, optional)');
     expect(out).not.toContain('offset (integer, optional)');
   });
+
+  it('renders a See also section when seeAlso entries are supplied', () => {
+    const out = describeTool({
+      summary: 'Read a thing.',
+      seeAlso: [
+        'other_tool — when you want the other variant.',
+      ],
+    });
+    expect(out).toContain('See also:');
+    expect(out).toContain('  - other_tool — when you want the other variant.');
+  });
+
+  it('places See also between Examples and Errors', () => {
+    const out = describeTool({
+      summary: 'Read.',
+      examples: ['Use when: testing.'],
+      seeAlso: ['other_tool — alternative.'],
+      errors: ['"boom" on failure.'],
+    });
+    const examplesIdx = out.indexOf('Examples:');
+    const seeAlsoIdx = out.indexOf('See also:');
+    const errorsIdx = out.indexOf('Errors:');
+    expect(examplesIdx).toBeGreaterThan(0);
+    expect(seeAlsoIdx).toBeGreaterThan(examplesIdx);
+    expect(errorsIdx).toBeGreaterThan(seeAlsoIdx);
+  });
+
+  it('omits See also when no seeAlso entries are supplied', () => {
+    const out = describeTool({ summary: 'Read.' });
+    expect(out).not.toContain('See also:');
+  });
 });

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -55,6 +55,7 @@ function makeModule(
     tools(): ReturnType<ToolModule['tools']> {
       return toolNames.map((name) => ({
         name,
+        title: name,
         description: '',
         schema: {},
         handler: () => Promise.resolve({ content: [] }),


### PR DESCRIPTION
Closes #289

## Summary

- Adds a required `title: string` field to `ToolDefinition`; forwarded to both `Tool.title` (top-level) and `ToolAnnotations.title` (legacy hint slot) at registration so hosts render a human-readable label in confirmation/auto-approve UI — the third Anthropic Directory hard-pass criterion alongside `readOnlyHint` and `destructiveHint`.
- All 54 tools across 8 modules carry a sentence-case title (≤40 chars, no module prefix, disambiguator suffixes where two titles would otherwise collide — e.g. `vault_list` / `vault_list_recursive`).
- Adds a structured `seeAlso` section to `describeTool` and populates it for the 4 sibling pairs called out in #289 plus 2 in-scope expansions noticed during review (editor `insert`/`replace`/`delete` triple and `search_tags` ↔ `search_by_tag`).
- New registry tests (`tests/registry/tool-titles.test.ts`) assert title presence/length/uniqueness and sibling-pair symmetry. Existing test fixtures that hand-construct `ToolDefinition` values updated to satisfy the now-required field.
- `scripts/list-tools.ts` and `docs/tools.generated.md` regenerated with per-module title + annotation tables; CI's `docs:check` confirms zero drift.
- `docs/help/en.md` spot-checked: the three places that name a specific tool now surface its title parenthetically.

Breaking change at the type layer: `ToolDefinition.title` is now required. Wire-level shape unchanged — clients see the same `Tool.title` and `ToolAnnotations.title`.

Follow-up sibling pairs deferred to separate issues per the spec: `vault_get_outgoing_links` / `vault_get_embeds` / `vault_get_backlinks`; `editor_set_cursor` / `editor_set_selection`; `editor_get_active_file` / `workspace_get_active_leaf`; `template_create_from` / `template_expand`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 650/650 tests pass, including the new `tests/registry/tool-titles.test.ts` (3 + 16 cases)
- [x] `npm run docs:check` — no drift between code and `docs/tools.generated.md`