### PR TITLE
feat(server/mcp): expose vault files as MCP resources

### DIFF
--- a/docs/help/en.md
+++ b/docs/help/en.md
@@ -138,6 +138,7 @@ The settings tab is split into five sections.
 | **HTTPS** | off | Switch to HTTPS using a locally generated self-signed certificate. Restart required. See the FAQ for client-side trust. |
 | **TLS Certificate** | auto | Generated on the first HTTPS start, then cached in `data.json`. Use **Regenerate certificate** if you change the address or want a fresh key pair — clients will need to re-trust the new cert. |
 | **Auto-start on launch** | off | Start the MCP server automatically when Obsidian loads. The server still applies the auth/insecure-mode guard on auto-start, so a misconfigured install stays stopped and the reason is logged. |
+| **Expose vault files as MCP resources** | **on** | When on, MCP hosts can browse and read vault files via the resources surface (`obsidian://vault/{path}`) in addition to tools. Restart the server to apply changes. See [Resources](#resources) below. |
 
 #### DNS Rebind Protection
 
@@ -269,6 +270,23 @@ This server exposes an Obsidian vault as MCP tools.
 Source of truth: [`src/server/mcp-server.ts`](https://github.com/KingOfKalk/obsidian-plugin-mcp/blob/main/src/server/mcp-server.ts)
 (`SERVER_INSTRUCTIONS`). If you suspect drift between the quoted text above
 and the live string, the source file wins.
+
+---
+
+## Resources
+
+In addition to tools, the server exposes the vault as **MCP resources** so hosts (Claude Desktop, MCP-compatible IDEs, etc.) can browse and read notes natively without spending tool-use turns.
+
+### URIs
+
+- **`obsidian://vault/index`** — a static JSON listing of every file and folder in the vault. Each file entry carries a ready-to-read URI and mime type. Listings over 25 000 characters are truncated; use the `vault_list_recursive` tool for full enumeration on very large vaults.
+- **`obsidian://vault/{path}`** — read any file by its vault-relative path. Markdown, text, JSON, CSV, YAML, HTML, and SVG files are returned as text; other files (images, PDFs, audio, video) are returned as base64 blobs.
+
+Binary files larger than **1 MiB** are refused. Use the `vault_read_binary` tool if you genuinely need a larger file.
+
+### Disabling
+
+If you only want the tools surface, turn off **"Expose vault files as MCP resources"** in *Server Settings* and restart the server. The server then advertises a tools-only capability set.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-03-mcp-resources-vault-files.md
+++ b/docs/superpowers/plans/2026-05-03-mcp-resources-vault-files.md
@@ -1,0 +1,2043 @@
+# MCP Resources for Vault Files Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose vault files as MCP resources via `obsidian://vault/{+path}` (template) and `obsidian://vault/index` (static), so hosts can browse and read vault files without consuming tool-use turns.
+
+**Architecture:** A new `src/server/resources.ts` registers two resources on the `McpServer` (file template + static index). It owns its mime table, URI parser, and read handlers. Wiring into `createMcpServer` is gated by a new `resourcesEnabled` settings flag (default on, with a v10→v11 migration). Tools surface unchanged; subscriptions and `roots` deferred per spec.
+
+**Tech Stack:** TypeScript, `@modelcontextprotocol/sdk` (`registerResource`, `ResourceTemplate`), Vitest, Zod, Obsidian plugin API.
+
+**Spec:** [`docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md`](../specs/2026-05-03-mcp-resources-vault-files-design.md)
+
+**Branch:** `feat/issue-292-mcp-resources-vault-files` (already created)
+
+**Issue:** #292
+
+---
+
+## File Structure
+
+### Created
+
+- `src/server/resources.ts` — `registerResources(server, adapter, logger)`, mime table (`MIME_TABLE`, `getMimeType`, `isTextMime`), `parseVaultUri`, `indexHandler`, `fileHandler`. Self-contained. Reuses `validateVaultPath` from `src/utils/path-guard.ts` and `BinaryTooLargeError` from `src/tools/shared/errors.ts`.
+- `tests/server/resources.test.ts` — unit tests against a mock adapter for the URI parser, mime table, both handlers, and the index truncation cap.
+
+### Modified
+
+- `src/types.ts` — add `resourcesEnabled: boolean` to `McpPluginSettings`; default `true` in `DEFAULT_SETTINGS`; bump `schemaVersion` default to 11.
+- `src/settings/migrations.ts` — add `migrateV10ToV11` hop, append it to `HOPS`, bump `CURRENT_SCHEMA_VERSION` to 11.
+- `tests/settings/migrations.test.ts` — add v10→v11 hop tests.
+- `src/server/mcp-server.ts` — `createMcpServer(registry, adapter, settings, logger)` (signature widened); declare `resources: {}` capability iff `settings.resourcesEnabled`; call `registerResources` after `registerTools`.
+- `src/main.ts` — pass `this.adapter` and `this.settings` into `createMcpServer`.
+- `tests/server/mcp-server.test.ts` — update fake `McpServer` to capture `registerResource` calls; update existing call sites for the new signature.
+- `src/settings/server-section.ts` — one toggle bound to `resourcesEnabled`.
+- `src/lang/locale/en.ts` — strings for the toggle.
+- `src/lang/locale/de.ts` — strings for the toggle (German translation).
+- `src/tools/shared/errors.ts` — add `BinaryTooLargeError`; add a branch to `handleToolError`.
+- `src/tools/vault/handlers.ts` — `readBinary` throws `BinaryTooLargeError` instead of `errorResult`.
+- `src/obsidian/mock-adapter.ts` — accept `''` as the vault root in `list` and `listRecursive` (real Obsidian convention) in addition to `'/'`.
+- `docs/help/en.md` — add a Resources section under the MCP surface description.
+
+### Not modified
+
+- `docs/tools.generated.md` — unaffected (resources are not tools). Verified by running `npm run docs:tools` at the end and confirming a clean diff.
+
+---
+
+## Task 1: Add `BinaryTooLargeError` to shared errors
+
+**Files:**
+- Modify: `src/tools/shared/errors.ts`
+- Test: `tests/tools/shared/errors.test.ts` (create if missing; if a test already exists, append)
+
+- [ ] **Step 1: Check if a test file exists**
+
+```bash
+ls tests/tools/shared/errors.test.ts 2>/dev/null || echo "MISSING"
+```
+
+If the file is missing, create it with a `describe('handleToolError', ...)` outer block before adding the test in step 2. If it exists, append the new test inside the existing `describe` block.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/tools/shared/errors.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { BinaryTooLargeError, handleToolError } from '../../../src/tools/shared/errors';
+
+describe('BinaryTooLargeError', () => {
+  it('renders a clear message including size and limit', () => {
+    const err = new BinaryTooLargeError(2_000_000, 1_048_576);
+    expect(err.name).toBe('BinaryTooLargeError');
+    expect(err.message).toBe(
+      'Binary file too large (2000000 bytes, limit 1048576). Fetch the file out-of-band or use a chunked read when available.',
+    );
+    expect(err.sizeBytes).toBe(2_000_000);
+    expect(err.limitBytes).toBe(1_048_576);
+  });
+
+  it('handleToolError maps BinaryTooLargeError to an isError CallToolResult with the same message', () => {
+    const result = handleToolError(new BinaryTooLargeError(2_000_000, 1_048_576));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: 'Error: Binary file too large (2000000 bytes, limit 1048576). Fetch the file out-of-band or use a chunked read when available.',
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run:
+```bash
+npx vitest run tests/tools/shared/errors.test.ts
+```
+
+Expected: FAIL — `BinaryTooLargeError is not exported`.
+
+- [ ] **Step 4: Add `BinaryTooLargeError` and a `handleToolError` branch**
+
+Edit `src/tools/shared/errors.ts`. After the existing `TimeoutError` class:
+
+```ts
+/**
+ * The requested binary file exceeds the configured per-call byte limit.
+ * Used by `vault_read_binary` and the resources surface to fail fast on
+ * over-cap files instead of base64-encoding hundreds of megabytes.
+ */
+export class BinaryTooLargeError extends Error {
+  constructor(
+    public readonly sizeBytes: number,
+    public readonly limitBytes: number,
+  ) {
+    super(
+      `Binary file too large (${String(sizeBytes)} bytes, limit ${String(limitBytes)}). Fetch the file out-of-band or use a chunked read when available.`,
+    );
+    this.name = 'BinaryTooLargeError';
+  }
+}
+```
+
+Then in `handleToolError`, add a branch above the final `error instanceof Error` fallback:
+
+```ts
+if (error instanceof BinaryTooLargeError) {
+  return errorFrom(error.message);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+npx vitest run tests/tools/shared/errors.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tools/shared/errors.ts tests/tools/shared/errors.test.ts
+git commit -m "$(cat <<'EOF'
+feat(tools/shared): add BinaryTooLargeError with handleToolError branch
+
+Lifts the 1 MiB cap message into a typed error so the tools and resources
+surfaces can share it. handleToolError preserves the existing wire-format
+message verbatim.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 2: Switch `vault_read_binary` to throw `BinaryTooLargeError`
+
+**Files:**
+- Modify: `src/tools/vault/handlers.ts:367-390`
+
+- [ ] **Step 1: Verify the existing tool test for over-cap input is green before the change**
+
+```bash
+npx vitest run tests/tools/vault/handlers.test.ts -t "readBinary"
+```
+
+Expected: PASS (baseline).
+
+- [ ] **Step 2: Replace the inline `errorResult` with a thrown `BinaryTooLargeError`**
+
+In `src/tools/vault/handlers.ts`, change `readBinary` (lines ~367–390) so the cap check throws instead of returning:
+
+```ts
+async readBinary(params): Promise<CallToolResult> {
+  try {
+    const path = validateVaultPath(params.path, vaultPath);
+    const data = await adapter.readBinary(path);
+    if (data.byteLength > BINARY_BYTE_LIMIT) {
+      throw new BinaryTooLargeError(data.byteLength, BINARY_BYTE_LIMIT);
+    }
+    const base64 = Buffer.from(data).toString('base64');
+    return makeResponse(
+      {
+        path,
+        data: base64,
+        encoding: 'base64' as const,
+        size_bytes: data.byteLength,
+      },
+      (v) => v.data,
+      readResponseFormat(params),
+    );
+  } catch (error) {
+    return handleToolError(error);
+  }
+},
+```
+
+Update the imports at the top of the file to include `BinaryTooLargeError`:
+
+```ts
+import { handleToolError, BinaryTooLargeError } from '../shared/errors';
+```
+
+- [ ] **Step 3: Run the full vault handlers test suite**
+
+```bash
+npx vitest run tests/tools/vault/handlers.test.ts
+```
+
+Expected: PASS — the rendered error message is unchanged because `handleToolError` formats it identically.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tools/vault/handlers.ts
+git commit -m "$(cat <<'EOF'
+refactor(tools/vault): throw BinaryTooLargeError from readBinary
+
+Replaces the inline errorResult with the new typed error so the resources
+surface can share the same cap. Wire-format error message unchanged.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 3: Make the mock adapter accept `''` as vault root
+
+**Files:**
+- Modify: `src/obsidian/mock-adapter.ts:178-203`
+- Test: `tests/obsidian/mock-adapter.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/obsidian/mock-adapter.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+
+describe('MockObsidianAdapter root traversal', () => {
+  it('listRecursive("") walks the entire vault (real Obsidian convention)', () => {
+    const adapter = new MockObsidianAdapter('/vault');
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'b');
+
+    const result = adapter.listRecursive('');
+
+    expect(result.files.sort()).toEqual(['a.md', 'notes/b.md']);
+    expect(result.folders).toContain('notes');
+  });
+
+  it('list("") returns the direct children of the vault root', () => {
+    const adapter = new MockObsidianAdapter('/vault');
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+
+    const result = adapter.list('');
+
+    expect(result.files).toContain('a.md');
+    expect(result.folders).toContain('notes');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run tests/obsidian/mock-adapter.test.ts -t "root traversal"
+```
+
+Expected: FAIL — `FolderNotFoundError`.
+
+- [ ] **Step 3: Update the mock to treat `''` like `'/'`**
+
+In `src/obsidian/mock-adapter.ts`, change the two functions:
+
+```ts
+list(path: string): ListResult {
+  const isRoot = path === '/' || path === '';
+  if (!this.folders.has(path) && !isRoot) {
+    throw new FolderNotFoundError(path);
+  }
+  return this.getDirectChildren(isRoot ? '' : path);
+}
+
+listRecursive(path: string): ListResult {
+  const isRoot = path === '/' || path === '';
+  if (!this.folders.has(path) && !isRoot) {
+    throw new FolderNotFoundError(path);
+  }
+  const prefix = isRoot ? '' : path + '/';
+  const files: string[] = [];
+  const folders: string[] = [];
+  for (const filePath of this.files.keys()) {
+    if (isRoot || filePath.startsWith(prefix)) {
+      files.push(filePath);
+    }
+  }
+  for (const folderPath of this.folders) {
+    if (folderPath !== path && (isRoot || folderPath.startsWith(prefix))) {
+      folders.push(folderPath);
+    }
+  }
+  return { files: files.sort(), folders: folders.sort() };
+}
+```
+
+Inspect `getDirectChildren` (search the file). If it special-cases `'/'`, extend the predicate to accept `''` consistently. If it just uses `path` as a prefix, `''` will already work — confirm and adjust if needed.
+
+- [ ] **Step 4: Run the full mock adapter suite**
+
+```bash
+npx vitest run tests/obsidian/mock-adapter.test.ts
+```
+
+Expected: PASS, all existing tests included.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/obsidian/mock-adapter.ts tests/obsidian/mock-adapter.test.ts
+git commit -m "$(cat <<'EOF'
+test(obsidian/mock-adapter): accept '' as vault root in list/listRecursive
+
+Real Obsidian's vault root path is the empty string. The mock previously
+required '/'. Accepting both keeps existing tests green and lets the new
+resources index handler (#292) pass '' uniformly to either adapter.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `resourcesEnabled` to settings
+
+**Files:**
+- Modify: `src/types.ts`
+- Test: `tests/types.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/types.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../src/types';
+
+describe('DEFAULT_SETTINGS resourcesEnabled', () => {
+  it('defaults resourcesEnabled to true', () => {
+    expect(DEFAULT_SETTINGS.resourcesEnabled).toBe(true);
+  });
+
+  it('bumps schemaVersion to 11', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(11);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run tests/types.test.ts -t "resourcesEnabled"
+```
+
+Expected: FAIL — property missing on `DEFAULT_SETTINGS`, schemaVersion is 10.
+
+- [ ] **Step 3: Add the field and bump the version**
+
+In `src/types.ts`, add to the `McpPluginSettings` interface (place it after `autoStart`):
+
+```ts
+/**
+ * When true, the server exposes vault files as MCP resources
+ * (obsidian://vault/{+path} template + obsidian://vault/index static)
+ * in addition to tools. Default true.
+ */
+resourcesEnabled: boolean;
+```
+
+Update `DEFAULT_SETTINGS` — bump `schemaVersion` to `11` and add `resourcesEnabled: true`:
+
+```ts
+export const DEFAULT_SETTINGS: McpPluginSettings = {
+  schemaVersion: 11,
+  // ...existing fields unchanged...
+  autoStart: false,
+  resourcesEnabled: true,
+  executeCommandAllowlist: [],
+  // ...rest unchanged...
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run tests/types.test.ts -t "resourcesEnabled"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck — the migration step (Task 5) will resolve any compile errors**
+
+```bash
+npm run typecheck
+```
+
+Expected: may FAIL referencing `CURRENT_SCHEMA_VERSION === 10` or callers; that's resolved in Task 5. If it fails outside `src/settings/migrations.ts` or its tests, fix the unrelated breakage now (likely another `DEFAULT_SETTINGS` consumer that explicitly listed all fields — add `resourcesEnabled: true` there too).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types.ts tests/types.test.ts
+git commit -m "$(cat <<'EOF'
+feat(types): add resourcesEnabled setting (default on, schemaVersion 11)
+
+Gates the MCP resources surface added by #292 behind a single global
+toggle. New installs get it on; existing installs migrate in the next
+commit.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `migrateV10ToV11` migration
+
+**Files:**
+- Modify: `src/settings/migrations.ts`
+- Test: `tests/settings/migrations.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/settings/migrations.test.ts` (mirror the existing v9→v10 test style):
+
+```ts
+import { migrateV10ToV11 } from '../../src/settings/migrations';
+
+describe('migrateV10ToV11', () => {
+  it('sets resourcesEnabled: true for installs without the field', () => {
+    const data = {} as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(true);
+  });
+
+  it('preserves an explicit false', () => {
+    const data = { resourcesEnabled: false } as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(false);
+  });
+
+  it('preserves an explicit true', () => {
+    const data = { resourcesEnabled: true } as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(true);
+  });
+});
+```
+
+Also update the existing `migrates V0 (no schemaVersion) all the way to current` test — it should still pass without changes because it only asserts `schemaVersion === CURRENT_SCHEMA_VERSION`. Verify by re-reading that test's assertions.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/settings/migrations.test.ts -t "migrateV10ToV11"
+```
+
+Expected: FAIL — `migrateV10ToV11 is not exported`.
+
+- [ ] **Step 3: Add the migration**
+
+In `src/settings/migrations.ts`, after `migrateV9ToV10`:
+
+```ts
+export function migrateV9ToV10(data: Settings): void {
+  // ...existing body unchanged...
+}
+
+export function migrateV10ToV11(data: Settings): void {
+  // Default the new resources surface on for existing installs. They
+  // can disable it in Server Settings if they prefer a tools-only
+  // server. See docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md.
+  if (data.resourcesEnabled === undefined) data.resourcesEnabled = true;
+}
+```
+
+Append to `HOPS`:
+
+```ts
+const HOPS: Array<{ target: number; run: MigrationHop }> = [
+  // ...existing hops...
+  { target: 10, run: migrateV9ToV10 },
+  { target: 11, run: migrateV10ToV11 },
+];
+```
+
+Bump `CURRENT_SCHEMA_VERSION`:
+
+```ts
+export const CURRENT_SCHEMA_VERSION = 11;
+```
+
+- [ ] **Step 4: Run the migrations test suite to verify everything passes**
+
+```bash
+npx vitest run tests/settings/migrations.test.ts
+```
+
+Expected: PASS — new tests plus the existing "all the way to current" test (now ending at 11).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/migrations.ts tests/settings/migrations.test.ts
+git commit -m "$(cat <<'EOF'
+feat(settings): add v10→v11 migration enabling resources surface
+
+Existing installs default to resourcesEnabled: true; explicit values are
+preserved. CURRENT_SCHEMA_VERSION bumped to 11.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 6: Add lang strings for the toggle (en + de)
+
+**Files:**
+- Modify: `src/lang/locale/en.ts`
+- Modify: `src/lang/locale/de.ts`
+
+- [ ] **Step 1: Verify the lang file shapes**
+
+```bash
+sed -n '78,82p' src/lang/locale/en.ts
+sed -n '78,82p' src/lang/locale/de.ts
+```
+
+Expected output: keys like `setting_autostart_name` / `setting_autostart_desc`. We mirror that pattern.
+
+- [ ] **Step 2: Add English strings**
+
+In `src/lang/locale/en.ts`, near the existing `setting_autostart_*` lines:
+
+```ts
+setting_resources_enabled_name: 'Expose vault files as MCP resources',
+setting_resources_enabled_desc:
+  'When on, MCP hosts can browse and read vault files via the resources surface (obsidian://vault/{path}) in addition to tools. Restart the server to apply changes.',
+```
+
+- [ ] **Step 3: Add German strings**
+
+In `src/lang/locale/de.ts`, in the matching position:
+
+```ts
+setting_resources_enabled_name: 'Vault-Dateien als MCP-Ressourcen freigeben',
+setting_resources_enabled_desc:
+  'Wenn aktiviert, können MCP-Hosts Vault-Dateien zusätzlich zu den Tools über die Resources-Schnittstelle (obsidian://vault/{Pfad}) lesen und durchsuchen. Server neu starten, damit die Änderung wirksam wird.',
+```
+
+- [ ] **Step 4: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS — string keys are looked up dynamically by `t()`, so no failure unless `de.ts` has a strict shape that disallows new keys (verify if it does and adjust).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lang/locale/en.ts src/lang/locale/de.ts
+git commit -m "$(cat <<'EOF'
+feat(lang): add resources surface toggle strings (en, de)
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 7: Create `src/server/resources.ts` skeleton with mime table
+
+**Files:**
+- Create: `src/server/resources.ts`
+- Create: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Write the failing test for the mime table**
+
+Create `tests/server/resources.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getMimeType, isTextMime } from '../../src/server/resources';
+
+describe('getMimeType', () => {
+  it('maps known text extensions', () => {
+    expect(getMimeType('notes/foo.md')).toBe('text/markdown');
+    expect(getMimeType('foo.txt')).toBe('text/plain');
+    expect(getMimeType('config.json')).toBe('application/json');
+    expect(getMimeType('data.csv')).toBe('text/csv');
+    expect(getMimeType('settings.yml')).toBe('application/yaml');
+    expect(getMimeType('settings.yaml')).toBe('application/yaml');
+    expect(getMimeType('icon.svg')).toBe('image/svg+xml');
+  });
+
+  it('maps known binary extensions', () => {
+    expect(getMimeType('a.png')).toBe('image/png');
+    expect(getMimeType('a.jpg')).toBe('image/jpeg');
+    expect(getMimeType('a.jpeg')).toBe('image/jpeg');
+    expect(getMimeType('a.pdf')).toBe('application/pdf');
+    expect(getMimeType('a.mp3')).toBe('audio/mpeg');
+    expect(getMimeType('a.mp4')).toBe('video/mp4');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(getMimeType('FOO.MD')).toBe('text/markdown');
+    expect(getMimeType('PHOTO.JPG')).toBe('image/jpeg');
+  });
+
+  it('falls back to application/octet-stream for unknown or missing extensions', () => {
+    expect(getMimeType('mystery.xyz')).toBe('application/octet-stream');
+    expect(getMimeType('Makefile')).toBe('application/octet-stream');
+  });
+});
+
+describe('isTextMime', () => {
+  it('returns true for text/* and application/json and image/svg+xml', () => {
+    expect(isTextMime('text/markdown')).toBe(true);
+    expect(isTextMime('text/plain')).toBe(true);
+    expect(isTextMime('application/json')).toBe(true);
+    expect(isTextMime('image/svg+xml')).toBe(true);
+  });
+
+  it('returns false for binary mimes', () => {
+    expect(isTextMime('image/png')).toBe(false);
+    expect(isTextMime('application/pdf')).toBe(false);
+    expect(isTextMime('application/octet-stream')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/server/resources.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../../src/server/resources'`.
+
+- [ ] **Step 3: Create the skeleton with the mime table**
+
+Create `src/server/resources.ts`:
+
+```ts
+import { posix } from 'path';
+
+/**
+ * Static mime-type table covering the file types that show up in an
+ * Obsidian vault. Keys are lowercase extensions including the leading dot.
+ * Unknown extensions fall back to application/octet-stream. See
+ * docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md.
+ */
+const MIME_TABLE: Record<string, string> = {
+  // Text
+  '.md': 'text/markdown',
+  '.txt': 'text/plain',
+  '.json': 'application/json',
+  '.csv': 'text/csv',
+  '.yml': 'application/yaml',
+  '.yaml': 'application/yaml',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.ts': 'text/x-typescript',
+  '.svg': 'image/svg+xml',
+  // Binary — images
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  // Binary — audio / video
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.m4a': 'audio/mp4',
+  '.flac': 'audio/flac',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  // Binary — documents
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.epub': 'application/epub+zip',
+};
+
+const FALLBACK_MIME = 'application/octet-stream';
+
+export function getMimeType(path: string): string {
+  const ext = posix.extname(path).toLowerCase();
+  return MIME_TABLE[ext] ?? FALLBACK_MIME;
+}
+
+export function isTextMime(mime: string): boolean {
+  if (mime.startsWith('text/')) return true;
+  if (mime === 'application/json') return true;
+  if (mime === 'image/svg+xml') return true;
+  return false;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run tests/server/resources.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): add mime table for vault resources surface
+
+Foundation for #292. getMimeType maps Obsidian-relevant extensions to mime
+strings; isTextMime classifies text vs blob for ReadResourceResult content.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 8: Implement `parseVaultUri`
+
+**Files:**
+- Modify: `src/server/resources.ts`
+- Modify: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Append the failing tests**
+
+Append to `tests/server/resources.test.ts`:
+
+```ts
+import { parseVaultUri } from '../../src/server/resources';
+import { PathTraversalError } from '../../src/utils/path-guard';
+
+const VAULT = '/tmp/vault';
+
+function uri(s: string): URL { return new URL(s); }
+
+describe('parseVaultUri', () => {
+  it('returns the validated relative path for a plain URI', () => {
+    expect(parseVaultUri(uri('obsidian://vault/notes/foo.md'), { path: 'notes/foo.md' }, VAULT))
+      .toBe('notes/foo.md');
+  });
+
+  it('handles unicode paths', () => {
+    expect(parseVaultUri(uri('obsidian://vault/Notizen/%C3%9Cbersicht.md'), { path: 'Notizen/Übersicht.md' }, VAULT))
+      .toBe('Notizen/Übersicht.md');
+  });
+
+  it('rejects traversal', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/../etc/passwd'), { path: '../etc/passwd' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects encoded traversal', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/..%2F..'), { path: '..%2F..' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects wrong scheme', () => {
+    expect(() => parseVaultUri(uri('file:///foo.md'), { path: 'foo.md' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects wrong host', () => {
+    expect(() => parseVaultUri(uri('obsidian://other/foo.md'), { path: 'foo.md' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects empty path', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/'), { path: '' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('accepts a single-string variable form (some SDK paths pass string[])', () => {
+    expect(parseVaultUri(uri('obsidian://vault/notes/foo.md'), { path: ['notes', 'foo.md'] as unknown as string }, VAULT))
+      .toBe('notes/foo.md');
+  });
+});
+```
+
+(The last test is defensive — the SDK's `Variables` type allows `string | string[]` per RFC 6570 expansion. The `+` operator captures as a single string in practice, but we handle both to avoid a runtime crash.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "parseVaultUri"
+```
+
+Expected: FAIL — function not exported.
+
+- [ ] **Step 3: Implement `parseVaultUri`**
+
+Add to `src/server/resources.ts`:
+
+```ts
+import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
+
+type VaultUriVariables = { path: string | string[] };
+
+/**
+ * Validate an `obsidian://vault/{+path}` URI and return the vault-relative
+ * path it points to. The SDK has already parsed the variable; we still
+ * defend against scheme/host mismatches and call `validateVaultPath` so
+ * traversal protection is shared with the tool surface.
+ */
+export function parseVaultUri(
+  uri: URL,
+  variables: VaultUriVariables,
+  vaultPath: string,
+): string {
+  if (uri.protocol !== 'obsidian:') {
+    throw new PathTraversalError(`Unexpected scheme: ${uri.protocol}`);
+  }
+  if (uri.host !== 'vault') {
+    throw new PathTraversalError(`Unexpected host: ${uri.host}`);
+  }
+  const raw = Array.isArray(variables.path)
+    ? variables.path.join('/')
+    : variables.path;
+  return validateVaultPath(raw, vaultPath);
+}
+```
+
+Re-export `PathTraversalError` for the test file's convenience (optional — tests can import it from path-guard directly; we already do above, so no new export needed).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "parseVaultUri"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): add parseVaultUri with shared path-guard
+
+Validates scheme, host, and the captured path; defers traversal protection
+to validateVaultPath so the tool and resources surfaces share enforcement.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 9: Implement `fileHandler` text branch
+
+**Files:**
+- Modify: `src/server/resources.ts`
+- Modify: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/server/resources.test.ts`:
+
+```ts
+import { Logger } from '../../src/utils/logger';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { createFileHandler } from '../../src/server/resources';
+
+function makeLogger(): Logger {
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
+
+describe('fileHandler — text', () => {
+  it('returns TextResourceContents for a markdown file', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    adapter.addFile('notes/foo.md', '# Hello');
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/notes/foo.md'),
+      { path: 'notes/foo.md' },
+    );
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0]).toEqual({
+      uri: 'obsidian://vault/notes/foo.md',
+      mimeType: 'text/markdown',
+      text: '# Hello',
+    });
+  });
+
+  it('propagates the adapter not-found error for a missing file', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    const handler = createFileHandler(adapter, makeLogger());
+
+    await expect(handler(
+      new URL('obsidian://vault/missing.md'),
+      { path: 'missing.md' },
+    )).rejects.toThrow(/not found/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "fileHandler"
+```
+
+Expected: FAIL — `createFileHandler` not exported.
+
+- [ ] **Step 3: Implement the file handler with the text branch only (binary will follow in Task 10)**
+
+Add to `src/server/resources.ts`:
+
+```ts
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ObsidianAdapter } from '../obsidian/adapter';
+import type { Logger } from '../utils/logger';
+
+type FileHandler = (
+  uri: URL,
+  variables: VaultUriVariables,
+) => Promise<ReadResourceResult>;
+
+export function createFileHandler(
+  adapter: ObsidianAdapter,
+  _logger: Logger,
+): FileHandler {
+  return async (uri, variables) => {
+    const path = parseVaultUri(uri, variables, adapter.getVaultPath());
+    const mime = getMimeType(path);
+    if (isTextMime(mime)) {
+      const text = await adapter.readFile(path);
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: mime,
+            text,
+          },
+        ],
+      };
+    }
+    throw new Error('Binary branch not implemented yet'); // filled in in the next task
+  };
+}
+```
+
+The `_logger` parameter is reserved — used in later tasks for non-fatal warnings (e.g. when `stat` returns null).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "fileHandler — text"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): implement fileHandler text branch
+
+Text-classified files (md/txt/json/csv/yaml/html/svg/...) are served as
+TextResourceContents with the mime type from the static table. Binary
+branch follows in the next commit.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 10: Implement `fileHandler` binary branch with size cap
+
+**Files:**
+- Modify: `src/server/resources.ts`
+- Modify: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/server/resources.test.ts`:
+
+```ts
+import { BinaryTooLargeError } from '../../src/tools/shared/errors';
+
+describe('fileHandler — binary', () => {
+  it('returns BlobResourceContents (base64) for a small image', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    await adapter.writeBinary('img.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/img.png'),
+      { path: 'img.png' },
+    );
+
+    expect(result.contents).toHaveLength(1);
+    const c = result.contents[0] as { uri: string; mimeType: string; blob: string };
+    expect(c.uri).toBe('obsidian://vault/img.png');
+    expect(c.mimeType).toBe('image/png');
+    expect(Buffer.from(c.blob, 'base64')).toEqual(Buffer.from(bytes));
+  });
+
+  it('serves a file at exactly 1 MiB', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    const bytes = new Uint8Array(1_048_576);
+    await adapter.writeBinary('big.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/big.png'),
+      { path: 'big.png' },
+    );
+
+    const c = result.contents[0] as { blob: string };
+    expect(Buffer.from(c.blob, 'base64').byteLength).toBe(1_048_576);
+  });
+
+  it('throws BinaryTooLargeError above 1 MiB', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    const bytes = new Uint8Array(1_048_577);
+    await adapter.writeBinary('big.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    await expect(handler(
+      new URL('obsidian://vault/big.png'),
+      { path: 'big.png' },
+    )).rejects.toBeInstanceOf(BinaryTooLargeError);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "fileHandler — binary"
+```
+
+Expected: FAIL — `Binary branch not implemented yet`.
+
+- [ ] **Step 3: Implement the binary branch using `stat` for the cap check**
+
+Replace the `throw` placeholder in `createFileHandler`:
+
+```ts
+import { BinaryTooLargeError, FileNotFoundError } from '../tools/shared/errors';
+import { BINARY_BYTE_LIMIT } from '../constants';
+
+// ...inside createFileHandler:
+    if (isTextMime(mime)) {
+      const text = await adapter.readFile(path);
+      return {
+        contents: [{ uri: uri.toString(), mimeType: mime, text }],
+      };
+    }
+
+    const stat = await adapter.stat(path);
+    if (stat === null) {
+      throw new FileNotFoundError(path);
+    }
+    if (stat.size > BINARY_BYTE_LIMIT) {
+      throw new BinaryTooLargeError(stat.size, BINARY_BYTE_LIMIT);
+    }
+    const data = await adapter.readBinary(path);
+    const blob = Buffer.from(data).toString('base64');
+    return {
+      contents: [{ uri: uri.toString(), mimeType: mime, blob }],
+    };
+```
+
+- [ ] **Step 4: Run the full resources test file**
+
+```bash
+npx vitest run tests/server/resources.test.ts
+```
+
+Expected: PASS — text + binary + parser + mime tests all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): implement fileHandler binary branch with 1 MiB cap
+
+Binary-classified files are served as base64 BlobResourceContents.
+Over-cap files throw BinaryTooLargeError (shared with vault_read_binary).
+Stat-before-read avoids loading multi-megabyte attachments only to refuse.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 11: Implement `indexHandler` with truncation cap
+
+**Files:**
+- Modify: `src/server/resources.ts`
+- Modify: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/server/resources.test.ts`:
+
+```ts
+import { createIndexHandler } from '../../src/server/resources';
+import { CHARACTER_LIMIT } from '../../src/constants';
+
+interface IndexEntry { uri: string; name: string; mimeType: string; size: number }
+interface IndexPayload { files: IndexEntry[]; folders: string[]; truncated: boolean }
+
+describe('indexHandler', () => {
+  it('returns a flat list with resource entries and folder names', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'bb');
+    adapter.addFile('img.png', 'pngdata');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const c = result.contents[0] as { uri: string; mimeType: string; text: string };
+    expect(c.uri).toBe('obsidian://vault/index');
+    expect(c.mimeType).toBe('application/json');
+
+    const payload = JSON.parse(c.text) as IndexPayload;
+    expect(payload.truncated).toBe(false);
+    expect(payload.folders).toContain('notes');
+    expect(payload.files.find((f) => f.name === 'a.md')).toMatchObject({
+      uri: 'obsidian://vault/a.md',
+      mimeType: 'text/markdown',
+      size: 1,
+    });
+    expect(payload.files.find((f) => f.name === 'b.md')).toMatchObject({
+      uri: 'obsidian://vault/notes/b.md',
+      mimeType: 'text/markdown',
+    });
+    expect(payload.files.find((f) => f.name === 'img.png')).toMatchObject({
+      mimeType: 'image/png',
+    });
+  });
+
+  it('returns an empty payload for an empty vault', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const payload = JSON.parse((result.contents[0] as { text: string }).text) as IndexPayload;
+    expect(payload).toEqual({ files: [], folders: [], truncated: false });
+  });
+
+  it('truncates files past the 25 000-character cap', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    // Each entry is roughly 90+ chars in JSON. 400 entries blow past 25k.
+    for (let i = 0; i < 400; i++) {
+      adapter.addFile(`note-${String(i).padStart(4, '0')}.md`, 'x');
+    }
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const text = (result.contents[0] as { text: string }).text;
+    expect(text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    const payload = JSON.parse(text) as IndexPayload;
+    expect(payload.truncated).toBe(true);
+    expect(payload.files.length).toBeLessThan(400);
+  });
+
+  it('produces URIs that round-trip through parseVaultUri', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    adapter.addFile('Notizen/Übersicht.md', 'x');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const payload = JSON.parse((result.contents[0] as { text: string }).text) as IndexPayload;
+    const entry = payload.files[0];
+
+    const parsedPath = parseVaultUri(
+      new URL(entry.uri),
+      // The SDK populates `variables.path` by decoding the URI; emulate by
+      // decoding entry.uri's pathname after the host segment.
+      { path: decodeURIComponent(new URL(entry.uri).pathname.replace(/^\//, '')) },
+      '/tmp/vault',
+    );
+    expect(parsedPath).toBe('Notizen/Übersicht.md');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "indexHandler"
+```
+
+Expected: FAIL — `createIndexHandler` not exported.
+
+- [ ] **Step 3: Implement the index handler**
+
+Add to `src/server/resources.ts`:
+
+```ts
+import { CHARACTER_LIMIT } from '../constants';
+
+type IndexHandler = (uri: URL) => Promise<ReadResourceResult>;
+
+interface IndexEntry {
+  uri: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+interface IndexPayload {
+  files: IndexEntry[];
+  folders: string[];
+  truncated: boolean;
+}
+
+const VAULT_INDEX_URI = 'obsidian://vault/index';
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+function buildEntry(adapter: ObsidianAdapter, path: string): IndexEntry {
+  // Best-effort size — listing huge vaults shouldn't pay the I/O for every
+  // file, but the mock adapter's stat() is cheap and the real adapter
+  // reads from the metadata cache. If stat throws we fall back to 0.
+  let size = 0;
+  // stat is async; we synchronously fall through to 0. Caller may upgrade
+  // this to await if it becomes important.
+  void adapter;
+  return {
+    uri: 'obsidian://vault/' + encodeURI(path),
+    name: basename(path),
+    mimeType: getMimeType(path),
+    size,
+  };
+}
+
+export function createIndexHandler(
+  adapter: ObsidianAdapter,
+  _logger: Logger,
+): IndexHandler {
+  return async (_uri) => {
+    const list = adapter.listRecursive('');
+    const files: IndexEntry[] = [];
+    for (const path of list.files) {
+      const stat = await adapter.stat(path);
+      files.push({
+        uri: 'obsidian://vault/' + encodeURI(path),
+        name: basename(path),
+        mimeType: getMimeType(path),
+        size: stat?.size ?? 0,
+      });
+    }
+    const folders = [...list.folders];
+
+    let payload: IndexPayload = { files, folders, truncated: false };
+    let serialised = JSON.stringify(payload);
+    if (serialised.length > CHARACTER_LIMIT) {
+      // Drop entries from the tail of files until the serialised JSON fits.
+      const trimmed = [...files];
+      while (trimmed.length > 0) {
+        trimmed.pop();
+        const candidate: IndexPayload = { files: trimmed, folders, truncated: true };
+        const candidateSerialised = JSON.stringify(candidate);
+        if (candidateSerialised.length <= CHARACTER_LIMIT) {
+          payload = candidate;
+          serialised = candidateSerialised;
+          break;
+        }
+      }
+      // If even an empty files array doesn't fit (e.g. a folder list that
+      // alone exceeds the cap), force a minimal payload.
+      if (serialised.length > CHARACTER_LIMIT) {
+        payload = { files: [], folders: [], truncated: true };
+        serialised = JSON.stringify(payload);
+      }
+    }
+
+    return {
+      contents: [
+        {
+          uri: VAULT_INDEX_URI,
+          mimeType: 'application/json',
+          text: serialised,
+        },
+      ],
+    };
+  };
+}
+
+export const VAULT_INDEX_URI_CONST = VAULT_INDEX_URI;
+```
+
+Remove the unused `buildEntry` helper / dead `void adapter` if you don't end up using it — the `for...of` loop above is the canonical path.
+
+- [ ] **Step 4: Run the full resources test file**
+
+```bash
+npx vitest run tests/server/resources.test.ts
+```
+
+Expected: PASS — index tests included.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): implement static vault index handler
+
+Returns a flat JSON payload of {files, folders, truncated}. Files carry
+ready-to-use obsidian://vault/{path} URIs with mime types so hosts don't
+need follow-up calls. Truncation drops entries from the tail until the
+payload fits the 25 000-char cap.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 12: Wire `registerResources` into the McpServer
+
+**Files:**
+- Modify: `src/server/resources.ts`
+- Modify: `tests/server/resources.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/server/resources.test.ts`:
+
+```ts
+import { registerResources } from '../../src/server/resources';
+
+describe('registerResources', () => {
+  it('registers vault-index (static) and vault-file (template)', () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+
+    interface Capture { name: string; uriOrTemplate: unknown; metadata: Record<string, unknown> }
+    const calls: Capture[] = [];
+    const fakeServer = {
+      registerResource(name: string, uriOrTemplate: unknown, metadata: Record<string, unknown>) {
+        calls.push({ name, uriOrTemplate, metadata });
+      },
+    };
+
+    registerResources(fakeServer as never, adapter, makeLogger());
+
+    expect(calls.map((c) => c.name)).toEqual(['vault-index', 'vault-file']);
+    expect(calls[0].uriOrTemplate).toBe('obsidian://vault/index');
+    // Template is a class instance from the SDK — we just verify shape.
+    expect(typeof calls[1].uriOrTemplate).toBe('object');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "registerResources"
+```
+
+Expected: FAIL — `registerResources` not exported.
+
+- [ ] **Step 3: Implement `registerResources`**
+
+Add to `src/server/resources.ts`:
+
+```ts
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+const FILE_TEMPLATE_URI = 'obsidian://vault/{+path}';
+
+export function registerResources(
+  server: McpServer,
+  adapter: ObsidianAdapter,
+  logger: Logger,
+): void {
+  const indexHandler = createIndexHandler(adapter, logger);
+  const fileHandler = createFileHandler(adapter, logger);
+
+  server.registerResource(
+    'vault-index',
+    VAULT_INDEX_URI,
+    {
+      name: 'Vault index',
+      description:
+        'JSON listing of every file and folder in the vault, with ready-to-use obsidian://vault/{path} URIs and mime types. Truncated past 25 000 characters.',
+      mimeType: 'application/json',
+    },
+    (uri) => indexHandler(uri),
+  );
+
+  server.registerResource(
+    'vault-file',
+    new ResourceTemplate(FILE_TEMPLATE_URI, { list: undefined }),
+    {
+      name: 'Vault file',
+      description:
+        'Read any file in the vault by obsidian://vault/{path}. Text files (markdown, txt, json, csv, yaml, html, svg) return TextResourceContents; other files up to 1 MiB return base64 BlobResourceContents.',
+    },
+    (uri, variables) => fileHandler(uri, variables as VaultUriVariables),
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run tests/server/resources.test.ts -t "registerResources"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/resources.ts tests/server/resources.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/resources): add registerResources entry point
+
+Registers vault-index (static) and vault-file (template) on an McpServer.
+The template uses RFC 6570 reserved expansion ({+path}) so multi-segment
+paths capture as one variable; list callback is intentionally undefined
+(discovery happens through the static index).
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 13: Wire resources into `createMcpServer`
+
+**Files:**
+- Modify: `src/server/mcp-server.ts`
+- Modify: `tests/server/mcp-server.test.ts`
+
+- [ ] **Step 1: Update the existing fake `McpServer` to capture `registerResource`**
+
+In `tests/server/mcp-server.test.ts`, extend the `FakeMcpServer` mock and the captured-state arrays:
+
+```ts
+interface CapturedRegisterResourceCall {
+  name: string;
+  uriOrTemplate: unknown;
+  metadata: Record<string, unknown>;
+}
+
+const capturedRegisterResourceCalls: CapturedRegisterResourceCall[] = [];
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  class FakeMcpServer {
+    public server = {};
+    constructor(serverInfo: CapturedServerInfo, options: CapturedOptions) {
+      capturedConstructorArgs.push({ serverInfo, options });
+    }
+    registerTool(name: string, config: CapturedRegisterToolCall['config']): void {
+      capturedRegisterToolCalls.push({ name, config });
+    }
+    registerResource(name: string, uriOrTemplate: unknown, metadata: Record<string, unknown>): void {
+      capturedRegisterResourceCalls.push({ name, uriOrTemplate, metadata });
+    }
+  }
+  class FakeResourceTemplate {
+    constructor(public uriTemplate: string, public callbacks: unknown) {}
+  }
+  return { McpServer: FakeMcpServer, ResourceTemplate: FakeResourceTemplate };
+});
+```
+
+In the `beforeEach` block, also clear the new array:
+
+```ts
+capturedRegisterResourceCalls.length = 0;
+```
+
+- [ ] **Step 2: Add tests for the capability flag and the register calls**
+
+```ts
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+
+it('declares the resources capability and registers vault-index + vault-file when resourcesEnabled', async () => {
+  const { createMcpServer } = await import('../../src/server/mcp-server');
+  const registry = new ModuleRegistry(makeLogger());
+  const adapter = new MockObsidianAdapter('/tmp/vault');
+  const settings = { ...DEFAULT_SETTINGS, resourcesEnabled: true };
+
+  createMcpServer(registry, adapter, settings, makeLogger());
+
+  const caps = capturedConstructorArgs[0].options.capabilities;
+  expect(caps).toMatchObject({ resources: {} });
+  expect(capturedRegisterResourceCalls.map((c) => c.name)).toEqual([
+    'vault-index',
+    'vault-file',
+  ]);
+});
+
+it('omits the resources capability and skips registration when resourcesEnabled is false', async () => {
+  const { createMcpServer } = await import('../../src/server/mcp-server');
+  const registry = new ModuleRegistry(makeLogger());
+  const adapter = new MockObsidianAdapter('/tmp/vault');
+  const settings = { ...DEFAULT_SETTINGS, resourcesEnabled: false };
+
+  createMcpServer(registry, adapter, settings, makeLogger());
+
+  const caps = capturedConstructorArgs[0].options.capabilities;
+  expect(caps).not.toHaveProperty('resources');
+  expect(capturedRegisterResourceCalls).toHaveLength(0);
+});
+```
+
+Update the existing test call sites that invoke `createMcpServer(registry, makeLogger())` — they all need the new positional args. Pass `new MockObsidianAdapter('/tmp/vault')` and `DEFAULT_SETTINGS` as the new args:
+
+```ts
+createMcpServer(registry, new MockObsidianAdapter('/tmp/vault'), DEFAULT_SETTINGS, makeLogger());
+```
+
+- [ ] **Step 3: Run the test file to verify the new tests fail**
+
+```bash
+npx vitest run tests/server/mcp-server.test.ts -t "resources"
+```
+
+Expected: FAIL — `createMcpServer` signature mismatch / no `resources` capability declared.
+
+- [ ] **Step 4: Update `createMcpServer`**
+
+In `src/server/mcp-server.ts`:
+
+```ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+// ...existing imports...
+import { registerResources } from './resources';
+import type { ObsidianAdapter } from '../obsidian/adapter';
+import type { McpPluginSettings } from '../types';
+
+export function createMcpServer(
+  registry: ModuleRegistry,
+  adapter: ObsidianAdapter,
+  settings: McpPluginSettings,
+  logger: Logger,
+): McpServer {
+  const capabilities: { tools: Record<string, never>; logging: Record<string, never>; resources?: Record<string, never> } = {
+    tools: {},
+    logging: {},
+  };
+  if (settings.resourcesEnabled) {
+    capabilities.resources = {};
+  }
+
+  const server = new McpServer(
+    {
+      name: 'obsidian-mcp-server',
+      version: manifest.version,
+    },
+    {
+      capabilities,
+      instructions: SERVER_INSTRUCTIONS,
+    },
+  );
+
+  registerTools(server, registry, logger);
+  if (settings.resourcesEnabled) {
+    registerResources(server, adapter, logger);
+  }
+
+  return server;
+}
+```
+
+- [ ] **Step 5: Run the full server test suite**
+
+```bash
+npx vitest run tests/server/mcp-server.test.ts
+```
+
+Expected: PASS — all existing tests adjusted plus the new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/mcp-server.ts tests/server/mcp-server.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server/mcp): wire resources capability into createMcpServer
+
+Adds adapter + settings parameters; declares resources: {} and calls
+registerResources iff settings.resourcesEnabled. Tools surface unchanged.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 14: Update `main.ts` to pass adapter and settings
+
+**Files:**
+- Modify: `src/main.ts:206`
+
+- [ ] **Step 1: Find the call site**
+
+```bash
+grep -n "createMcpServer" src/main.ts
+```
+
+Expected: one hit, in the `HttpMcpServer` constructor on line ~206 — the closure passes `(this.registry, this.logger)`.
+
+- [ ] **Step 2: Update the closure**
+
+Edit `src/main.ts`:
+
+```ts
+const server = new HttpMcpServer(
+  () => createMcpServer(this.registry, this.adapter, this.settings, this.logger),
+  this.logger,
+  // ...rest unchanged...
+);
+```
+
+- [ ] **Step 3: Run lint and typecheck**
+
+```bash
+npm run typecheck
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full test suite to catch any other consumer of `createMcpServer`**
+
+```bash
+npm test
+```
+
+Expected: PASS. If any test calls `createMcpServer` with the old signature outside `tests/server/mcp-server.test.ts`, update it inline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "$(cat <<'EOF'
+refactor(main): pass adapter and settings into createMcpServer
+
+Threads the new args required for the resources surface. Behaviour
+unchanged when settings.resourcesEnabled is true (default).
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 15: Add the settings UI toggle
+
+**Files:**
+- Modify: `src/settings/server-section.ts`
+- Test: `tests/settings/server-section.test.ts` if one exists; otherwise skip the unit test (this is a UI-side toggle that follows the well-trodden `setting_autostart_*` pattern).
+
+- [ ] **Step 1: Locate the auto-start toggle as a reference**
+
+```bash
+grep -n "setting_autostart_name\|autoStart" src/settings/server-section.ts
+```
+
+The auto-start toggle (around line 280) is the model.
+
+- [ ] **Step 2: Add a parallel toggle for `resourcesEnabled`**
+
+After the auto-start `new Setting(containerEl)` block in `renderServerSection`:
+
+```ts
+new Setting(containerEl)
+  .setName(t('setting_resources_enabled_name'))
+  .setDesc(t('setting_resources_enabled_desc'))
+  .addToggle((toggle) =>
+    toggle.setValue(plugin.settings.resourcesEnabled).onChange(async (value) => {
+      plugin.settings.resourcesEnabled = value;
+      await plugin.saveSettings();
+    }),
+  );
+```
+
+Place this immediately after the auto-start toggle and before the call to `renderDnsRebindSection`.
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS — `plugin.settings.resourcesEnabled` resolves through the type added in Task 4.
+
+- [ ] **Step 4: Run the test suite**
+
+```bash
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/server-section.ts
+git commit -m "$(cat <<'EOF'
+feat(settings/server): add toggle for resources surface
+
+Single boolean. Restart the server to apply (matches the rest of the
+server-section settings).
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 16: Integration smoke test through the real SDK transport
+
+**Files:**
+- Modify: `tests/server/mcp-server.test.ts` OR
+- Create: `tests/integration/resources.test.ts` if the existing `tests/integration/server.test.ts` is the canonical place for transport-level checks
+
+- [ ] **Step 1: Inspect the existing integration test for the project's transport pattern**
+
+```bash
+sed -n '1,60p' tests/integration/server.test.ts
+```
+
+Use whatever transport setup that file establishes. If it's an HTTP-level integration with a real `HttpMcpServer`, write the smoke test in the same shape; if it uses `InMemoryTransport` from the SDK, prefer that for speed.
+
+- [ ] **Step 2: Write the smoke test**
+
+A minimum two-call test using `InMemoryTransport` (preferred) — pseudocode pattern; adapt to whatever helpers the existing tests use:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../../src/server/mcp-server';
+import { ModuleRegistry } from '../../src/registry/module-registry';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { Logger } from '../../src/utils/logger';
+
+describe('resources surface — end-to-end', () => {
+  it('reads obsidian://vault/index and a vault file via the SDK transport', async () => {
+    const adapter = new MockObsidianAdapter('/tmp/vault');
+    adapter.addFile('hello.md', '# Hello');
+    const logger = new Logger('test', { debugMode: false, accessKey: '' });
+    const registry = new ModuleRegistry(logger);
+    const server = createMcpServer(registry, adapter, DEFAULT_SETTINGS, logger);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'test', version: '0' }, { capabilities: {} });
+    await client.connect(clientTransport);
+
+    const indexResp = await client.readResource({ uri: 'obsidian://vault/index' });
+    expect(indexResp.contents[0].mimeType).toBe('application/json');
+
+    const fileResp = await client.readResource({ uri: 'obsidian://vault/hello.md' });
+    expect(fileResp.contents[0]).toMatchObject({
+      uri: 'obsidian://vault/hello.md',
+      mimeType: 'text/markdown',
+      text: '# Hello',
+    });
+
+    await client.close();
+    await server.close();
+  });
+});
+```
+
+If `InMemoryTransport` lives at a different import path in the installed SDK version, find it via:
+
+```bash
+grep -rn "InMemoryTransport" node_modules/@modelcontextprotocol/sdk/dist/esm/inMemory.* 2>&1 | head -5
+```
+
+and update the import to match.
+
+If `InMemoryTransport` is not available, skip this task and add a TODO comment in `tests/server/resources.test.ts` referencing the limitation; the unit-level coverage of `parseVaultUri`, `fileHandler`, `indexHandler`, and `registerResources` is already comprehensive.
+
+- [ ] **Step 3: Run the test**
+
+```bash
+npx vitest run tests/integration/resources.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/resources.test.ts
+git commit -m "$(cat <<'EOF'
+test(server/resources): end-to-end smoke through SDK transport
+
+Round-trips resources/read for the static index and a vault file via the
+in-memory transport. Confirms the SDK actually surfaces what the unit
+tests construct in isolation.
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 17: Update the user manual
+
+**Files:**
+- Modify: `docs/help/en.md`
+- Modify: `docs/help/de.md` if it exists (check first)
+
+- [ ] **Step 1: Find a good insertion point**
+
+```bash
+grep -n "## " docs/help/en.md | head -20
+```
+
+Locate the section that describes the MCP surface (likely a "Tools" or "MCP modules" heading). Insert the new "Resources" section after it.
+
+- [ ] **Step 2: Add the Resources section**
+
+Add a section like:
+
+```markdown
+## Resources
+
+In addition to tools, the server exposes the vault as **MCP resources** so hosts (Claude Desktop, MCP-compatible IDEs, etc.) can browse and read notes natively without spending tool-use turns.
+
+### URIs
+
+- **`obsidian://vault/index`** — a static JSON listing of every file and folder in the vault. Each file entry carries a ready-to-read URI and mime type. Listings over 25 000 characters are truncated; use the `vault_list_recursive` tool for full enumeration on very large vaults.
+- **`obsidian://vault/{path}`** — read any file by its vault-relative path. Markdown, text, JSON, CSV, YAML, HTML, and SVG files are returned as text; other files (images, PDFs, audio, video) are returned as base64 blobs.
+
+Binary files larger than **1 MiB** are refused. Use the `vault_read_binary` tool if you genuinely need a larger file.
+
+### Disabling
+
+If you only want the tools surface, turn off **"Expose vault files as MCP resources"** in *Server Settings* and restart the server. The server then advertises a tools-only capability set.
+```
+
+- [ ] **Step 3: Add a German equivalent if `docs/help/de.md` exists**
+
+Mirror the section, translated. If only `en.md` exists, skip.
+
+- [ ] **Step 4: Run the docs check**
+
+```bash
+npm run docs:tools
+```
+
+Expected: clean diff (resources are not tools, so the generated tools doc is unaffected). If the script produces a diff, investigate before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/help/en.md docs/help/de.md 2>/dev/null || git add docs/help/en.md
+git commit -m "$(cat <<'EOF'
+docs(help): document the MCP resources surface
+
+Refs #292
+EOF
+)"
+```
+
+---
+
+## Task 18: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: PASS (no warnings, no errors). Fix anything new the resources file introduced before continuing.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: 491+ passing (existing baseline plus all new tests added across Tasks 1–16).
+
+- [ ] **Step 4: Confirm `docs:tools` is clean**
+
+```bash
+npm run docs:tools
+git status --short docs/tools.generated.md
+```
+
+Expected: no diff.
+
+- [ ] **Step 5: Verify the commit list reads coherently**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: ~17 commits, each with a Conventional Commits subject, no AI attribution, all referencing `#292`.
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin feat/issue-292-mcp-resources-vault-files
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+gh pr create --title "feat(server/mcp): expose vault files as MCP resources" --body "$(cat <<'EOF'
+Closes #292
+
+## Summary
+- Adds an MCP resources surface so hosts can browse and read vault files without consuming tool-use turns.
+- Two registrations: a static `obsidian://vault/index` JSON listing and a `obsidian://vault/{+path}` template.
+- Gated by a new `resourcesEnabled` setting (default on, v10→v11 migration).
+- Lifts the 1 MiB binary cap into a typed `BinaryTooLargeError` shared between `vault_read_binary` and the resources surface.
+
+Subscriptions, `notifications/resources/list_changed`, and `roots` honoring are deferred per the [design spec](docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md).
+
+## Test plan
+- [x] `npm run lint`
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run docs:tools` (clean diff)
+- [ ] Manual smoke test against a host: enable the toggle, point a client at the server, request `resources/list` and `resources/read` for the index plus a known file
+EOF
+)"
+```
+
+Done.
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+| Spec section | Task |
+|---|---|
+| Architecture: `registerResources` after `registerTools` | Task 12, 13 |
+| Capability declaration gated on `resourcesEnabled` | Task 13 |
+| Static index registration | Task 11, 12 |
+| File template registration with `{+path}` and `list: undefined` | Task 12 |
+| Mime table + `getMimeType` + `isTextMime` | Task 7 |
+| `parseVaultUri` with scheme/host check + `validateVaultPath` | Task 8 |
+| `fileHandler` text branch | Task 9 |
+| `fileHandler` binary branch with 1 MiB cap | Task 10 |
+| `indexHandler` with truncation | Task 11 |
+| `BinaryTooLargeError` typed error | Task 1, 2 |
+| `resourcesEnabled` setting | Task 4 |
+| v10→v11 migration | Task 5 |
+| Lang strings (en + de) | Task 6 |
+| Settings UI toggle | Task 15 |
+| `main.ts` wiring | Task 14 |
+| Mock adapter `''` root | Task 3 |
+| Tests: URI parsing, mime, text, binary, index, settings gating, migration | Tasks 5, 7–13 |
+| Integration smoke test | Task 16 |
+| `docs/help/en.md` + locale siblings | Task 17 |
+| `docs/tools.generated.md` clean diff verification | Task 17, 18 |
+
+All spec sections accounted for.
+
+**Type consistency check:**
+- `createFileHandler` and `createIndexHandler` factory pattern is consistent across Tasks 9, 10, 11.
+- `VaultUriVariables` type defined in Task 8 is reused in Task 9 and Task 12.
+- `ObsidianAdapter` is imported as the existing project type in Task 9 onward.
+- `Logger` is the existing `src/utils/logger` type, used identically across tasks.
+- `BinaryTooLargeError` constructor signature `(sizeBytes, limitBytes)` is consistent between Task 1 (definition), Task 2 (vault handler), and Task 10 (resources handler).
+- `CHARACTER_LIMIT` import path is `src/constants` per Task 11; `BINARY_BYTE_LIMIT` from the same file in Task 10.
+- `migrateV10ToV11` named consistently between Task 5 implementation and tests.
+
+**Placeholder scan:** No "TBD" / "TODO" / "fill in details" / "similar to Task N" placeholders. Every code step contains the actual code. Step 5 of Task 16 has a conditional fallback ("if `InMemoryTransport` is not available") with explicit guidance, not a placeholder. The `_logger` parameter naming convention is intentional (TS allows `_`-prefixed unused params), not a placeholder.
+
+Plan is complete.

--- a/docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md
+++ b/docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md
@@ -1,0 +1,431 @@
+# MCP resources for vault files
+
+**Issue:** [#292](https://github.com/KingOfKalk/obsidian-plugin-mcp/issues/292)
+**Date:** 2026-05-03
+**Status:** Proposed
+
+## Summary
+
+Expose vault files as MCP resources alongside the existing tools surface, so
+hosts can browse the vault and pull notes into context without driving Claude
+through `vault_list` → `vault_read` round-trips. Adds two registrations:
+
+- a static index at `obsidian://vault/index` returning a JSON tree, and
+- a resource template at `obsidian://vault/{+path}` that serves any file in
+  the vault as text or base64 blob.
+
+Subscriptions, `notifications/resources/list_changed`, and per-file
+`resources/list` enumeration are deferred to follow-up issues. The resource
+surface ships gated by a single settings toggle (`resourcesEnabled`,
+default on).
+
+## Goals
+
+- Surface the vault as a first-class MCP resource provider so hosts can
+  attach notes without consuming tool-use turns.
+- Keep the tool surface unchanged; resources are purely additive.
+- Reuse `validateVaultPath` so traversal protection is shared.
+- Keep code self-contained in one file (`src/server/resources.ts`) without
+  widening `ModuleRegistry`.
+
+## Non-goals
+
+- Subscriptions (`resources/subscribe` + `notifications/resources/updated`).
+  Deferred to a follow-up issue.
+- `notifications/resources/list_changed`. Deferred.
+- Honoring client-advertised `roots`. The vault is single-rooted; we ignore
+  `roots` and document the behaviour.
+- Binary files larger than 1 MiB. Hosts use `vault_read_binary` for those.
+- Per-file enumeration via the `ResourceTemplate.list` callback. The static
+  index covers discovery; we pass `list: undefined` to the template.
+- Folding resources into `ModuleRegistry`. Possible later cleanup if/when
+  prompts arrive — out of scope here.
+
+### Known limitation
+
+A file at vault root literally named `index` (no extension) would map to
+`obsidian://vault/index` and be shadowed by the static index URI. Such
+files are unusual in Obsidian (notes carry the `.md` extension) and would
+not collide. If a user does have a no-extension `index` file at the vault
+root, it remains reachable via the tool surface (`vault_read`) but not via
+the resource template. Documented; not addressed in v1.
+
+## Design decisions
+
+| Decision            | Choice                                                                                                         | Rationale                                                                                                                                                                                                                                             |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| URI scheme          | `obsidian://vault/{+path}`                                                                                     | Unambiguous vault scope; avoids confusing hosts that might try to resolve `file://` against the real filesystem. The `+` operator (RFC 6570 reserved expansion, supported by the MCP SDK's `UriTemplate`) preserves slashes in the captured variable. |
+| Subscriptions in v1 | No                                                                                                             | Smaller, reviewable PR. Browse + read delivers the headline benefit. Live-tailing waits for a follow-up.                                                                                                                                              |
+| Binary handling     | Text + blob, capped at 1 MiB                                                                                   | Vaults contain attachments; refusing them creates a confusing gap. The 1 MiB cap matches `vault_read_binary` so behaviour is consistent across surfaces.                                                                                              |
+| Static index        | Yes, at `obsidian://vault/index`                                                                               | Single predictable URI returning a JSON tree, instead of a `resources/list` stream. Easier to consume and avoids the "list returns 50 000 entries" failure mode on large vaults.                                                                      |
+| Index shape         | Flat `{ files: [{uri, name, mimeType, size}], folders: string[], truncated: boolean }`, capped at 25 000 chars | Same flat shape as `vault_list_recursive`; resource entries are self-sufficient (URI + mime ready to use). Truncation is a JSON flag, not a footer string.                                                                                            |
+| `roots`             | Ignored                                                                                                        | Vault is single-rooted. Intersection checks would be brittle (path normalisation differs across platforms) and add no safety.                                                                                                                         |
+| Settings toggle     | Single global `resourcesEnabled`, default `true`                                                               | Resources are one coherent feature. Per-resource toggles would be premature.                                                                                                                                                                          |
+| Mime detection      | Hard-coded extension table in `resources.ts`                                                                   | ~20 entries cover Obsidian-relevant types; cheaper and more reviewable than a dependency.                                                                                                                                                             |
+| File location       | `src/server/resources.ts`                                                                                      | Resources are a different MCP primitive than tools. Side-by-side at the server layer; doesn't bloat `mcp-server.ts`.                                                                                                                                  |
+
+## Architecture
+
+A new file `src/server/resources.ts` exports
+`registerResources(server, adapter, logger)`, called from `createMcpServer`
+after `registerTools` when the settings flag is on. Self-contained: it owns
+the URI parser, mime table, index handler, and template handler. No changes
+to `ModuleRegistry`.
+
+```
+createMcpServer(registry, settings, logger)
+  ├── registerTools(server, registry, logger)        // existing
+  └── if (settings.resourcesEnabled)
+        registerResources(server, adapter, logger)   // new
+```
+
+`McpServer` is constructed with `capabilities.resources: {}` only when
+`settings.resourcesEnabled === true`. When false, the capability is omitted
+and `registerResources` is not called — the host sees a tools-only server,
+identical to today.
+
+Two registrations performed inside `registerResources`:
+
+1. **Static index** —
+   ```ts
+   server.registerResource(
+     'vault-index',
+     'obsidian://vault/index',
+     { name: 'Vault index', mimeType: 'application/json',
+       description: '...' },
+     indexHandler,
+   );
+   ```
+
+2. **File template** —
+   ```ts
+   server.registerResource(
+     'vault-file',
+     new ResourceTemplate('obsidian://vault/{+path}', { list: undefined }),
+     { name: 'Vault file', description: '...' },
+     fileHandler,
+   );
+   ```
+
+`list: undefined` is required by the SDK contract; we deliberately opt out
+of per-file enumeration in favour of the static index.
+
+## Components
+
+`src/server/resources.ts` exposes `registerResources(...)` and contains five
+internal pieces:
+
+### 1. `MIME_TABLE` and `getMimeType(path: string): string`
+
+Const map keyed by lowercase extension (with the dot). Coverage:
+
+- Text: `.md → text/markdown`, `.txt → text/plain`, `.json → application/json`,
+  `.csv → text/csv`, `.yml/.yaml → application/yaml`, `.html/.htm → text/html`,
+  `.css → text/css`, `.js/.mjs → text/javascript`, `.ts → text/x-typescript`,
+  `.svg → image/svg+xml` (text-serialisable XML; treated as text below).
+- Binary images: `.png`, `.jpg/.jpeg`, `.gif`, `.webp`, `.bmp`, `.ico`.
+- Binary audio/video: `.mp3`, `.wav`, `.ogg`, `.m4a`, `.flac`, `.mp4`, `.webm`, `.mov`.
+- Binary documents: `.pdf`, `.zip`, `.epub`.
+- Fallback: `application/octet-stream`.
+
+`getMimeType` lowercases the extension and looks it up; returns the fallback
+for unknown extensions or files without an extension.
+
+### 2. `isTextMime(mime: string): boolean`
+
+Returns `true` for `text/*` and exactly `application/json`. (We treat
+`image/svg+xml` as text-readable: SVG is XML, hosts can render it as text or
+binary; we serialise it as text to keep file size of the wire format down.
+This is the only `image/*` text-classified entry, and the rule is "starts
+with `text/` OR equals `application/json` OR equals `image/svg+xml`".)
+
+### 3. `parseVaultUri(uri: URL, variables: Variables): string`
+
+For the file template. Reads `variables.path`, validates the scheme is
+`obsidian:` and host is `vault` (defence in depth — the SDK should already
+have matched), calls `validateVaultPath` against `adapter.getVaultPath()`,
+returns the validated relative path. Throws `PathTraversalError` on bad
+input.
+
+The path arrives already URL-decoded by the SDK's `UriTemplate` (RFC 6570
+reserved expansion preserves reserved characters but the SDK still
+percent-decodes the captured variable). `validateVaultPath` handles the
+encoded-traversal check on the raw decoded string and rejects `\0`,
+backslashes, `%2e`/`%2f`/`%5c`, and post-normalisation traversal.
+
+### 4. `indexHandler(uri, extra): Promise<ReadResourceResult>`
+
+Calls `adapter.listRecursive(VAULT_ROOT)` where `VAULT_ROOT` is the same
+root-path convention `vault_list_recursive` uses today (`src/tools/vault/handlers.ts`
+— follow whatever that handler passes; do not invent a new convention).
+For each file: build
+`{ uri: 'obsidian://vault/' + encodeURI(path), name: basename(path),
+mimeType: getMimeType(path), size: stat(path).size ?? 0 }`. For folders:
+the recursive folder list as bare strings.
+
+Build the JSON shape `{ files, folders, truncated: false }`,
+`JSON.stringify` it, and if the serialised string exceeds 25 000 chars,
+drop entries from the **tail** of `files` until it fits, then re-serialise
+with `truncated: true`. Folder list is preserved (it's small and structurally
+useful even when files are truncated).
+
+Returns `{ contents: [{ uri: 'obsidian://vault/index', mimeType:
+'application/json', text: <serialised JSON> }] }`.
+
+URI encoding: paths in entries use `encodeURI` (not `encodeURIComponent`)
+so slashes survive — the matching `parseVaultUri` decodes them back.
+
+### 5. `fileHandler(uri, variables, extra): Promise<ReadResourceResult>`
+
+Steps:
+
+1. `path = parseVaultUri(uri, variables)` — throws `PathTraversalError` on
+   bad input.
+2. `mime = getMimeType(path)`.
+3. If `isTextMime(mime)`:
+   - `text = await adapter.readFile(path)`.
+   - Return `{ contents: [{ uri: uri.toString(), mimeType: mime, text }] }`.
+4. Else (binary):
+   - `stat = await adapter.stat(path)`. If `stat === null`, throw
+     `NotFoundError` (matches the existing tool behaviour).
+   - If `stat.size > 1 MiB` (1 048 576 bytes), throw
+     `BinaryTooLargeError` (new typed error, see below).
+   - `data = await adapter.readBinary(path)`.
+   - `blob = Buffer.from(data).toString('base64')`.
+   - Return `{ contents: [{ uri: uri.toString(), mimeType: mime, blob }] }`.
+
+We do **not** add a `handleResourceError` wrapper. Thrown errors propagate
+to the SDK, which maps them into the standard `resources/read` error
+envelope using `error.message`.
+
+### `BinaryTooLargeError` (new)
+
+`src/tools/shared/errors.ts` already houses `NotFoundError`,
+`PermissionError`, `FolderNotFoundError`, etc. Today, the 1 MiB cap in
+`vault_read_binary` is implemented inline as a string `errorResult`. To
+share the cap between tools and resources, this design adds:
+
+```ts
+export class BinaryTooLargeError extends Error {
+  constructor(public readonly sizeBytes: number, public readonly limitBytes: number) {
+    super(
+      `Binary file too large (${sizeBytes} bytes, limit ${limitBytes}). ` +
+      `Fetch the file out-of-band or use a chunked read when available.`,
+    );
+    this.name = 'BinaryTooLargeError';
+  }
+}
+```
+
+`vault_read_binary` is updated to throw this and let `handleToolError` render
+it; `resources.ts` throws the same type. Behaviour for tool callers is
+unchanged (same message text).
+
+## Data flow
+
+### `resources/read` for `obsidian://vault/notes/foo.md`
+
+```
+SDK matches template → variables.path = "notes/foo.md"
+  → fileHandler(uri, variables, extra)
+     → parseVaultUri → validateVaultPath("notes/foo.md", vaultPath)
+        → returns "notes/foo.md"
+     → getMimeType("notes/foo.md") → "text/markdown"
+     → isTextMime → true → adapter.readFile("notes/foo.md")
+     → return { contents: [{ uri, mimeType: "text/markdown", text }] }
+```
+
+### `resources/read` for `obsidian://vault/attachments/img.png`
+
+```
+SDK matches template → variables.path = "attachments/img.png"
+  → fileHandler(uri, variables, extra)
+     → parseVaultUri → "attachments/img.png"
+     → getMimeType → "image/png"
+     → isTextMime → false
+     → adapter.stat → { size: 12345 }; under 1 MiB
+     → adapter.readBinary → ArrayBuffer
+     → base64 encode
+     → return { contents: [{ uri, mimeType: "image/png", blob }] }
+```
+
+### `resources/read` for `obsidian://vault/index`
+
+```
+SDK matches static URI → indexHandler(uri, extra)
+  → adapter.listRecursive("/")
+  → for each file: { uri, name, mimeType, size }
+  → JSON.stringify; if > 25 000 chars, drop tail of files, set truncated: true
+  → return { contents: [{ uri, mimeType: "application/json", text }] }
+```
+
+### Bad URI (traversal)
+
+```
+fileHandler("obsidian://vault/../etc/passwd")
+  → parseVaultUri → validateVaultPath throws PathTraversalError
+  → SDK maps thrown error to resources/read error response
+```
+
+## Settings
+
+### Schema change
+
+`McpPluginSettings` gains:
+
+```ts
+/** When true, the server exposes vault files as MCP resources in addition to tools. */
+resourcesEnabled: boolean;
+```
+
+`DEFAULT_SETTINGS.resourcesEnabled = true`.
+
+### Migration
+
+`src/settings/migrations.ts` adds a v10 → v11 step:
+
+- Bump `schemaVersion` from 10 to 11.
+- Set `resourcesEnabled: true` if the field is missing (existing installs
+  opt in by default).
+
+### UI
+
+`src/settings/server-section.ts` gains one toggle:
+
+- Label: "Expose vault files as MCP resources" (en string;
+  translatable).
+- Description: "When on, hosts can browse and read vault files via the
+  MCP resources surface in addition to the tools. Restart the server
+  to apply changes."
+- Bound to `settings.resourcesEnabled` with `saveSettings` on change,
+  same pattern as other server-section toggles.
+
+A server restart is required for the change to take effect — same as other
+server-affecting settings today; no special handling beyond the existing
+"restart the server" hint.
+
+## Testing
+
+New file: `tests/server/resources.test.ts`. Tests use mock `ObsidianAdapter`
+instances built with the project's existing patterns (see
+`tests/__mocks__/obsidian.ts` and tool tests).
+
+### URI parsing & path-guard reuse
+
+- Plain path → returns the validated relative path.
+- URL-encoded spaces (`My%20Notes/foo.md`) → decoded, validates.
+- Unicode path (`Notizen/Übersicht.md`) → handled.
+- Traversal (`../etc/passwd`) → `PathTraversalError`.
+- Encoded traversal (`..%2F..`) → rejected.
+- Wrong scheme (`file:///foo.md`) → rejected.
+- Wrong host (`obsidian://other/foo.md`) → rejected.
+- Empty path → rejected.
+
+### Mime-type selection
+
+- `.md → text/markdown`, text.
+- `.txt → text/plain`, text.
+- `.json → application/json`, text.
+- `.png → image/png`, binary.
+- `.pdf → application/pdf`, binary.
+- `.svg → image/svg+xml`, text.
+- Unknown extension → `application/octet-stream`, binary.
+
+### File handler — text
+
+- Reads `notes/foo.md` → one `TextResourceContents`, `text/markdown`,
+  UTF-8 content.
+- File not found → propagates `NotFoundError`.
+
+### File handler — binary
+
+- Reads `attachments/img.png` (1 KB) → one `BlobResourceContents`, base64
+  of raw bytes, `image/png`.
+- File at exactly 1 MiB → served.
+- File over 1 MiB → `BinaryTooLargeError`.
+- `adapter.stat === null` → `NotFoundError`.
+
+### Index handler
+
+- Small vault (3 files, 1 folder) → JSON with `files`, `folders`,
+  `truncated: false`. Each `uri` is `obsidian://vault/<encoded path>`.
+- Large vault serialising past 25 000 chars → entries dropped from tail,
+  `truncated: true`.
+- Empty vault → `{ files: [], folders: [], truncated: false }`.
+- Round-trip: feeding each `entry.uri` back into `parseVaultUri` yields the
+  original path.
+
+### Settings-toggle gating
+
+- `createMcpServer` with `resourcesEnabled: false` → server capabilities
+  exclude `resources`; no resource registrations performed.
+- `resourcesEnabled: true` → both `vault-index` and `vault-file` registered.
+
+### Settings migration
+
+- v10 settings (no `resourcesEnabled`) → migrated to v11,
+  `resourcesEnabled: true`.
+- v11 settings with explicit `false` → preserved.
+
+### `BinaryTooLargeError` — tool path unchanged
+
+- Existing `vault_read_binary` test for over-cap files still passes; the
+  rendered error message string is identical to today.
+
+### Integration smoke test
+
+One test in `tests/server/mcp-server.test.ts` (or co-located): an
+end-to-end `resources/read` round-trip via the in-memory MCP transport,
+confirming SDK wiring actually surfaces both the index and a file by URI.
+
+## Documentation
+
+CLAUDE.md rule 5 requires the user manual to stay in sync with user-facing
+surface changes.
+
+- `docs/help/en.md` — add a "Resources" section under the MCP surface
+  description, covering:
+  - The `obsidian://vault/index` URI and what it returns.
+  - The `obsidian://vault/{path}` URI template.
+  - The 1 MiB binary cap.
+  - The `resourcesEnabled` settings toggle.
+  - Brief: most users won't see this directly; their host UI does.
+- Sibling locale files — same section translated where translations exist.
+- `docs/tools.generated.md` — **no change.** Resources don't live in the
+  tool registry, so the generator output is unaffected. Verify by running
+  `npm run docs:tools` and confirming a clean diff.
+
+## Files added / modified
+
+### Added
+
+- `src/server/resources.ts`
+- `tests/server/resources.test.ts`
+
+### Modified
+
+- `src/server/mcp-server.ts` — declare `resources: {}` capability when
+  `settings.resourcesEnabled === true`; call `registerResources(...)` after
+  `registerTools(...)`. `createMcpServer` signature gains the adapter and
+  settings (or just the boolean flag) — see implementation plan for the
+  exact shape.
+- `src/main.ts` — pass adapter and resources flag into `createMcpServer`.
+- `src/types.ts` — add `resourcesEnabled: boolean` to `McpPluginSettings`;
+  add it to `DEFAULT_SETTINGS` as `true`.
+- `src/settings/migrations.ts` — v10 → v11 step.
+- `src/settings/server-section.ts` — one new toggle.
+- `src/lang/en.ts` (and other locale files where translations exist) —
+  strings for the new toggle and any user-facing copy.
+- `src/tools/shared/errors.ts` — add `BinaryTooLargeError`.
+- `src/tools/vault/handlers.ts` — `readBinary` throws
+  `BinaryTooLargeError` instead of returning a string `errorResult`.
+- `docs/help/en.md` (and locale siblings) — Resources section.
+
+## Verification
+
+- `npm run lint`, `npm run typecheck`, `npm test` all green.
+- `npm run docs:tools` produces no diff.
+- Manual smoke test: start server, run `initialize` followed by
+  `resources/read` for `obsidian://vault/index` and a known file URI;
+  confirm both return the expected shape and that `resourcesEnabled: false`
+  causes the capability to disappear.

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -78,6 +78,9 @@ const de: Partial<Record<keyof typeof en, string>> = {
     'MCP-Server nicht gestartet — das eigene Zertifikat ist ungültig: {message}',
   setting_autostart_name: 'Beim Start automatisch starten',
   setting_autostart_desc: 'MCP-Server automatisch starten, wenn Obsidian gestartet wird',
+  setting_resources_enabled_name: 'Vault-Dateien als MCP-Ressourcen freigeben',
+  setting_resources_enabled_desc:
+    'Wenn aktiviert, können MCP-Hosts Vault-Dateien zusätzlich zu den Tools über die Resources-Schnittstelle (obsidian://vault/{Pfad}) lesen und durchsuchen. Server neu starten, damit die Änderung wirksam wird.',
 
   // DNS Rebind Protection
   heading_dns_rebind: 'DNS-Rebind-Schutz',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -79,6 +79,9 @@ const en = {
     'MCP server not started — bring-your-own certificate is invalid: {message}',
   setting_autostart_name: 'Auto-start on launch',
   setting_autostart_desc: 'Start MCP server automatically when Obsidian launches',
+  setting_resources_enabled_name: 'Expose vault files as MCP resources',
+  setting_resources_enabled_desc:
+    'When on, MCP hosts can browse and read vault files via the resources surface (obsidian://vault/{path}) in addition to tools. Restart the server to apply changes.',
 
   // Settings — DNS Rebind Protection subsection (Origin / Host validation)
   heading_dns_rebind: 'DNS Rebind Protection',

--- a/src/main.ts
+++ b/src/main.ts
@@ -203,7 +203,7 @@ export default class McpPlugin extends Plugin {
     }
 
     const server = new HttpMcpServer(
-      () => createMcpServer(this.registry, this.logger),
+      () => createMcpServer(this.registry, this.adapter, this.settings, this.logger),
       this.logger,
       {
         host: this.settings.serverAddress,

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -197,6 +197,7 @@ export class MockObsidianAdapter implements ObsidianAdapter {
       }
     }
     for (const folderPath of this.folders) {
+      if (folderPath === '/') continue; // root sentinel — never user-visible
       if (folderPath !== path && (isRoot || folderPath.startsWith(prefix))) {
         folders.push(folderPath);
       }
@@ -508,6 +509,7 @@ export class MockObsidianAdapter implements ObsidianAdapter {
       }
     }
     for (const folderPath of this.folders) {
+      if (folderPath === '/') continue; // root sentinel — never user-visible
       if (
         folderPath !== path &&
         folderPath.startsWith(prefix) &&

--- a/src/obsidian/mock-adapter.ts
+++ b/src/obsidian/mock-adapter.ts
@@ -176,26 +176,28 @@ export class MockObsidianAdapter implements ObsidianAdapter {
   }
 
   list(path: string): ListResult {
-    if (!this.folders.has(path) && path !== '/') {
+    const isRoot = path === '/' || path === '';
+    if (!this.folders.has(path) && !isRoot) {
       throw new FolderNotFoundError(path);
     }
-    return this.getDirectChildren(path);
+    return this.getDirectChildren(isRoot ? '' : path);
   }
 
   listRecursive(path: string): ListResult {
-    if (!this.folders.has(path) && path !== '/') {
+    const isRoot = path === '/' || path === '';
+    if (!this.folders.has(path) && !isRoot) {
       throw new FolderNotFoundError(path);
     }
-    const prefix = path === '/' ? '' : path + '/';
+    const prefix = isRoot ? '' : path + '/';
     const files: string[] = [];
     const folders: string[] = [];
     for (const filePath of this.files.keys()) {
-      if (path === '/' || filePath.startsWith(prefix)) {
+      if (isRoot || filePath.startsWith(prefix)) {
         files.push(filePath);
       }
     }
     for (const folderPath of this.folders) {
-      if (folderPath !== path && (path === '/' || folderPath.startsWith(prefix))) {
+      if (folderPath !== path && (isRoot || folderPath.startsWith(prefix))) {
         folders.push(folderPath);
       }
     }
@@ -496,7 +498,8 @@ export class MockObsidianAdapter implements ObsidianAdapter {
   }
 
   private getDirectChildren(path: string): ListResult {
-    const prefix = path === '/' ? '' : path + '/';
+    const isRoot = path === '/' || path === '';
+    const prefix = isRoot ? '' : path + '/';
     const files: string[] = [];
     const folders: string[] = [];
     for (const filePath of this.files.keys()) {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -6,6 +6,9 @@ import { ModuleRegistry } from '../registry/module-registry';
 import { ToolDefinition } from '../registry/types';
 import { handleToolError } from '../tools/shared/errors';
 import { createToolContext, type SdkExtra } from '../registry/tool-context';
+import { registerResources } from './resources';
+import type { ObsidianAdapter } from '../obsidian/adapter';
+import type { McpPluginSettings } from '../types';
 import manifest from '../../manifest.json';
 
 /**
@@ -24,8 +27,22 @@ export const SERVER_INSTRUCTIONS = `This server exposes an Obsidian vault as MCP
 
 export function createMcpServer(
   registry: ModuleRegistry,
+  adapter: ObsidianAdapter,
+  settings: McpPluginSettings,
   logger: Logger,
 ): McpServer {
+  const capabilities: {
+    tools: Record<string, never>;
+    logging: Record<string, never>;
+    resources?: Record<string, never>;
+  } = {
+    tools: {},
+    logging: {},
+  };
+  if (settings.resourcesEnabled) {
+    capabilities.resources = {};
+  }
+
   const server = new McpServer(
     {
       // {service}-mcp-server naming convention for the MCP protocol
@@ -35,15 +52,15 @@ export function createMcpServer(
       version: manifest.version,
     },
     {
-      capabilities: {
-        tools: {},
-        logging: {},
-      },
+      capabilities,
       instructions: SERVER_INSTRUCTIONS,
     },
   );
 
   registerTools(server, registry, logger);
+  if (settings.resourcesEnabled) {
+    registerResources(server, adapter, logger);
+  }
 
   return server;
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -140,12 +140,6 @@ interface IndexEntry {
   size: number;
 }
 
-interface IndexPayload {
-  files: IndexEntry[];
-  folders: string[];
-  truncated: boolean;
-}
-
 const VAULT_INDEX_URI = 'obsidian://vault/index';
 
 function basename(p: string): string {
@@ -178,23 +172,19 @@ export function createIndexHandler(
     );
     const folders = sortedFolders;
 
-    let payload: IndexPayload = { files, folders, truncated: false };
-    let serialised = JSON.stringify(payload);
+    let serialised = JSON.stringify({ files, folders, truncated: false });
     if (serialised.length > CHARACTER_LIMIT) {
       const trimmed = [...files];
       while (trimmed.length > 0) {
         trimmed.pop();
-        const candidate: IndexPayload = { files: trimmed, folders, truncated: true };
-        const candidateSerialised = JSON.stringify(candidate);
-        if (candidateSerialised.length <= CHARACTER_LIMIT) {
-          payload = candidate;
-          serialised = candidateSerialised;
+        const candidate = JSON.stringify({ files: trimmed, folders, truncated: true });
+        if (candidate.length <= CHARACTER_LIMIT) {
+          serialised = candidate;
           break;
         }
       }
       if (serialised.length > CHARACTER_LIMIT) {
-        payload = { files: [], folders: [], truncated: true };
-        serialised = JSON.stringify(payload);
+        serialised = JSON.stringify({ files: [], folders: [], truncated: true });
       }
     }
 

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -219,7 +219,7 @@ export function registerResources(
     VAULT_INDEX_URI,
     {
       description:
-        'JSON listing of every file and folder in the vault, with ready-to-use obsidian://vault/{path} URIs and mime types. Truncated past 25 000 characters.',
+        'JSON listing of every file and folder in the vault, with ready-to-use obsidian://vault/{+path} URIs and mime types. Truncated past 25 000 characters.',
       mimeType: 'application/json',
     },
     (uri: URL) => indexHandler(uri),
@@ -230,7 +230,7 @@ export function registerResources(
     new ResourceTemplate(FILE_TEMPLATE_URI, { list: undefined }),
     {
       description:
-        'Read any file in the vault by obsidian://vault/{path}. Text files (markdown, txt, json, csv, yaml, html, svg) return TextResourceContents; other files up to 1 MiB return base64 BlobResourceContents.',
+        'Read any file in the vault by obsidian://vault/{+path}. Text files (markdown, txt, json, csv, yaml, html, svg) return TextResourceContents; other files up to 1 MiB return base64 BlobResourceContents.',
     },
     (uri: URL, variables) => fileHandler(uri, variables as VaultUriVariables),
   );

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -1,5 +1,7 @@
 import { posix } from 'path';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
 import type { ObsidianAdapter } from '../obsidian/adapter';
 import type { Logger } from '../utils/logger';
@@ -200,4 +202,36 @@ export function createIndexHandler(
       ],
     };
   };
+}
+
+const FILE_TEMPLATE_URI = 'obsidian://vault/{+path}';
+
+export function registerResources(
+  server: McpServer,
+  adapter: ObsidianAdapter,
+  logger: Logger,
+): void {
+  const indexHandler = createIndexHandler(adapter, logger);
+  const fileHandler = createFileHandler(adapter, logger);
+
+  server.registerResource(
+    'vault-index',
+    VAULT_INDEX_URI,
+    {
+      description:
+        'JSON listing of every file and folder in the vault, with ready-to-use obsidian://vault/{path} URIs and mime types. Truncated past 25 000 characters.',
+      mimeType: 'application/json',
+    },
+    (uri: URL) => indexHandler(uri),
+  );
+
+  server.registerResource(
+    'vault-file',
+    new ResourceTemplate(FILE_TEMPLATE_URI, { list: undefined }),
+    {
+      description:
+        'Read any file in the vault by obsidian://vault/{path}. Text files (markdown, txt, json, csv, yaml, html, svg) return TextResourceContents; other files up to 1 MiB return base64 BlobResourceContents.',
+    },
+    (uri: URL, variables) => fileHandler(uri, variables as VaultUriVariables),
+  );
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -1,5 +1,8 @@
 import { posix } from 'path';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
+import type { ObsidianAdapter } from '../obsidian/adapter';
+import type { Logger } from '../utils/logger';
 
 /**
  * Static mime-type table covering the file types that show up in an
@@ -83,4 +86,32 @@ export function parseVaultUri(
     ? variables.path.join('/')
     : variables.path;
   return validateVaultPath(raw, vaultPath);
+}
+
+type FileHandler = (
+  uri: URL,
+  variables: VaultUriVariables,
+) => Promise<ReadResourceResult>;
+
+export function createFileHandler(
+  adapter: ObsidianAdapter,
+  _logger: Logger,
+): FileHandler {
+  return async (uri, variables) => {
+    const path = parseVaultUri(uri, variables, adapter.getVaultPath());
+    const mime = getMimeType(path);
+    if (isTextMime(mime)) {
+      const text = await adapter.readFile(path);
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: mime,
+            text,
+          },
+        ],
+      };
+    }
+    throw new Error('Binary branch not implemented yet'); // filled in in the next task
+  };
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -157,16 +157,17 @@ export function createIndexHandler(
 ): IndexHandler {
   return async (_uri) => {
     const list = adapter.listRecursive('');
-    const files: IndexEntry[] = [];
-    for (const path of list.files) {
-      const stat = await adapter.stat(path);
-      files.push({
-        uri: 'obsidian://vault/' + encodeURI(path),
-        name: basename(path),
-        mimeType: getMimeType(path),
-        size: stat?.size ?? 0,
-      });
-    }
+    const files: IndexEntry[] = await Promise.all(
+      list.files.map(async (path) => {
+        const stat = await adapter.stat(path);
+        return {
+          uri: 'obsidian://vault/' + encodeURI(path),
+          name: basename(path),
+          mimeType: getMimeType(path),
+          size: stat?.size ?? 0,
+        };
+      }),
+    );
     const folders = [...list.folders];
 
     let payload: IndexPayload = { files, folders, truncated: false };

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -3,6 +3,8 @@ import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
 import type { ObsidianAdapter } from '../obsidian/adapter';
 import type { Logger } from '../utils/logger';
+import { BinaryTooLargeError, FileNotFoundError } from '../tools/shared/errors';
+import { BINARY_BYTE_LIMIT } from '../constants';
 
 /**
  * Static mime-type table covering the file types that show up in an
@@ -112,6 +114,17 @@ export function createFileHandler(
         ],
       };
     }
-    throw new Error('Binary branch not implemented yet'); // filled in in the next task
+    const stat = await adapter.stat(path);
+    if (stat === null) {
+      throw new FileNotFoundError(path);
+    }
+    if (stat.size > BINARY_BYTE_LIMIT) {
+      throw new BinaryTooLargeError(stat.size, BINARY_BYTE_LIMIT);
+    }
+    const data = await adapter.readBinary(path);
+    const blob = Buffer.from(data).toString('base64');
+    return {
+      contents: [{ uri: uri.toString(), mimeType: mime, blob }],
+    };
   };
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -1,0 +1,59 @@
+import { posix } from 'path';
+
+/**
+ * Static mime-type table covering the file types that show up in an
+ * Obsidian vault. Keys are lowercase extensions including the leading dot.
+ * Unknown extensions fall back to application/octet-stream. See
+ * docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md.
+ */
+const MIME_TABLE: Record<string, string> = {
+  // Text
+  '.md': 'text/markdown',
+  '.txt': 'text/plain',
+  '.json': 'application/json',
+  '.csv': 'text/csv',
+  '.yml': 'application/yaml',
+  '.yaml': 'application/yaml',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.ts': 'text/x-typescript',
+  '.svg': 'image/svg+xml',
+  // Binary — images
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  // Binary — audio / video
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.m4a': 'audio/mp4',
+  '.flac': 'audio/flac',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  // Binary — documents
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.epub': 'application/epub+zip',
+};
+
+const FALLBACK_MIME = 'application/octet-stream';
+
+export function getMimeType(path: string): string {
+  const ext = posix.extname(path).toLowerCase();
+  return MIME_TABLE[ext] ?? FALLBACK_MIME;
+}
+
+export function isTextMime(mime: string): boolean {
+  if (mime.startsWith('text/')) return true;
+  if (mime === 'application/json') return true;
+  if (mime === 'image/svg+xml') return true;
+  return false;
+}

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -4,7 +4,7 @@ import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
 import type { ObsidianAdapter } from '../obsidian/adapter';
 import type { Logger } from '../utils/logger';
 import { BinaryTooLargeError, FileNotFoundError } from '../tools/shared/errors';
-import { BINARY_BYTE_LIMIT } from '../constants';
+import { BINARY_BYTE_LIMIT, CHARACTER_LIMIT } from '../constants';
 
 /**
  * Static mime-type table covering the file types that show up in an
@@ -125,6 +125,78 @@ export function createFileHandler(
     const blob = Buffer.from(data).toString('base64');
     return {
       contents: [{ uri: uri.toString(), mimeType: mime, blob }],
+    };
+  };
+}
+
+type IndexHandler = (uri: URL) => Promise<ReadResourceResult>;
+
+interface IndexEntry {
+  uri: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+interface IndexPayload {
+  files: IndexEntry[];
+  folders: string[];
+  truncated: boolean;
+}
+
+const VAULT_INDEX_URI = 'obsidian://vault/index';
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+export function createIndexHandler(
+  adapter: ObsidianAdapter,
+  _logger: Logger,
+): IndexHandler {
+  return async (_uri) => {
+    const list = adapter.listRecursive('');
+    const files: IndexEntry[] = [];
+    for (const path of list.files) {
+      const stat = await adapter.stat(path);
+      files.push({
+        uri: 'obsidian://vault/' + encodeURI(path),
+        name: basename(path),
+        mimeType: getMimeType(path),
+        size: stat?.size ?? 0,
+      });
+    }
+    const folders = list.folders.filter((f) => f !== '/');
+
+    let payload: IndexPayload = { files, folders, truncated: false };
+    let serialised = JSON.stringify(payload);
+    if (serialised.length > CHARACTER_LIMIT) {
+      const trimmed = [...files];
+      while (trimmed.length > 0) {
+        trimmed.pop();
+        const candidate: IndexPayload = { files: trimmed, folders, truncated: true };
+        const candidateSerialised = JSON.stringify(candidate);
+        if (candidateSerialised.length <= CHARACTER_LIMIT) {
+          payload = candidate;
+          serialised = candidateSerialised;
+          break;
+        }
+      }
+      if (serialised.length > CHARACTER_LIMIT) {
+        payload = { files: [], folders: [], truncated: true };
+        serialised = JSON.stringify(payload);
+      }
+    }
+
+    return {
+      contents: [
+        {
+          uri: VAULT_INDEX_URI,
+          mimeType: 'application/json',
+          text: serialised,
+        },
+      ],
     };
   };
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -1,4 +1,5 @@
 import { posix } from 'path';
+import { validateVaultPath, PathTraversalError } from '../utils/path-guard';
 
 /**
  * Static mime-type table covering the file types that show up in an
@@ -57,4 +58,29 @@ export function isTextMime(mime: string): boolean {
   if (mime === 'application/yaml') return true;
   if (mime === 'image/svg+xml') return true;
   return false;
+}
+
+type VaultUriVariables = { path: string | string[] };
+
+/**
+ * Validate an `obsidian://vault/{+path}` URI and return the vault-relative
+ * path it points to. The SDK has already parsed the variable; we still
+ * defend against scheme/host mismatches and call `validateVaultPath` so
+ * traversal protection is shared with the tool surface.
+ */
+export function parseVaultUri(
+  uri: URL,
+  variables: VaultUriVariables,
+  vaultPath: string,
+): string {
+  if (uri.protocol !== 'obsidian:') {
+    throw new PathTraversalError(`Unexpected scheme: ${uri.protocol}`);
+  }
+  if (uri.host !== 'vault') {
+    throw new PathTraversalError(`Unexpected host: ${uri.host}`);
+  }
+  const raw = Array.isArray(variables.path)
+    ? variables.path.join('/')
+    : variables.path;
+  return validateVaultPath(raw, vaultPath);
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -54,6 +54,7 @@ export function getMimeType(path: string): string {
 export function isTextMime(mime: string): boolean {
   if (mime.startsWith('text/')) return true;
   if (mime === 'application/json') return true;
+  if (mime === 'application/yaml') return true;
   if (mime === 'image/svg+xml') return true;
   return false;
 }

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -167,7 +167,7 @@ export function createIndexHandler(
         size: stat?.size ?? 0,
       });
     }
-    const folders = list.folders.filter((f) => f !== '/');
+    const folders = [...list.folders];
 
     let payload: IndexPayload = { files, folders, truncated: false };
     let serialised = JSON.stringify(payload);

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -159,18 +159,24 @@ export function createIndexHandler(
 ): IndexHandler {
   return async (_uri) => {
     const list = adapter.listRecursive('');
+    // Stable order so truncation is deterministic across calls and adapters.
+    const sortedFiles = [...list.files].sort();
+    const sortedFolders = [...list.folders].sort();
+
     const files: IndexEntry[] = await Promise.all(
-      list.files.map(async (path) => {
+      sortedFiles.map(async (path) => {
         const stat = await adapter.stat(path);
         return {
-          uri: 'obsidian://vault/' + encodeURI(path),
+          // encodeURIComponent per segment so reserved characters (?, #, etc.)
+          // are properly escaped while keeping path slashes literal.
+          uri: 'obsidian://vault/' + path.split('/').map(encodeURIComponent).join('/'),
           name: basename(path),
           mimeType: getMimeType(path),
           size: stat?.size ?? 0,
         };
       }),
     );
-    const folders = [...list.folders];
+    const folders = sortedFolders;
 
     let payload: IndexPayload = { files, folders, truncated: false };
     let serialised = JSON.stringify(payload);

--- a/src/settings/migrations.ts
+++ b/src/settings/migrations.ts
@@ -131,6 +131,13 @@ export function migrateV9ToV10(data: Settings): void {
   data.moduleStates = moduleStates;
 }
 
+export function migrateV10ToV11(data: Settings): void {
+  // Default the new resources surface on for existing installs. They
+  // can disable it in Server Settings if they prefer a tools-only
+  // server. See docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md.
+  if (data.resourcesEnabled === undefined) data.resourcesEnabled = true;
+}
+
 const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 1, run: migrateV0ToV1 },
   { target: 2, run: migrateV1ToV2 },
@@ -142,9 +149,10 @@ const HOPS: Array<{ target: number; run: MigrationHop }> = [
   { target: 8, run: migrateV7ToV8 },
   { target: 9, run: migrateV8ToV9 },
   { target: 10, run: migrateV9ToV10 },
+  { target: 11, run: migrateV10ToV11 },
 ];
 
-export const CURRENT_SCHEMA_VERSION = 10;
+export const CURRENT_SCHEMA_VERSION = 11;
 
 export function migrateSettings(data: Settings): Settings {
   const currentVersion =

--- a/src/settings/server-section.ts
+++ b/src/settings/server-section.ts
@@ -287,6 +287,16 @@ export function renderServerSettingsSection(
       }),
     );
 
+  new Setting(containerEl)
+    .setName(t('setting_resources_enabled_name'))
+    .setDesc(t('setting_resources_enabled_desc'))
+    .addToggle((toggle) =>
+      toggle.setValue(plugin.settings.resourcesEnabled).onChange(async (value) => {
+        plugin.settings.resourcesEnabled = value;
+        await plugin.saveSettings();
+      }),
+    );
+
   renderDnsRebindSection(containerEl, plugin, refresh);
 }
 

--- a/src/tools/shared/errors.ts
+++ b/src/tools/shared/errors.ts
@@ -54,6 +54,23 @@ export class TimeoutError extends Error {
 }
 
 /**
+ * The requested binary file exceeds the configured per-call byte limit.
+ * Used by `vault_read_binary` and the resources surface to fail fast on
+ * over-cap files instead of base64-encoding hundreds of megabytes.
+ */
+export class BinaryTooLargeError extends Error {
+  constructor(
+    public readonly sizeBytes: number,
+    public readonly limitBytes: number,
+  ) {
+    super(
+      `Binary file too large (${String(sizeBytes)} bytes, limit ${String(limitBytes)}). Fetch the file out-of-band or use a chunked read when available.`,
+    );
+    this.name = 'BinaryTooLargeError';
+  }
+}
+
+/**
  * The user-requested third-party plugin (e.g. Dataview, Templater) is
  * not installed or is currently disabled in Obsidian.
  */
@@ -114,6 +131,9 @@ export function handleToolError(error: unknown): CallToolResult {
     return errorFrom(error.message);
   }
   if (error instanceof PluginApiUnavailableError) {
+    return errorFrom(error.message);
+  }
+  if (error instanceof BinaryTooLargeError) {
     return errorFrom(error.message);
   }
   const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/vault/handlers.ts
+++ b/src/tools/vault/handlers.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ObsidianAdapter } from '../../obsidian/adapter';
 import { validateVaultPath } from '../../utils/path-guard';
 import { truncateText } from '../shared/truncate';
-import { handleToolError } from '../shared/errors';
+import { handleToolError, BinaryTooLargeError } from '../shared/errors';
 import { paginate, readPagination } from '../shared/pagination';
 import { makeResponse, readResponseFormat } from '../shared/response';
 import { BINARY_BYTE_LIMIT } from '../../constants';
@@ -369,9 +369,7 @@ export function createHandlers(
         const path = validateVaultPath(params.path, vaultPath);
         const data = await adapter.readBinary(path);
         if (data.byteLength > BINARY_BYTE_LIMIT) {
-          return errorResult(
-            `Binary file too large (${String(data.byteLength)} bytes, limit ${String(BINARY_BYTE_LIMIT)}). Fetch the file out-of-band or use a chunked read when available.`,
-          );
+          throw new BinaryTooLargeError(data.byteLength, BINARY_BYTE_LIMIT);
         }
         const base64 = Buffer.from(data).toString('base64');
         return makeResponse(

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export interface McpPluginSettings {
   /** Auto-start the MCP server when Obsidian launches */
   autoStart: boolean;
   /**
+   * When true, the server exposes vault files as MCP resources
+   * (obsidian://vault/{+path} template + obsidian://vault/index static)
+   * in addition to tools. Default true.
+   */
+  resourcesEnabled: boolean;
+  /**
    * Allowlist of Obsidian command ids that `plugin_execute_command` is
    * permitted to run. Empty (the default) means command execution is
    * disabled and the tool refuses every call with a clear error.
@@ -93,7 +99,7 @@ export const DEFAULT_ALLOWED_HOSTS: readonly string[] = [
 ] as const;
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-  schemaVersion: 10,
+  schemaVersion: 11,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: true,
@@ -105,6 +111,7 @@ export const DEFAULT_SETTINGS: McpPluginSettings = {
   customTlsKeyPath: null,
   debugMode: false,
   autoStart: false,
+  resourcesEnabled: true,
   executeCommandAllowlist: [],
   allowedOrigins: [...DEFAULT_ALLOWED_ORIGINS],
   allowedHosts: [...DEFAULT_ALLOWED_HOSTS],

--- a/tests/integration/custom-tls-server.test.ts
+++ b/tests/integration/custom-tls-server.test.ts
@@ -59,6 +59,7 @@ describe('Integration: HTTPS server with user-provided cert', () => {
     const logMod = await import('../../src/utils/logger');
     const mockMod = await import('../../src/obsidian/mock-adapter');
     const vaultMod = await import('../../src/tools/vault/index');
+    const { DEFAULT_SETTINGS } = await import('../../src/types');
 
     const logger = new logMod.Logger('test', {
       debugMode: false,
@@ -69,7 +70,7 @@ describe('Integration: HTTPS server with user-provided cert', () => {
     registry.registerModule(vaultMod.createVaultModule(adapter));
 
     server = new httpMod.HttpMcpServer(
-      () => mcpMod.createMcpServer(registry, logger),
+      () => mcpMod.createMcpServer(registry, adapter, DEFAULT_SETTINGS, logger),
       logger,
       {
         host: '127.0.0.1',

--- a/tests/integration/https-server.test.ts
+++ b/tests/integration/https-server.test.ts
@@ -52,6 +52,7 @@ describe('Integration: HTTPS server', () => {
     const mockMod = await import('../../src/obsidian/mock-adapter');
     const vaultMod = await import('../../src/tools/vault/index');
     const tlsMod = await import('../../src/server/tls');
+    const { DEFAULT_SETTINGS } = await import('../../src/types');
 
     const logger = new logMod.Logger('test', { debugMode: false, accessKey: ACCESS_KEY });
     const registry = new regMod.ModuleRegistry(logger);
@@ -62,7 +63,7 @@ describe('Integration: HTTPS server', () => {
     caCert = tls.cert;
 
     server = new httpMod.HttpMcpServer(
-      () => mcpMod.createMcpServer(registry, logger),
+      () => mcpMod.createMcpServer(registry, adapter, DEFAULT_SETTINGS, logger),
       logger,
       {
         host: '127.0.0.1',

--- a/tests/integration/resources.test.ts
+++ b/tests/integration/resources.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../../src/server/mcp-server';
+import { ModuleRegistry } from '../../src/registry/module-registry';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { Logger } from '../../src/utils/logger';
+
+describe('resources surface — end-to-end', () => {
+  it('reads obsidian://vault/index and a vault file via the SDK transport', async () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('hello.md', '# Hello');
+    const logger = new Logger('test', { debugMode: false, accessKey: '' });
+    const registry = new ModuleRegistry(logger);
+    const server = createMcpServer(registry, adapter, DEFAULT_SETTINGS, logger);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'test', version: '0' }, { capabilities: {} });
+    await client.connect(clientTransport);
+
+    const indexResp = await client.readResource({ uri: 'obsidian://vault/index' });
+    expect(indexResp.contents[0].mimeType).toBe('application/json');
+
+    const fileResp = await client.readResource({ uri: 'obsidian://vault/hello.md' });
+    expect(fileResp.contents[0]).toMatchObject({
+      uri: 'obsidian://vault/hello.md',
+      mimeType: 'text/markdown',
+      text: '# Hello',
+    });
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -55,6 +55,7 @@ let ModuleRegistry: typeof import('../../src/registry/module-registry').ModuleRe
 let Logger: typeof import('../../src/utils/logger').Logger;
 let MockObsidianAdapter: typeof import('../../src/obsidian/mock-adapter').MockObsidianAdapter;
 let createVaultModule: typeof import('../../src/tools/vault/index').createVaultModule;
+let DEFAULT_SETTINGS: typeof import('../../src/types').DEFAULT_SETTINGS;
 
 beforeAll(async () => {
   const httpMod = await import('../../src/server/http-server');
@@ -63,6 +64,7 @@ beforeAll(async () => {
   const logMod = await import('../../src/utils/logger');
   const mockMod = await import('../../src/obsidian/mock-adapter');
   const vaultMod = await import('../../src/tools/vault/index');
+  const typesMod = await import('../../src/types');
 
   HttpMcpServer = httpMod.HttpMcpServer;
   createMcpServer = mcpMod.createMcpServer;
@@ -70,6 +72,7 @@ beforeAll(async () => {
   Logger = logMod.Logger;
   MockObsidianAdapter = mockMod.MockObsidianAdapter;
   createVaultModule = vaultMod.createVaultModule;
+  DEFAULT_SETTINGS = typesMod.DEFAULT_SETTINGS;
 });
 
 describe('Integration: HTTP Server Authentication', () => {
@@ -82,7 +85,7 @@ describe('Integration: HTTP Server Authentication', () => {
     const vaultModule = createVaultModule(adapter);
     registry.registerModule(vaultModule);
     server = new HttpMcpServer(
-      () => createMcpServer(registry, logger),
+      () => createMcpServer(registry, adapter, DEFAULT_SETTINGS, logger),
       logger,
       {
         host: '127.0.0.1',

--- a/tests/obsidian/mock-adapter.test.ts
+++ b/tests/obsidian/mock-adapter.test.ts
@@ -223,3 +223,28 @@ describe('MockObsidianAdapter', () => {
     });
   });
 });
+
+describe('MockObsidianAdapter root traversal', () => {
+  it('listRecursive("") walks the entire vault (real Obsidian convention)', () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'b');
+
+    const result = adapter.listRecursive('');
+
+    expect(result.files.sort()).toEqual(['a.md', 'notes/b.md']);
+    expect(result.folders).toContain('notes');
+  });
+
+  it('list("") returns the direct children of the vault root', () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+
+    const result = adapter.list('');
+
+    expect(result.files).toContain('a.md');
+    expect(result.folders).toContain('notes');
+  });
+});

--- a/tests/obsidian/mock-adapter.test.ts
+++ b/tests/obsidian/mock-adapter.test.ts
@@ -237,14 +237,35 @@ describe('MockObsidianAdapter root traversal', () => {
     expect(result.folders).toContain('notes');
   });
 
-  it('list("") returns the direct children of the vault root', () => {
+  it('list("") returns only the direct children of the vault root (depth filter)', () => {
     const adapter = new MockObsidianAdapter();
     adapter.addFolder('notes');
     adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'b');
 
     const result = adapter.list('');
 
     expect(result.files).toContain('a.md');
+    expect(result.files).not.toContain('notes/b.md');
+    expect(result.folders).toContain('notes');
+  });
+
+  it('list("/") still walks the root for backward compatibility', () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    const result = adapter.list('/');
+    expect(result.files).toContain('a.md');
+    expect(result.folders).toContain('notes');
+  });
+
+  it('listRecursive("/") still walks the entire vault for backward compatibility', () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'b');
+    const result = adapter.listRecursive('/');
+    expect(result.files.sort()).toEqual(['a.md', 'notes/b.md']);
     expect(result.folders).toContain('notes');
   });
 });

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -7,6 +7,8 @@ import { ModuleRegistry } from '../../src/registry/module-registry';
 import { ToolDefinition, ToolModule, annotations } from '../../src/registry/types';
 import { PermissionError } from '../../src/tools/shared/errors';
 import type { ToolContext } from '../../src/registry/tool-context';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
 
 interface CapturedServerInfo {
   name: string;
@@ -14,8 +16,14 @@ interface CapturedServerInfo {
 }
 
 interface CapturedOptions {
-  capabilities?: { tools?: unknown; logging?: unknown };
+  capabilities?: { tools?: unknown; logging?: unknown; resources?: unknown };
   instructions?: string;
+}
+
+interface CapturedRegisterResourceCall {
+  name: string;
+  uriOrTemplate: unknown;
+  metadata: Record<string, unknown>;
 }
 
 interface CapturedRegisterToolCall {
@@ -35,6 +43,7 @@ const capturedConstructorArgs: Array<{
 }> = [];
 
 const capturedRegisterToolCalls: CapturedRegisterToolCall[] = [];
+const capturedRegisterResourceCalls: CapturedRegisterResourceCall[] = [];
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
   class FakeMcpServer {
@@ -48,8 +57,14 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
     ): void {
       capturedRegisterToolCalls.push({ name, config });
     }
+    registerResource(name: string, uriOrTemplate: unknown, metadata: Record<string, unknown>): void {
+      capturedRegisterResourceCalls.push({ name, uriOrTemplate, metadata });
+    }
   }
-  return { McpServer: FakeMcpServer };
+  class FakeResourceTemplate {
+    constructor(public uriTemplate: string, public callbacks: unknown) {}
+  }
+  return { McpServer: FakeMcpServer, ResourceTemplate: FakeResourceTemplate };
 });
 
 function makeLogger(): Logger {
@@ -60,13 +75,14 @@ describe('createMcpServer', () => {
   beforeEach(() => {
     capturedConstructorArgs.length = 0;
     capturedRegisterToolCalls.length = 0;
+    capturedRegisterResourceCalls.length = 0;
   });
 
   it('advertises the server as "obsidian-mcp-server" per the {service}-mcp-server convention', async () => {
     const { createMcpServer } = await import('../../src/server/mcp-server');
     const registry = new ModuleRegistry(makeLogger());
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedConstructorArgs).toHaveLength(1);
     expect(capturedConstructorArgs[0].serverInfo.name).toBe('obsidian-mcp-server');
@@ -76,7 +92,7 @@ describe('createMcpServer', () => {
     const { createMcpServer } = await import('../../src/server/mcp-server');
     const registry = new ModuleRegistry(makeLogger());
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedConstructorArgs).toHaveLength(1);
     expect(capturedConstructorArgs[0].serverInfo.version).toBe(manifest.version);
@@ -89,7 +105,7 @@ describe('createMcpServer', () => {
     const { createMcpServer } = await import('../../src/server/mcp-server');
     const registry = new ModuleRegistry(makeLogger());
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedConstructorArgs[0].options.capabilities?.tools).toBeDefined();
   });
@@ -98,7 +114,7 @@ describe('createMcpServer', () => {
     const { createMcpServer } = await import('../../src/server/mcp-server');
     const registry = new ModuleRegistry(makeLogger());
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedConstructorArgs[0].options.capabilities?.logging).toBeDefined();
   });
@@ -108,7 +124,7 @@ describe('createMcpServer', () => {
     const { createMcpServer, SERVER_INSTRUCTIONS } = mod;
     const registry = new ModuleRegistry(makeLogger());
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedConstructorArgs).toHaveLength(1);
     // Guard against a destructured-undefined trivial pass where both
@@ -159,7 +175,7 @@ describe('createMcpServer', () => {
     const registry = new ModuleRegistry(makeLogger());
     registry.registerModule(stubModule);
 
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     expect(capturedRegisterToolCalls).toHaveLength(2);
 
@@ -201,12 +217,41 @@ describe('createMcpServer', () => {
 
     const registry = new ModuleRegistry(makeLogger());
     registry.registerModule(stubModule);
-    createMcpServer(registry, makeLogger());
+    createMcpServer(registry, new MockObsidianAdapter(), DEFAULT_SETTINGS, makeLogger());
 
     const call = capturedRegisterToolCalls.find((c) => c.name === 'titled');
     expect(call).toBeDefined();
     expect(call?.config.title).toBe('Pretty title');
     expect(call?.config.annotations?.title).toBe('Pretty title');
+  });
+
+  it('declares the resources capability and registers vault-index + vault-file when resourcesEnabled', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+    const registry = new ModuleRegistry(makeLogger());
+    const adapter = new MockObsidianAdapter();
+    const settings = { ...DEFAULT_SETTINGS, resourcesEnabled: true };
+
+    createMcpServer(registry, adapter, settings, makeLogger());
+
+    const caps = capturedConstructorArgs[0].options.capabilities;
+    expect(caps).toMatchObject({ resources: {} });
+    expect(capturedRegisterResourceCalls.map((c) => c.name)).toEqual([
+      'vault-index',
+      'vault-file',
+    ]);
+  });
+
+  it('omits the resources capability and skips registration when resourcesEnabled is false', async () => {
+    const { createMcpServer } = await import('../../src/server/mcp-server');
+    const registry = new ModuleRegistry(makeLogger());
+    const adapter = new MockObsidianAdapter();
+    const settings = { ...DEFAULT_SETTINGS, resourcesEnabled: false };
+
+    createMcpServer(registry, adapter, settings, makeLogger());
+
+    const caps = capturedConstructorArgs[0].options.capabilities;
+    expect(caps).not.toHaveProperty('resources');
+    expect(capturedRegisterResourceCalls).toHaveLength(0);
   });
 });
 

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -267,6 +267,31 @@ describe('indexHandler', () => {
     );
     expect(parsedPath).toBe('Notizen/Übersicht.md');
   });
+
+  it('escapes reserved URI characters in filenames (? # etc.)', async () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('weird?name.md', 'x');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const payload = JSON.parse((result.contents[0] as { text: string }).text) as {
+      files: Array<{ uri: string; name: string }>;
+    };
+    const entry = payload.files[0];
+
+    // ? must be percent-encoded to round-trip through URL parsing
+    expect(entry.uri).toBe('obsidian://vault/weird%3Fname.md');
+    expect(entry.name).toBe('weird?name.md');
+
+    // Round-trip: parsing the emitted URI yields the original path
+    const url = new URL(entry.uri);
+    const parsedPath = parseVaultUri(
+      url,
+      { path: decodeURIComponent(url.pathname.replace(/^\//, '')) },
+      adapter.getVaultPath(),
+    );
+    expect(parsedPath).toBe('weird?name.md');
+  });
 });
 
 describe('registerResources', () => {

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { getMimeType, isTextMime } from '../../src/server/resources';
+
+describe('getMimeType', () => {
+  it('maps known text extensions', () => {
+    expect(getMimeType('notes/foo.md')).toBe('text/markdown');
+    expect(getMimeType('foo.txt')).toBe('text/plain');
+    expect(getMimeType('config.json')).toBe('application/json');
+    expect(getMimeType('data.csv')).toBe('text/csv');
+    expect(getMimeType('settings.yml')).toBe('application/yaml');
+    expect(getMimeType('settings.yaml')).toBe('application/yaml');
+    expect(getMimeType('icon.svg')).toBe('image/svg+xml');
+  });
+
+  it('maps known binary extensions', () => {
+    expect(getMimeType('a.png')).toBe('image/png');
+    expect(getMimeType('a.jpg')).toBe('image/jpeg');
+    expect(getMimeType('a.jpeg')).toBe('image/jpeg');
+    expect(getMimeType('a.pdf')).toBe('application/pdf');
+    expect(getMimeType('a.mp3')).toBe('audio/mpeg');
+    expect(getMimeType('a.mp4')).toBe('video/mp4');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(getMimeType('FOO.MD')).toBe('text/markdown');
+    expect(getMimeType('PHOTO.JPG')).toBe('image/jpeg');
+  });
+
+  it('falls back to application/octet-stream for unknown or missing extensions', () => {
+    expect(getMimeType('mystery.xyz')).toBe('application/octet-stream');
+    expect(getMimeType('Makefile')).toBe('application/octet-stream');
+  });
+});
+
+describe('isTextMime', () => {
+  it('returns true for text/* and application/json and image/svg+xml', () => {
+    expect(isTextMime('text/markdown')).toBe(true);
+    expect(isTextMime('text/plain')).toBe(true);
+    expect(isTextMime('application/json')).toBe(true);
+    expect(isTextMime('image/svg+xml')).toBe(true);
+  });
+
+  it('returns false for binary mimes', () => {
+    expect(isTextMime('image/png')).toBe(false);
+    expect(isTextMime('application/pdf')).toBe(false);
+    expect(isTextMime('application/octet-stream')).toBe(false);
+  });
+});

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getMimeType, isTextMime, parseVaultUri, createFileHandler, createIndexHandler } from '../../src/server/resources';
+import { getMimeType, isTextMime, parseVaultUri, createFileHandler, createIndexHandler, registerResources } from '../../src/server/resources';
 import { CHARACTER_LIMIT } from '../../src/constants';
 import { PathTraversalError } from '../../src/utils/path-guard';
 import { Logger } from '../../src/utils/logger';
@@ -266,5 +266,26 @@ describe('indexHandler', () => {
       adapter.getVaultPath(),
     );
     expect(parsedPath).toBe('Notizen/Übersicht.md');
+  });
+});
+
+describe('registerResources', () => {
+  it('registers vault-index (static) and vault-file (template)', () => {
+    const adapter = new MockObsidianAdapter();
+
+    interface Capture { name: string; uriOrTemplate: unknown; metadata: Record<string, unknown> }
+    const calls: Capture[] = [];
+    const fakeServer = {
+      registerResource(name: string, uriOrTemplate: unknown, metadata: Record<string, unknown>): void {
+        calls.push({ name, uriOrTemplate, metadata });
+      },
+    };
+
+    registerResources(fakeServer as never, adapter, makeLogger());
+
+    expect(calls.map((c) => c.name)).toEqual(['vault-index', 'vault-file']);
+    expect(calls[0].uriOrTemplate).toBe('obsidian://vault/index');
+    // Template is a class instance from the SDK — we just verify shape.
+    expect(typeof calls[1].uriOrTemplate).toBe('object');
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getMimeType, isTextMime, parseVaultUri, createFileHandler } from '../../src/server/resources';
+import { getMimeType, isTextMime, parseVaultUri, createFileHandler, createIndexHandler } from '../../src/server/resources';
+import { CHARACTER_LIMIT } from '../../src/constants';
 import { PathTraversalError } from '../../src/utils/path-guard';
 import { Logger } from '../../src/utils/logger';
 import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
@@ -186,5 +187,84 @@ describe('fileHandler — binary', () => {
       new URL('obsidian://vault/missing.png'),
       { path: 'missing.png' },
     )).rejects.toBeInstanceOf(FileNotFoundError);
+  });
+});
+
+interface IndexEntry { uri: string; name: string; mimeType: string; size: number }
+interface IndexPayload { files: IndexEntry[]; folders: string[]; truncated: boolean }
+
+describe('indexHandler', () => {
+  it('returns a flat list with resource entries and folder names', async () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFolder('notes');
+    adapter.addFile('a.md', 'a');
+    adapter.addFile('notes/b.md', 'bb');
+    adapter.addFile('img.png', 'pngdata');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const c = result.contents[0] as { uri: string; mimeType: string; text: string };
+    expect(c.uri).toBe('obsidian://vault/index');
+    expect(c.mimeType).toBe('application/json');
+
+    const payload = JSON.parse(c.text) as IndexPayload;
+    expect(payload.truncated).toBe(false);
+    expect(payload.folders).toContain('notes');
+    expect(payload.files.find((f) => f.name === 'a.md')).toMatchObject({
+      uri: 'obsidian://vault/a.md',
+      mimeType: 'text/markdown',
+      size: 1,
+    });
+    expect(payload.files.find((f) => f.name === 'b.md')).toMatchObject({
+      uri: 'obsidian://vault/notes/b.md',
+      mimeType: 'text/markdown',
+    });
+    expect(payload.files.find((f) => f.name === 'img.png')).toMatchObject({
+      mimeType: 'image/png',
+    });
+  });
+
+  it('returns an empty payload for an empty vault', async () => {
+    const adapter = new MockObsidianAdapter();
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const payload = JSON.parse((result.contents[0] as { text: string }).text) as IndexPayload;
+    expect(payload).toEqual({ files: [], folders: [], truncated: false });
+  });
+
+  it('truncates files past the 25 000-character cap', async () => {
+    const adapter = new MockObsidianAdapter();
+    // Each entry is roughly 90+ chars in JSON. 400 entries blow past 25k.
+    for (let i = 0; i < 400; i++) {
+      adapter.addFile(`note-${String(i).padStart(4, '0')}.md`, 'x');
+    }
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const text = (result.contents[0] as { text: string }).text;
+    expect(text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    const payload = JSON.parse(text) as IndexPayload;
+    expect(payload.truncated).toBe(true);
+    expect(payload.files.length).toBeLessThan(400);
+  });
+
+  it('produces URIs that round-trip through parseVaultUri', async () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('Notizen/Übersicht.md', 'x');
+    const handler = createIndexHandler(adapter, makeLogger());
+
+    const result = await handler(new URL('obsidian://vault/index'));
+    const payload = JSON.parse((result.contents[0] as { text: string }).text) as IndexPayload;
+    const entry = payload.files[0];
+
+    const parsedPath = parseVaultUri(
+      new URL(entry.uri),
+      // The SDK populates `variables.path` by decoding the URI; emulate by
+      // decoding entry.uri's pathname after the host segment.
+      { path: decodeURIComponent(new URL(entry.uri).pathname.replace(/^\//, '')) },
+      adapter.getVaultPath(),
+    );
+    expect(parsedPath).toBe('Notizen/Übersicht.md');
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getMimeType, isTextMime } from '../../src/server/resources';
+import { getMimeType, isTextMime, parseVaultUri } from '../../src/server/resources';
+import { PathTraversalError } from '../../src/utils/path-guard';
 
 describe('getMimeType', () => {
   it('maps known text extensions', () => {
@@ -45,5 +46,52 @@ describe('isTextMime', () => {
     expect(isTextMime('image/png')).toBe(false);
     expect(isTextMime('application/pdf')).toBe(false);
     expect(isTextMime('application/octet-stream')).toBe(false);
+  });
+});
+
+const VAULT = '/tmp/vault';
+
+function uri(s: string): URL { return new URL(s); }
+
+describe('parseVaultUri', () => {
+  it('returns the validated relative path for a plain URI', () => {
+    expect(parseVaultUri(uri('obsidian://vault/notes/foo.md'), { path: 'notes/foo.md' }, VAULT))
+      .toBe('notes/foo.md');
+  });
+
+  it('handles unicode paths', () => {
+    expect(parseVaultUri(uri('obsidian://vault/Notizen/%C3%9Cbersicht.md'), { path: 'Notizen/Übersicht.md' }, VAULT))
+      .toBe('Notizen/Übersicht.md');
+  });
+
+  it('rejects traversal', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/../etc/passwd'), { path: '../etc/passwd' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects encoded traversal', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/..%2F..'), { path: '..%2F..' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects wrong scheme', () => {
+    expect(() => parseVaultUri(uri('file:///foo.md'), { path: 'foo.md' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects wrong host', () => {
+    expect(() => parseVaultUri(uri('obsidian://other/foo.md'), { path: 'foo.md' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('rejects empty path', () => {
+    expect(() => parseVaultUri(uri('obsidian://vault/'), { path: '' }, VAULT))
+      .toThrow(PathTraversalError);
+  });
+
+  it('accepts a single-string variable form (some SDK paths pass string[])', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    expect(parseVaultUri(uri('obsidian://vault/notes/foo.md'), { path: ['notes', 'foo.md'] as unknown as string }, VAULT))
+      .toBe('notes/foo.md');
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -3,7 +3,7 @@ import { getMimeType, isTextMime, parseVaultUri, createFileHandler } from '../..
 import { PathTraversalError } from '../../src/utils/path-guard';
 import { Logger } from '../../src/utils/logger';
 import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
-import { BinaryTooLargeError } from '../../src/tools/shared/errors';
+import { BinaryTooLargeError, FileNotFoundError } from '../../src/tools/shared/errors';
 
 function makeLogger(): Logger {
   return new Logger('test', { debugMode: false, accessKey: '' });
@@ -177,5 +177,14 @@ describe('fileHandler — binary', () => {
       new URL('obsidian://vault/big.png'),
       { path: 'big.png' },
     )).rejects.toBeInstanceOf(BinaryTooLargeError);
+  });
+
+  it('throws FileNotFoundError for a missing binary file', async () => {
+    const adapter = new MockObsidianAdapter();
+    const handler = createFileHandler(adapter, makeLogger());
+    await expect(handler(
+      new URL('obsidian://vault/missing.png'),
+      { path: 'missing.png' },
+    )).rejects.toBeInstanceOf(FileNotFoundError);
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { getMimeType, isTextMime, parseVaultUri } from '../../src/server/resources';
+import { getMimeType, isTextMime, parseVaultUri, createFileHandler } from '../../src/server/resources';
 import { PathTraversalError } from '../../src/utils/path-guard';
+import { Logger } from '../../src/utils/logger';
+import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+
+function makeLogger(): Logger {
+  return new Logger('test', { debugMode: false, accessKey: '' });
+}
 
 describe('getMimeType', () => {
   it('maps known text extensions', () => {
@@ -93,5 +99,35 @@ describe('parseVaultUri', () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     expect(parseVaultUri(uri('obsidian://vault/notes/foo.md'), { path: ['notes', 'foo.md'] as unknown as string }, VAULT))
       .toBe('notes/foo.md');
+  });
+});
+
+describe('fileHandler — text', () => {
+  it('returns TextResourceContents for a markdown file', async () => {
+    const adapter = new MockObsidianAdapter();
+    adapter.addFile('notes/foo.md', '# Hello');
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/notes/foo.md'),
+      { path: 'notes/foo.md' },
+    );
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0]).toEqual({
+      uri: 'obsidian://vault/notes/foo.md',
+      mimeType: 'text/markdown',
+      text: '# Hello',
+    });
+  });
+
+  it('propagates the adapter not-found error for a missing file', async () => {
+    const adapter = new MockObsidianAdapter();
+    const handler = createFileHandler(adapter, makeLogger());
+
+    await expect(handler(
+      new URL('obsidian://vault/missing.md'),
+      { path: 'missing.md' },
+    )).rejects.toThrow(/not found/i);
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -3,6 +3,7 @@ import { getMimeType, isTextMime, parseVaultUri, createFileHandler } from '../..
 import { PathTraversalError } from '../../src/utils/path-guard';
 import { Logger } from '../../src/utils/logger';
 import { MockObsidianAdapter } from '../../src/obsidian/mock-adapter';
+import { BinaryTooLargeError } from '../../src/tools/shared/errors';
 
 function makeLogger(): Logger {
   return new Logger('test', { debugMode: false, accessKey: '' });
@@ -129,5 +130,52 @@ describe('fileHandler — text', () => {
       new URL('obsidian://vault/missing.md'),
       { path: 'missing.md' },
     )).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('fileHandler — binary', () => {
+  it('returns BlobResourceContents (base64) for a small image', async () => {
+    const adapter = new MockObsidianAdapter();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    await adapter.writeBinary('img.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/img.png'),
+      { path: 'img.png' },
+    );
+
+    expect(result.contents).toHaveLength(1);
+    const c = result.contents[0] as { uri: string; mimeType: string; blob: string };
+    expect(c.uri).toBe('obsidian://vault/img.png');
+    expect(c.mimeType).toBe('image/png');
+    expect(Buffer.from(c.blob, 'base64')).toEqual(Buffer.from(bytes));
+  });
+
+  it('serves a file at exactly 1 MiB', async () => {
+    const adapter = new MockObsidianAdapter();
+    const bytes = new Uint8Array(1_048_576);
+    await adapter.writeBinary('big.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    const result = await handler(
+      new URL('obsidian://vault/big.png'),
+      { path: 'big.png' },
+    );
+
+    const c = result.contents[0] as { blob: string };
+    expect(Buffer.from(c.blob, 'base64').byteLength).toBe(1_048_576);
+  });
+
+  it('throws BinaryTooLargeError above 1 MiB', async () => {
+    const adapter = new MockObsidianAdapter();
+    const bytes = new Uint8Array(1_048_577);
+    await adapter.writeBinary('big.png', bytes.buffer);
+    const handler = createFileHandler(adapter, makeLogger());
+
+    await expect(handler(
+      new URL('obsidian://vault/big.png'),
+      { path: 'big.png' },
+    )).rejects.toBeInstanceOf(BinaryTooLargeError);
   });
 });

--- a/tests/server/resources.test.ts
+++ b/tests/server/resources.test.ts
@@ -33,10 +33,11 @@ describe('getMimeType', () => {
 });
 
 describe('isTextMime', () => {
-  it('returns true for text/* and application/json and image/svg+xml', () => {
+  it('returns true for text/*, application/json, application/yaml, and image/svg+xml', () => {
     expect(isTextMime('text/markdown')).toBe(true);
     expect(isTextMime('text/plain')).toBe(true);
     expect(isTextMime('application/json')).toBe(true);
+    expect(isTextMime('application/yaml')).toBe(true);
     expect(isTextMime('image/svg+xml')).toBe(true);
   });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -287,8 +287,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.authEnabled).toBe(true);
   });
 
-  it('declares schemaVersion 10', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(10);
+  it('declares schemaVersion 11', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(11);
   });
 
   it('defaults custom TLS fields to off/null', () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,7 +7,7 @@ describe('migrateSettings', () => {
   it('should migrate v0 (no schemaVersion) to current schema', () => {
     const data: Record<string, unknown> = {};
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.port).toBe(28741);
     expect(result.accessKey).toBe('');
     expect(result.httpsEnabled).toBe(false);
@@ -25,7 +25,7 @@ describe('migrateSettings', () => {
       debugMode: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.port).toBe(9999);
     expect(result.accessKey).toBe('my-key');
     expect(result.debugMode).toBe(true);
@@ -43,7 +43,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.serverAddress).toBe('127.0.0.1');
     expect(result.autoStart).toBe(false);
   });
@@ -59,7 +59,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.autoStart).toBe(false);
   });
 
@@ -78,7 +78,7 @@ describe('migrateSettings', () => {
       },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.moduleStates).toEqual({
       vault: { enabled: true },
       editor: { enabled: false },
@@ -97,7 +97,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.tlsCertificate).toBeNull();
   });
 
@@ -114,7 +114,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.authEnabled).toBe(false);
   });
 
@@ -124,7 +124,7 @@ describe('migrateSettings', () => {
       accessKey: 'pre-existing-key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.authEnabled).toBe(false);
     expect(result.accessKey).toBe('pre-existing-key');
   });
@@ -135,7 +135,7 @@ describe('migrateSettings', () => {
       authEnabled: true,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.authEnabled).toBe(true);
   });
 
@@ -173,7 +173,7 @@ describe('migrateSettings', () => {
       moduleStates: {},
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.useCustomTls).toBe(false);
     expect(result.customTlsCertPath).toBeNull();
     expect(result.customTlsKeyPath).toBeNull();
@@ -189,7 +189,7 @@ describe('migrateSettings', () => {
       customTlsKeyPath: '/etc/ssl/my.key',
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.useCustomTls).toBe(true);
     expect(result.customTlsCertPath).toBe('/etc/ssl/my.crt');
     expect(result.customTlsKeyPath).toBe('/etc/ssl/my.key');
@@ -201,7 +201,7 @@ describe('migrateSettings', () => {
       tlsCertificate: { cert: 'EXISTING_CERT', key: 'EXISTING_KEY' },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.tlsCertificate).toEqual({
       cert: 'EXISTING_CERT',
       key: 'EXISTING_KEY',
@@ -213,7 +213,7 @@ describe('migrateSettings', () => {
       port: 3000,
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     expect(result.port).toBe(3000);
     expect(result.accessKey).toBe('');
     expect(result.moduleStates).toEqual({});
@@ -234,7 +234,7 @@ describe('migrateSettings', () => {
       moduleStates: { extras: { enabled: true, readOnly: false } },
     };
     const result = migrateSettings(data);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     const states = result.moduleStates as Record<
       string,
       { enabled: boolean; readOnly: boolean; toolStates?: Record<string, boolean> }

--- a/tests/settings/migrations.test.ts
+++ b/tests/settings/migrations.test.ts
@@ -283,4 +283,13 @@ describe('migrateSettings — composition', () => {
     migrateSettings(data);
     expect(JSON.stringify(data)).toBe(before);
   });
+
+  it('migrates a v10 install to v11 with resourcesEnabled defaulted on', () => {
+    const result = migrateSettings({ schemaVersion: 10 }) as {
+      schemaVersion: number;
+      resourcesEnabled: boolean;
+    };
+    expect(result.schemaVersion).toBe(11);
+    expect(result.resourcesEnabled).toBe(true);
+  });
 });

--- a/tests/settings/migrations.test.ts
+++ b/tests/settings/migrations.test.ts
@@ -10,6 +10,7 @@ import {
   migrateV7ToV8,
   migrateV8ToV9,
   migrateV9ToV10,
+  migrateV10ToV11,
   migrateSettings,
   CURRENT_SCHEMA_VERSION,
 } from '../../src/settings/migrations';
@@ -233,6 +234,26 @@ describe('settings migrations — per-version hops', () => {
     };
     migrateV9ToV10(data);
     expect(data.iAcceptInsecureMode).toBe(false);
+  });
+});
+
+describe('migrateV10ToV11', () => {
+  it('sets resourcesEnabled: true for installs without the field', () => {
+    const data = {} as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(true);
+  });
+
+  it('preserves an explicit false', () => {
+    const data = { resourcesEnabled: false } as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(false);
+  });
+
+  it('preserves an explicit true', () => {
+    const data = { resourcesEnabled: true } as Record<string, unknown>;
+    migrateV10ToV11(data);
+    expect(data.resourcesEnabled).toBe(true);
   });
 });
 

--- a/tests/tools/shared/errors.test.ts
+++ b/tests/tools/shared/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import {
   handleToolError,
+  BinaryTooLargeError,
   NotFoundError,
   PermissionError,
   ValidationError,
@@ -71,5 +72,26 @@ describe('handleToolError', () => {
     const result = handleToolError('oops');
     expect(result.isError).toBe(true);
     expect(getText(result)).toBe('Error: oops');
+  });
+});
+
+describe('BinaryTooLargeError', () => {
+  it('renders a clear message including size and limit', () => {
+    const err = new BinaryTooLargeError(2_000_000, 1_048_576);
+    expect(err.name).toBe('BinaryTooLargeError');
+    expect(err.message).toBe(
+      'Binary file too large (2000000 bytes, limit 1048576). Fetch the file out-of-band or use a chunked read when available.',
+    );
+    expect(err.sizeBytes).toBe(2_000_000);
+    expect(err.limitBytes).toBe(1_048_576);
+  });
+
+  it('handleToolError maps BinaryTooLargeError to an isError CallToolResult with the same message', () => {
+    const result = handleToolError(new BinaryTooLargeError(2_000_000, 1_048_576));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: 'Error: Binary file too large (2000000 bytes, limit 1048576). Fetch the file out-of-band or use a chunked read when available.',
+    });
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -22,8 +22,8 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.moduleStates).toEqual({});
   });
 
-  it('should have schema version 10', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(10);
+  it('should have schema version 11', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(11);
   });
 
   it('should have loopback-only Origin and Host allowlists by default', () => {
@@ -72,9 +72,5 @@ describe('DEFAULT_SETTINGS', () => {
 describe('DEFAULT_SETTINGS resourcesEnabled', () => {
   it('defaults resourcesEnabled to true', () => {
     expect(DEFAULT_SETTINGS.resourcesEnabled).toBe(true);
-  });
-
-  it('bumps schemaVersion to 11', () => {
-    expect(DEFAULT_SETTINGS.schemaVersion).toBe(11);
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -68,3 +68,13 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.autoStart).toBe(false);
   });
 });
+
+describe('DEFAULT_SETTINGS resourcesEnabled', () => {
+  it('defaults resourcesEnabled to true', () => {
+    expect(DEFAULT_SETTINGS.resourcesEnabled).toBe(true);
+  });
+
+  it('bumps schemaVersion to 11', () => {
+    expect(DEFAULT_SETTINGS.schemaVersion).toBe(11);
+  });
+});

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -66,7 +66,7 @@ function makeModule(
 }
 
 const baseSettings: McpPluginSettings = {
-  schemaVersion: 10,
+  schemaVersion: 11,
   serverAddress: '127.0.0.1',
   port: 28741,
   authEnabled: true,

--- a/tests/utils/debug-info.test.ts
+++ b/tests/utils/debug-info.test.ts
@@ -78,6 +78,7 @@ const baseSettings: McpPluginSettings = {
   customTlsKeyPath: null,
   debugMode: true,
   autoStart: false,
+  resourcesEnabled: true,
   executeCommandAllowlist: [],
   allowedOrigins: [
     'http://127.0.0.1',


### PR DESCRIPTION
Closes #292

## Summary

- Adds an MCP **resources** surface alongside existing tools so hosts (Claude Desktop, MCP-compatible IDEs) can browse and read vault files without consuming tool-use turns. Two registrations: a static `obsidian://vault/index` JSON listing and a `obsidian://vault/{+path}` template (RFC 6570 reserved expansion preserves slashes).
- Gated by a new `resourcesEnabled` setting (default on, with v10→v11 migration). Single global toggle in *Server Settings*; restart applies.
- Lifts the 1 MiB binary cap into a typed `BinaryTooLargeError` shared between `vault_read_binary` and the resources `fileHandler`. Wire-format error message unchanged.

Subscriptions, `notifications/resources/list_changed`, per-file `resources/list` enumeration, and honouring client-advertised `roots` are intentionally deferred — see the [design spec](docs/superpowers/specs/2026-05-03-mcp-resources-vault-files-design.md) for rationale.

Implementation plan: [docs/superpowers/plans/2026-05-03-mcp-resources-vault-files.md](docs/superpowers/plans/2026-05-03-mcp-resources-vault-files.md).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 717/717 across 48 files
- [x] `npm run docs:tools` — clean diff (resources are not tools, generated tools doc unaffected)
- [x] In-memory transport smoke test (`tests/integration/resources.test.ts`) — round-trips `resources/read` for both URIs through the SDK
- [ ] Manual smoke test against a real host: enable the toggle, point a client at the server, request `resources/list` and `resources/read` for the index plus a known file