### PR TITLE
feat(tools): cross-reference editor_get_active_file and workspace_get_active_leaf

### DIFF
--- a/docs/superpowers/plans/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf.md
+++ b/docs/superpowers/plans/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf.md
@@ -1,0 +1,355 @@
+# Cross-reference `editor_get_active_file` and `workspace_get_active_leaf` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add symmetric `seeAlso` cross-references between `editor_get_active_file` and `workspace_get_active_leaf` so Claude doesn't confuse the two "what is the user looking at?" tools at tool-selection time.
+
+**Architecture:** Pure data change — two `seeAlso` strings added to existing `describeTool` calls in two different module files (editor and workspace), plus one row added to the parametric `SIBLING_PAIRS` symmetry test. No new infrastructure; the slot, the renderer, and the test helper already exist.
+
+**Tech Stack:** TypeScript (strict), Vitest, Zod for tool schemas, custom `describeTool` doc helper.
+
+**Spec:** [`docs/superpowers/specs/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf-design.md`](../specs/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf-design.md)
+
+**Issue:** [#299](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/issues/299)
+
+**Branch:** `feat/issue-299-cross-ref-editor-active-file-workspace-active-leaf` (already created off `origin/main` at `74c6780`; spec already committed as `822ea05`).
+
+---
+
+## File map
+
+- **Modify** [`tests/registry/tool-titles.test.ts`](../../../tests/registry/tool-titles.test.ts) — append one entry to `SIBLING_PAIRS`. The parametric `it()` block then auto-generates two new symmetry assertions.
+- **Modify** [`src/tools/editor/index.ts`](../../../src/tools/editor/index.ts) — add `seeAlso` array to the `editor_get_active_file` `defineTool` block.
+- **Modify** [`src/tools/workspace/index.ts`](../../../src/tools/workspace/index.ts) — add `seeAlso` array to the `workspace_get_active_leaf` `defineTool` block.
+
+No new files. No deletions. No schema changes.
+
+---
+
+## Task 1: Cross-reference `editor_get_active_file` and `workspace_get_active_leaf`
+
+**Files:**
+- Modify: `tests/registry/tool-titles.test.ts:43-53` (add row to `SIBLING_PAIRS` const)
+- Modify: `src/tools/editor/index.ts:327-339` (add `seeAlso` to `editor_get_active_file`)
+- Modify: `src/tools/workspace/index.ts:150-162` (add `seeAlso` to `workspace_get_active_leaf`)
+
+### Step 1: Baseline check — make sure the test suite is green before any change
+
+- [ ] **Step 1.1: Run the full test suite as the baseline**
+
+Run: `npm test`
+
+Expected: all tests pass. Note the pass count; we'll compare against it after the changes.
+
+If the baseline is red, stop and surface the failure to the user before continuing — the new failures we are about to add must be cleanly distinguishable from any pre-existing ones.
+
+### Step 2: Write the failing tests first (TDD)
+
+- [ ] **Step 2.1: Add the new pair to `SIBLING_PAIRS`**
+
+In [`tests/registry/tool-titles.test.ts`](../../../tests/registry/tool-titles.test.ts), the `SIBLING_PAIRS` constant currently looks like this (lines 43–53):
+
+```ts
+const SIBLING_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['editor_get_content', 'vault_read'],
+  ['vault_list', 'vault_list_recursive'],
+  ['search_resolved_links', 'search_unresolved_links'],
+  ['extras_get_date', 'vault_get_metadata'],
+  ['editor_insert', 'editor_replace'],
+  ['editor_insert', 'editor_delete'],
+  ['editor_replace', 'editor_delete'],
+  ['search_tags', 'search_by_tag'],
+  ['editor_set_cursor', 'editor_set_selection'],
+];
+```
+
+Replace it with:
+
+```ts
+const SIBLING_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['editor_get_content', 'vault_read'],
+  ['vault_list', 'vault_list_recursive'],
+  ['search_resolved_links', 'search_unresolved_links'],
+  ['extras_get_date', 'vault_get_metadata'],
+  ['editor_insert', 'editor_replace'],
+  ['editor_insert', 'editor_delete'],
+  ['editor_replace', 'editor_delete'],
+  ['search_tags', 'search_by_tag'],
+  ['editor_set_cursor', 'editor_set_selection'],
+  ['editor_get_active_file', 'workspace_get_active_leaf'],
+];
+```
+
+The parametric `for (const [a, b] of SIBLING_PAIRS)` block at line 62 will now auto-generate two new tests:
+
+- `editor_get_active_file description names workspace_get_active_leaf`
+- `workspace_get_active_leaf description names editor_get_active_file`
+
+- [ ] **Step 2.2: Run the test suite — the two new tests must fail**
+
+Run: `npm test -- tests/registry/tool-titles.test.ts`
+
+Expected: two new failures, both in the `sibling cross-references` describe block:
+
+```
+FAIL  sibling cross-references > editor_get_active_file description names workspace_get_active_leaf
+FAIL  sibling cross-references > workspace_get_active_leaf description names editor_get_active_file
+```
+
+The failure message will look like `expect(received).toContain(expected) … Expected substring: "workspace_get_active_leaf"` because the tool descriptions don't yet name their partners. All other tests should still pass.
+
+If you see anything other than exactly these two new failures, stop and investigate before continuing. (For example: if a third test fails, something else is wrong; if no tests fail, the SIBLING_PAIRS edit didn't take effect.)
+
+### Step 3: Add `seeAlso` to `editor_get_active_file`
+
+- [ ] **Step 3.1: Add the `seeAlso` block**
+
+In [`src/tools/editor/index.ts`](../../../src/tools/editor/index.ts), the `editor_get_active_file` `defineTool` block currently looks like this (lines 327–339):
+
+```ts
+        defineTool({
+          name: 'editor_get_active_file',
+          title: 'Get active file path',
+          description: describeTool({
+            summary: 'Get the vault-relative path of the currently active file.',
+            returns: 'Plain text: the path, e.g. "notes/today.md".',
+            errors: ['"No active file" if no file is open.'],
+          }, readOnlySchema),
+          schema: readOnlySchema,
+          outputSchema: getActiveFileOutputSchema,
+          handler: h.getActivePath,
+          annotations: annotations.read,
+        }),
+```
+
+Replace it with:
+
+```ts
+        defineTool({
+          name: 'editor_get_active_file',
+          title: 'Get active file path',
+          description: describeTool({
+            summary: 'Get the vault-relative path of the currently active file.',
+            returns: 'Plain text: the path, e.g. "notes/today.md".',
+            errors: ['"No active file" if no file is open.'],
+            seeAlso: [
+              'workspace_get_active_leaf — when you need the active pane/leaf (id and view type), not just the file path.',
+            ],
+          }, readOnlySchema),
+          schema: readOnlySchema,
+          outputSchema: getActiveFileOutputSchema,
+          handler: h.getActivePath,
+          annotations: annotations.read,
+        }),
+```
+
+Only one field is added: `seeAlso` between `errors` and the `}, readOnlySchema)` argument boundary of the `describeTool` call. The second positional argument (`readOnlySchema`) must remain — it is the schema-arg overload that lets `describeTool` document the shared `response_format` field.
+
+### Step 4: Add `seeAlso` to `workspace_get_active_leaf`
+
+- [ ] **Step 4.1: Add the `seeAlso` block**
+
+In [`src/tools/workspace/index.ts`](../../../src/tools/workspace/index.ts), the `workspace_get_active_leaf` `defineTool` block currently looks like this (lines 150–162):
+
+```ts
+        defineTool({
+          name: 'workspace_get_active_leaf',
+          title: 'Get active leaf',
+          description: describeTool({
+            summary: 'Get info about the currently-focused leaf (pane).',
+            returns: 'JSON: { id, type, ... } describing the active leaf.',
+            errors: ['"No active leaf" if no leaf is focused.'],
+          }, readOnlySchema),
+          schema: readOnlySchema,
+          outputSchema: getActiveLeafOutputSchema,
+          handler: h.getActiveLeaf,
+          annotations: annotations.read,
+        }),
+```
+
+Replace it with:
+
+```ts
+        defineTool({
+          name: 'workspace_get_active_leaf',
+          title: 'Get active leaf',
+          description: describeTool({
+            summary: 'Get info about the currently-focused leaf (pane).',
+            returns: 'JSON: { id, type, ... } describing the active leaf.',
+            errors: ['"No active leaf" if no leaf is focused.'],
+            seeAlso: [
+              'editor_get_active_file — when you only need the active file\'s path, not the surrounding leaf metadata.',
+            ],
+          }, readOnlySchema),
+          schema: readOnlySchema,
+          outputSchema: getActiveLeafOutputSchema,
+          handler: h.getActiveLeaf,
+          annotations: annotations.read,
+        }),
+```
+
+The apostrophe inside `file's` is escaped (`\'`) because the surrounding string is single-quoted — matching the existing single-quote convention in this file (see e.g. [`src/tools/workspace/index.ts:209`](../../../src/tools/workspace/index.ts#L209) `Obsidian\'s layout descriptor …`).
+
+### Step 5: Verify the targeted tests now pass
+
+- [ ] **Step 5.1: Re-run the registry-titles test file**
+
+Run: `npm test -- tests/registry/tool-titles.test.ts`
+
+Expected: all tests in the file pass, including the two new ones from Step 2.2.
+
+```
+PASS  sibling cross-references > editor_get_active_file description names workspace_get_active_leaf
+PASS  sibling cross-references > workspace_get_active_leaf description names editor_get_active_file
+```
+
+If either test still fails, the most likely cause is that the `seeAlso` string in Step 3 or Step 4 doesn't contain the partner's exact registry name. Check for typos.
+
+### Step 6: Run the full verification gauntlet (issue acceptance criteria)
+
+The issue requires four checks to be clean before merge.
+
+- [ ] **Step 6.1: Full test suite**
+
+Run: `npm test`
+
+Expected: all tests pass. Pass count should be exactly two higher than the Step 1.1 baseline (the two new sibling-cross-reference assertions).
+
+- [ ] **Step 6.2: Lint**
+
+Run: `npm run lint`
+
+Expected: no errors, no warnings. The change adds only string literals to existing arrays, so lint failures here would be surprising — but the rule is mandatory.
+
+- [ ] **Step 6.3: Type-check**
+
+Run: `npm run typecheck`
+
+Expected: clean. `seeAlso?: string[]` is already declared on `ToolDoc` ([`src/tools/shared/describe.ts:38`](../../../src/tools/shared/describe.ts#L38)), so the new field is type-compatible.
+
+- [ ] **Step 6.4: Generated-docs check**
+
+Run: `npm run docs:check`
+
+Expected: no diff. [`docs/tools.generated.md`](../../tools.generated.md) only renders the title / `readOnlyHint` / `destructiveHint` table and does not render `seeAlso` content (per the parent spec at [`2026-05-03-tool-titles-and-sibling-cross-refs-design.md`](../specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md), section "Generated docs"). Adding `seeAlso` strings to two existing tools therefore should not change the generated file.
+
+If `docs:check` reports a diff, run `npm run docs:tools` to regenerate, then read the diff to understand what changed before committing — the parent spec's claim about generator scope may have drifted.
+
+### Step 7: Commit
+
+- [ ] **Step 7.1: Stage the three modified files**
+
+Run: `git add src/tools/editor/index.ts src/tools/workspace/index.ts tests/registry/tool-titles.test.ts`
+
+Verify only those three files are staged:
+
+Run: `git status`
+
+Expected output (substring):
+
+```
+Changes to be committed:
+        modified:   src/tools/editor/index.ts
+        modified:   src/tools/workspace/index.ts
+        modified:   tests/registry/tool-titles.test.ts
+```
+
+If anything else is staged or modified, stop and clean it up before committing. Per project rules, each commit represents exactly one logical change.
+
+- [ ] **Step 7.2: Commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(tools): cross-reference editor_get_active_file and workspace_get_active_leaf
+
+Add symmetric seeAlso entries so Claude can disambiguate the two
+"what is the user looking at?" tools at tool-selection time:
+
+- editor_get_active_file → workspace_get_active_leaf — when you need
+  the active pane/leaf (id and view type), not just the file path.
+- workspace_get_active_leaf → editor_get_active_file — when you only
+  need the active file's path, not the surrounding leaf metadata.
+
+Wording is asymmetric ("not just" vs "only") because
+workspace_get_active_leaf already includes filePath in its payload;
+the contrast is "richer object" vs "narrower string + cleaner error
+on no file", not disjoint data.
+
+Also extend SIBLING_PAIRS in tests/registry/tool-titles.test.ts with
+the new pair so the existing parametric symmetry test enforces the
+relationship.
+
+Refs #299
+EOF
+)"
+```
+
+No `Co-Authored-By` footer. No AI attribution. (Project CLAUDE.md rule 16 + Rule 2.)
+
+- [ ] **Step 7.3: Verify the commit message**
+
+Run: `git log --oneline -1`
+
+Expected: subject line is exactly `feat(tools): cross-reference editor_get_active_file and workspace_get_active_leaf`.
+
+Run: `git log -1 --format=%B | head -25`
+
+Expected: full message body matches the heredoc above.
+
+### Step 8: Push and open the PR
+
+- [ ] **Step 8.1: Push the branch**
+
+Run: `git push -u origin feat/issue-299-cross-ref-editor-active-file-workspace-active-leaf`
+
+Expected: branch creates on the remote. (Spec commit `822ea05` and the new feat commit are both included.)
+
+- [ ] **Step 8.2: Open the pull request**
+
+Run:
+
+```bash
+gh pr create --title "feat(tools): cross-reference editor_get_active_file and workspace_get_active_leaf" --body "$(cat <<'EOF'
+Closes #299.
+
+## Summary
+
+- Add symmetric `seeAlso` entries between `editor_get_active_file` and `workspace_get_active_leaf` so Claude can disambiguate the two "what is the user looking at?" tools at tool-selection time.
+- Extend `SIBLING_PAIRS` in `tests/registry/tool-titles.test.ts` with the new pair — the existing parametric symmetry test then enforces both directions automatically.
+
+Implements the second of three deferred sibling pairs from the parent spec [`2026-05-03-tool-titles-and-sibling-cross-refs-design.md`](docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md). The first deferred pair shipped in #310; the third (`template_create_from` ↔ `template_expand`) remains open.
+
+## Test plan
+
+- [x] `npm test` — all tests pass; two new sibling-cross-reference assertions pass.
+- [x] `npm run lint` — clean.
+- [x] `npm run typecheck` — clean.
+- [x] `npm run docs:check` — clean (no diff in `docs/tools.generated.md`; the generator does not emit `seeAlso` content).
+EOF
+)"
+```
+
+No `Co-Authored-By`, no `Generated with`, no Claude session links. (Project rule 2.)
+
+- [ ] **Step 8.3: Report the PR URL**
+
+Print the PR URL returned by `gh pr create` so the user can review it.
+
+---
+
+## Self-review checklist (the planner ran this before saving)
+
+**Spec coverage:**
+
+- Spec "Code changes → editor_get_active_file" → covered by Step 3.
+- Spec "Code changes → workspace_get_active_leaf" → covered by Step 4.
+- Spec "Code changes → SIBLING_PAIRS" → covered by Step 2.1.
+- Spec "Verification gate (4 commands)" → covered by Steps 6.1–6.4.
+- Spec "Branch and commits" → branch already exists; spec already committed; one feat commit per Step 7; PR per Step 8. (The spec also mentions a separate `docs(plans):` commit for this plan file — that lands as part of the brainstorming → writing-plans handoff, not as a step inside Task 1.)
+- Spec "Generated docs / User manual" → no changes required; Step 6.4 verifies.
+
+**Placeholder scan:** none. Every code change shows the exact before/after; every command shows the expected output; every commit/PR message is a verbatim heredoc.
+
+**Type / name consistency:** `seeAlso` matches the field declared on `ToolDoc` ([`describe.ts:38`](../../../src/tools/shared/describe.ts#L38)). Tool registry names (`editor_get_active_file`, `workspace_get_active_leaf`) match `defineTool` calls verbatim. The new `SIBLING_PAIRS` row uses the same registry names. Apostrophe escaping (`file\'s`) matches the existing single-quote convention in the workspace module.

--- a/docs/superpowers/specs/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf-design.md
+++ b/docs/superpowers/specs/2026-05-05-cross-ref-editor-active-file-workspace-active-leaf-design.md
@@ -1,0 +1,114 @@
+# Cross-reference `editor_get_active_file` and `workspace_get_active_leaf`
+
+- Issue: [#299](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/issues/299)
+- Parent: [#289](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/issues/289) ([PR #296](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/pull/296))
+- Sibling deferred pair: [#298](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/issues/298) ([PR #310](https://github.com/KingOfKalk/obsidian-plugin-vault-mcp-server/pull/310))
+- Parent spec: [`2026-05-03-tool-titles-and-sibling-cross-refs-design.md`](2026-05-03-tool-titles-and-sibling-cross-refs-design.md)
+
+## Goal
+
+Author the second of three deferred sibling cross-references listed in the parent spec — the `editor_get_active_file` ↔ `workspace_get_active_leaf` pair. Both answer "what is the user looking at?" — one returns the active file's vault path, the other returns the surrounding leaf (id, view type, plus `filePath`). Names alone don't disambiguate them at tool-selection time.
+
+## Non-goals
+
+- New `seeAlso` infrastructure. The slot already exists on `describeTool` ([`src/tools/shared/describe.ts`](../../../src/tools/shared/describe.ts)) and is enforced for symmetry by `SIBLING_PAIRS` in [`tests/registry/tool-titles.test.ts`](../../../tests/registry/tool-titles.test.ts).
+- Cross-references for the third deferred pair (`template_create_from` ↔ `template_expand`). Separate follow-up issue.
+- Cross-references for any *other* near-sibling involving these two tools (e.g. `editor_get_content` ↔ `workspace_get_active_leaf`). Not in the parent spec's deferred list.
+- Tool renames, additions, removals, schema changes, or annotation-preset edits.
+
+## Architecture
+
+None. Pure data change — two `seeAlso` strings added to existing `describeTool` calls in two different module files, plus one row in the parametric symmetry test.
+
+## Data overlap (why the wording is asymmetric)
+
+Unlike the `editor_set_cursor` ↔ `editor_set_selection` pair (which return distinct shapes), `workspace_get_active_leaf` already includes `filePath` in its payload — the editor tool's full output is a strict subset of the workspace tool's. The contrast is therefore "richer object" vs "narrower string + cleaner error on no file":
+
+- `editor_get_active_file` returns plain text (a path string), errors with `"No active file"` if no file is open.
+- `workspace_get_active_leaf` returns `{ id, type, filePath }`; `filePath` can be `null` when the leaf holds no file.
+
+The cross-ref strings reflect this with asymmetric framing — "*not just* the file path" in one direction, "*only* need the active file's path" in the other — rather than the strictly parallel "X — when you want A, not B." form used by the cleanly-disjoint pairs.
+
+## Code changes
+
+### [`src/tools/editor/index.ts`](../../../src/tools/editor/index.ts)
+
+Add `seeAlso` to the `editor_get_active_file` `defineTool` block (currently around [`src/tools/editor/index.ts:327-339`](../../../src/tools/editor/index.ts#L327-L339)):
+
+```ts
+seeAlso: [
+  'workspace_get_active_leaf — when you need the active pane/leaf (id and view type), not just the file path.',
+],
+```
+
+### [`src/tools/workspace/index.ts`](../../../src/tools/workspace/index.ts)
+
+Add `seeAlso` to the `workspace_get_active_leaf` `defineTool` block (currently around [`src/tools/workspace/index.ts:150-162`](../../../src/tools/workspace/index.ts#L150-L162)):
+
+```ts
+seeAlso: [
+  'editor_get_active_file — when you only need the active file\'s path, not the surrounding leaf metadata.',
+],
+```
+
+Markdown emphasis from the issue sketch (`**pane/leaf**`, `**file's path**`) is dropped — none of the existing `seeAlso` strings use it.
+
+### [`tests/registry/tool-titles.test.ts`](../../../tests/registry/tool-titles.test.ts)
+
+Append one entry to `SIBLING_PAIRS` (currently [`tests/registry/tool-titles.test.ts:43-53`](../../../tests/registry/tool-titles.test.ts#L43-L53)):
+
+```ts
+['editor_get_active_file', 'workspace_get_active_leaf'],
+```
+
+The parametric `it()` block then auto-generates two new symmetry assertions:
+
+- `editor_get_active_file description names workspace_get_active_leaf`
+- `workspace_get_active_leaf description names editor_get_active_file`
+
+Both pass because `describeTool` renders the partner's registry name verbatim in the `See also:` block.
+
+## Generated docs
+
+[`docs/tools.generated.md`](../../tools.generated.md) does not render `seeAlso` content — per the parent spec's [Generated docs section](2026-05-03-tool-titles-and-sibling-cross-refs-design.md#L235-L246) the generator only emits the per-module title / `readOnlyHint` / `destructiveHint` table.
+
+Re-running `npm run docs:tools` should produce no diff. CI's `npm run docs:check` step verifies this.
+
+## User manual
+
+No changes to [`docs/help/en.md`](../../help/en.md) (or sibling locales). `seeAlso` is protocol-level metadata that hosts surface in their own UI; the manual does not enumerate per-tool descriptions. Same stance as the parent spec and the #298 spec.
+
+## Tests
+
+No new test cases. The existing parametric symmetry block in `tests/registry/tool-titles.test.ts` covers the new pair the moment it is added to `SIBLING_PAIRS`.
+
+## Verification gate
+
+The issue's acceptance criteria require all four of these to be clean:
+
+- `npm test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run docs:check`
+
+## Branch and commits
+
+- Branch: `feat/issue-299-cross-ref-editor-active-file-workspace-active-leaf` (already created off `origin/main` at commit `74c6780`).
+- Three commits, mirroring the #298 workflow:
+  1. `docs(specs): brainstorm cross-ref for editor_get_active_file and workspace_get_active_leaf` — this spec file.
+  2. `docs(plans): implementation plan for cross-ref editor_get_active_file and workspace_get_active_leaf` — the plan file (added in the writing-plans phase).
+  3. `feat(tools): cross-reference editor_get_active_file and workspace_get_active_leaf` — the three code edits. Body names the two `seeAlso` entries added and the new `SIBLING_PAIRS` row. Footer: `Refs #299`.
+- PR title mirrors the feat commit subject. PR body has `Closes #299`, a Summary section, and a Test plan section listing the four verification commands.
+
+## Risks
+
+- **Wording drift from house style.** Mitigation: follows the existing `editor_get_content` ↔ `vault_read` pattern (the closest precedent for an asymmetric overlap pair). Reviewer can spot drift in 30 seconds.
+- **Substring overlap in symmetry assertions.** The symmetry assertion uses `expect(description).toContain(name)`. Both new strings include the partner's full registry name verbatim, so this is a non-issue.
+- **Accidental cross-name match.** Neither tool's name is a substring of the other (`editor_get_active_file` vs `workspace_get_active_leaf` share no suffix), so the `toContain` assertion cannot match the wrong direction.
+
+## Out of scope (explicit)
+
+- Tool renames, additions, removals, or schema changes.
+- Editing `readOnlyHint` / `destructiveHint` presets.
+- Cross-references for the third deferred pair (`template_create_from` ↔ `template_expand`).
+- Cross-references for any other near-sibling involving these two tools.

--- a/src/tools/editor/index.ts
+++ b/src/tools/editor/index.ts
@@ -331,6 +331,9 @@ export function createEditorModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get the vault-relative path of the currently active file.',
             returns: 'Plain text: the path, e.g. "notes/today.md".',
             errors: ['"No active file" if no file is open.'],
+            seeAlso: [
+              'workspace_get_active_leaf — when you need the active pane/leaf (id and view type), not just the file path.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: getActiveFileOutputSchema,

--- a/src/tools/workspace/index.ts
+++ b/src/tools/workspace/index.ts
@@ -154,6 +154,9 @@ export function createWorkspaceModule(adapter: ObsidianAdapter): ToolModule {
             summary: 'Get info about the currently-focused leaf (pane).',
             returns: 'JSON: { id, type, ... } describing the active leaf.',
             errors: ['"No active leaf" if no leaf is focused.'],
+            seeAlso: [
+              'editor_get_active_file — when you only need the active file\'s path, not the surrounding leaf metadata.',
+            ],
           }, readOnlySchema),
           schema: readOnlySchema,
           outputSchema: getActiveLeafOutputSchema,

--- a/tests/registry/tool-titles.test.ts
+++ b/tests/registry/tool-titles.test.ts
@@ -50,6 +50,7 @@ const SIBLING_PAIRS: ReadonlyArray<readonly [string, string]> = [
   ['editor_replace', 'editor_delete'],
   ['search_tags', 'search_by_tag'],
   ['editor_set_cursor', 'editor_set_selection'],
+  ['editor_get_active_file', 'workspace_get_active_leaf'],
 ];
 
 describe('sibling cross-references', () => {


### PR DESCRIPTION
Closes #299.

## Summary

- Add symmetric `seeAlso` entries between `editor_get_active_file` and `workspace_get_active_leaf` so Claude can disambiguate the two "what is the user looking at?" tools at tool-selection time.
- Extend `SIBLING_PAIRS` in `tests/registry/tool-titles.test.ts` with the new pair — the existing parametric symmetry test then enforces both directions automatically.

Implements the second of three deferred sibling pairs from the parent spec [`2026-05-03-tool-titles-and-sibling-cross-refs-design.md`](docs/superpowers/specs/2026-05-03-tool-titles-and-sibling-cross-refs-design.md). The first deferred pair shipped in #310; the third (`template_create_from` ↔ `template_expand`) remains open.

## Test plan

- [x] `npm test` — all tests pass; two new sibling-cross-reference assertions pass.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run docs:check` — clean (no diff in `docs/tools.generated.md`; the generator does not emit `seeAlso` content).